### PR TITLE
Update macOS codesigning workflow

### DIFF
--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -127,6 +127,9 @@ jobs:
           mkdir -p "$PKGROOT/usr/local/$APPNAME"
           cp -R "$DIST"/* "$PKGROOT/usr/local/$APPNAME/"
 
+          # ensure files are writable so codesign can modify them
+          find "$PKGROOT/usr/local/$APPNAME" -type f -exec chmod u+w {} +
+
           echo "Codesigning binaries"
           while IFS= read -r -d '' file; do
             if file "$file" | grep -q 'Mach-O'; then

--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -115,23 +115,46 @@ jobs:
       - name: Codesign and package macOS app
         if: matrix.os == 'macos'
         env:
-          BUILD_CERTIFICATE_BASE64: ${{ secrets.MACOS_CERT_P12 }}
-          P12_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
-          INSTALLER_CERT_BASE64: ${{ secrets.MACOS_INSTALLER_CERT_P12 }}
-          INSTALLER_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
-          KEYCHAIN_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
-          NOTARIZE_APPLE_ID: ${{ secrets.NOTARIZE_APPLE_ID }}
-          NOTARIZE_PASSWORD: ${{ secrets.NOTARIZE_PASSWORD }}
-          NOTARIZE_TEAM_ID: ${{ secrets.NOTARIZE_TEAM_ID }}
+          CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
+          PKG_SIGN_IDENTITY: ${{ secrets.PKG_SIGN_IDENTITY }}
         run: |
-          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
-          security import <(echo "$BUILD_CERTIFICATE_BASE64" | base64 --decode) -k build.keychain -P "$P12_PASSWORD" -T /usr/bin/codesign
-          security list-keychains -s build.keychain
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
-          codesign --deep --force --options runtime --sign "$BUILD_CERTIFICATE_BASE64" build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/Pioneer.app
-          pkgbuild --root build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/Pioneer.app --identifier com.example.pioneer --install-location /Applications/Pioneer.app --sign "$BUILD_CERTIFICATE_BASE64" Pioneer.pkg
-          productbuild --package Pioneer.pkg --sign "$INSTALLER_CERT_BASE64" PioneerInstaller.pkg
-          xcrun notarytool submit PioneerInstaller.pkg --apple-id "$NOTARIZE_APPLE_ID" --team-id "$NOTARIZE_TEAM_ID" --password "$NOTARIZE_PASSWORD" --wait
+          APP_PATH="build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/Pioneer.app"
+          echo "Codesigning $APP_PATH"
+          codesign --deep --force --options runtime --timestamp \
+            --entitlements src/build/entitlements.plist \
+            --sign "$CODESIGN_IDENTITY" "$APP_PATH"
+          pkgbuild --root "$APP_PATH" \
+            --identifier com.example.pioneer \
+            --install-location /Applications/Pioneer.app \
+            PioneerUnsigned.pkg
+          productsign --sign "$PKG_SIGN_IDENTITY" \
+            PioneerUnsigned.pkg PioneerInstaller.pkg
+
+      - name: Notarize macOS package
+        if: matrix.os == 'macos'
+        env:
+          AC_USERNAME: ${{ secrets.NOTARIZE_APPLE_ID }}
+          AC_PASSWORD: ${{ secrets.NOTARIZE_PASSWORD }}
+          TEAM_ID: ${{ secrets.NOTARIZE_TEAM_ID }}
+        run: |
+          xcrun notarytool store-credentials notary-profile \
+            --apple-id "$AC_USERNAME" \
+            --team-id "$TEAM_ID" \
+            --password "$AC_PASSWORD"
+          result=$(xcrun notarytool submit PioneerInstaller.pkg \
+            --keychain-profile notary-profile --wait --output-format json)
+          echo "$result"
+          status=$(echo "$result" | grep -o '"status" *: *"[^" ]*"' | head -n1 | sed 's/.*"status" *: *"\([^"]*\)"/\1/')
+          subid=$(echo "$result" | grep -o '"id" *: *"[^" ]*"' | head -n1 | sed 's/.*"id" *: *"\([^"]*\)"/\1/')
+          if [ "$status" != "Accepted" ]; then
+            echo "Notarization failed with status $status"
+            xcrun notarytool log "$subid" --keychain-profile notary-profile
+            exit 1
+          fi
+
+      - name: Staple notarization ticket
+        if: matrix.os == 'macos'
+        run: |
           xcrun stapler staple PioneerInstaller.pkg
       
       

--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -21,10 +21,10 @@ jobs:
           #  runner: macos-latest
           #  arch: arm64
           #  identifier: macos-arm64
-          #- os: windows
-          #  runner: windows-latest
-          #  arch: x64
-          #  identifier: windows-x64
+          - os: windows
+            runner: windows-latest
+            arch: x64
+            identifier: windows-x64
           #- os: linux
           #  runner: ubuntu-latest
           #  arch: x64

--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -21,10 +21,10 @@ jobs:
           #  runner: macos-latest
           #  arch: arm64
           #  identifier: macos-arm64
-          - os: windows
-            runner: windows-latest
-            arch: x64
-            identifier: windows-x64
+          #- os: windows
+          #  runner: windows-latest
+          #  arch: x64
+          #  identifier: windows-x64
           #- os: linux
           #  runner: ubuntu-latest
           #  arch: x64
@@ -118,17 +118,31 @@ jobs:
           CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
           PKG_SIGN_IDENTITY: ${{ secrets.PKG_SIGN_IDENTITY }}
         run: |
-          APP_PATH="build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/Pioneer.app"
-          echo "Codesigning $APP_PATH"
-          codesign --deep --force --options runtime --timestamp \
-            --entitlements src/build/entitlements.plist \
-            --sign "$CODESIGN_IDENTITY" "$APP_PATH"
-          pkgbuild --root "$APP_PATH" \
+          APPNAME="Pioneer"
+          DIST="build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer"
+          PKGROOT="pkgroot"
+          VERSION=$(grep -m1 '^version' Project.toml | awk -F'"' '{print $2}')
+
+          rm -rf "$PKGROOT"
+          mkdir -p "$PKGROOT/usr/local/$APPNAME"
+          cp -R "$DIST"/* "$PKGROOT/usr/local/$APPNAME/"
+
+          echo "Codesigning binaries"
+          while IFS= read -r -d '' file; do
+            if file "$file" | grep -q 'Mach-O'; then
+              codesign --verbose=4 --force --options runtime --timestamp \
+                --entitlements src/build/entitlements.plist \
+                --sign "$CODESIGN_IDENTITY" "$file"
+            fi
+          done < <(find "$PKGROOT/usr/local/$APPNAME" -type f -print0)
+
+          pkgbuild --root "$PKGROOT" \
             --identifier com.example.pioneer \
-            --install-location /Applications/Pioneer.app \
-            PioneerUnsigned.pkg
+            --version "$VERSION" \
+            --install-location / PioneerUnsigned.pkg
           productsign --sign "$PKG_SIGN_IDENTITY" \
             PioneerUnsigned.pkg PioneerInstaller.pkg
+          rm PioneerUnsigned.pkg
 
       - name: Notarize macOS package
         if: matrix.os == 'macos'

--- a/src/build/windows/installer.wxs
+++ b/src/build/windows/installer.wxs
@@ -7,12 +7,12 @@
       <Directory Id="ProgramFilesFolder">
         <Directory Id="INSTALLDIR" Name="Pioneer">
           <Component Id="PioneerBinaries" Guid="12345678-1234-1234-1234-123456789ABD">
-            <File Source="build\\Pioneer_windows-x64\\Applications\\Pioneer\\SearchDIA.exe" />
-            <File Source="build\\Pioneer_windows-x64\\Applications\\Pioneer\\BuildSpecLib.exe" />
-            <File Source="build\\Pioneer_windows-x64\\Applications\\Pioneer\\GetSearchParams.exe" />
-            <File Source="build\\Pioneer_windows-x64\\Applications\\Pioneer\\GetBuildLibParams.exe" />
-            <File Source="build\\Pioneer_windows-x64\\Applications\\Pioneer\\convertMzML.exe" />
-            <File Source="build\\Pioneer_windows-x64\\Applications\\Pioneer\\ParseSpecLib.exe" />
+            <File Source="build\\Pioneer_windows-x64\\Applications\\Pioneer\\bin\\SearchDIA.exe" />
+            <File Source="build\\Pioneer_windows-x64\\Applications\\Pioneer\\bin\\BuildSpecLib.exe" />
+            <File Source="build\\Pioneer_windows-x64\\Applications\\Pioneer\\bin\\GetSearchParams.exe" />
+            <File Source="build\\Pioneer_windows-x64\\Applications\\Pioneer\\bin\\GetBuildLibParams.exe" />
+            <File Source="build\\Pioneer_windows-x64\\Applications\\Pioneer\\bin\\convertMzML.exe" />
+            <File Source="build\\Pioneer_windows-x64\\Applications\\Pioneer\\bin\\ParseSpecLib.exe" />
           </Component>
         </Directory>
       </Directory>


### PR DESCRIPTION
## Summary
- adjust macOS codesign step in the workflow to use secrets for identities
- notarize and staple the pkg in separate steps

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: Unsatisfiable requirements / download issues)*

------
https://chatgpt.com/codex/tasks/task_e_687a48802d6c8325b24148869e85458e