### PR TITLE
Use log-odds for global pg_score

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/CLAUDE.md
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/CLAUDE.md
@@ -79,7 +79,7 @@ The scoring search performs these steps:
 - `n_peptides`: Number of unique peptides
 - `peptide_coverage`: Fraction of possible peptides observed
 - `n_possible_peptides`: Total peptides in library
-- `global_pg_score`: Max score across all files
+- `global_pg_score`: Log-odds combination of scores across all files
 
 ## Memory Management
 


### PR DESCRIPTION
## Summary
- compute `global_pg_score` using log-odds across runs
- document new global_pg_score behaviour
- expose `logodds_weighted` helper

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: Unsatisfiable requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68673f818cd083259ffff337cd23e162