### PR TITLE
Add file and species info to protein group scoring

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
@@ -265,7 +265,8 @@ function summarize_results!(
             passing_proteins_folder,
             temp_folder,
             getPrecursors(getSpecLib(search_context)),
-            getProteins(getSpecLib(search_context));
+            getProteins(getSpecLib(search_context)),
+            collect(getFileIdToName(getMSData(search_context)));
             min_peptides = params.min_peptides,
             max_psms_in_memory = params.max_psms_in_memory
         )


### PR DESCRIPTION
## Summary
- include `file_names` parameter in `get_protein_groups` and plumb through
- track species per protein
- write `file_name` and `species` columns when outputting protein group scores

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: `julia` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2a9ff0008325b84dc70557016855