### PR TITLE
Add unified pioneer CLI

### DIFF
--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -110,7 +110,7 @@ jobs:
           julia --project=. -e '
             using PackageCompiler;
             create_app(".", "build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/", incremental=false, force=true,
-              executables=["SearchDIA" => "main_SearchDIA", "BuildSpecLib" => "main_BuildSpecLib", "GetSearchParams" => "main_GetSearchParams", "GetBuildLibParams" => "main_GetBuildLibParams", "convertMzML" => "main_convertMzML", "ParseSpecLib" => "main_ParseSpecLib"]);
+              executables=["pioneer" => "main_pioneer"]);
           '
       - name: Codesign and package macOS app
         if: matrix.os == 'macos'

--- a/docs/src/user_guide/quickstart.md
+++ b/docs/src/user_guide/quickstart.md
@@ -39,8 +39,13 @@ julia --threads 15 --gcthreads 7,1
 If Pioneer has already been installed, then open the REPL and enter the following command.
 ```@julia
 julia> using Pioneer
-```  
-The Pioneer.jl package exports four methods, `GetBuildLibParams`, `BuildSpecLib`, `GetSearchParams`, and `SearchDIA`. The first two methods build the in silico spectral libraries. The later two search DIA experiments given a spectral library and MS data files. 
+```
+The Pioneer.jl package exports several methods for programmatic use. When installed as an application it also provides a single `pioneer` command with subcommands `buildspeclib`, `parsespeclib`, `searchdia`, `getbuildlibparams`, `getsearchparams`, and `convertmzml`.
+
+From the command line the syntax is:
+```bash
+pioneer <subcommand> [arguments]
+```
 
 ## Spectral Library Building
 Pioneer.jl includes two methods for building spectral libraries. These are `GetBuildLibParams` and `BuildSpecLib`.

--- a/src/Pioneer.jl
+++ b/src/Pioneer.jl
@@ -80,6 +80,7 @@ include(joinpath(@__DIR__, "Routines","BuildSpecLib.jl"))
 include(joinpath(@__DIR__, "Routines","ParseSpecLib.jl"))
 include(joinpath(@__DIR__, "Routines","GenerateParams.jl"))
 include(joinpath(@__DIR__, "Routines","mzmlConverter","convertMzML.jl"))
+include(joinpath(@__DIR__, "Routines","PioneerCLI.jl"))
 const CHARGE_ADJUSTMENT_FACTORS = Float64[1, 0.9, 0.85, 0.8, 0.75]
 
 # H2O, PROTON, NEUTRON constants are defined in get_mz.jl and available via importScripts()

--- a/src/Routines/PioneerCLI.jl
+++ b/src/Routines/PioneerCLI.jl
@@ -1,0 +1,40 @@
+function main_pioneer()::Cint
+    if isempty(ARGS)
+        println("Usage: pioneer <subcommand> [args...]")
+        println("Available subcommands: searchdia, buildspeclib, parsespeclib, getsearchparams, getbuildlibparams, convertmzml")
+        return 1
+    end
+    cmd = lowercase(ARGS[1])
+    args = ARGS[2:end]
+    try
+        if cmd == "searchdia"
+            length(args) == 1 || error("SearchDIA requires one argument")
+            SearchDIA(args[1])
+        elseif cmd == "buildspeclib"
+            length(args) == 1 || error("BuildSpecLib requires one argument")
+            BuildSpecLib(args[1])
+        elseif cmd == "parsespeclib"
+            length(args) == 1 || error("ParseSpecLib requires one argument")
+            ParseSpecLib(args[1])
+        elseif cmd == "getsearchparams"
+            length(args) >= 3 || error("GetSearchParams requires at least three arguments")
+            params_path = length(args) >= 4 ? args[4] : missing
+            GetSearchParams(args[1], args[2], args[3]; params_path=params_path)
+        elseif cmd == "getbuildlibparams"
+            length(args) >= 3 || error("GetBuildLibParams requires at least three arguments")
+            params_path = length(args) >= 4 ? args[4] : missing
+            GetBuildLibParams(args[1], args[2], args[3]; params_path=params_path)
+        elseif cmd == "convertmzml"
+            length(args) >= 1 || error("convertMzML requires at least one argument")
+            skip_scan_header = length(args) >= 2 ? parse(Bool, args[2]) : true
+            convertMzML(args[1]; skip_scan_header=skip_scan_header)
+        else
+            println("Unknown subcommand: $cmd")
+            return 1
+        end
+    catch
+        Base.invokelatest(Base.display_error, Base.catch_stack())
+        return 1
+    end
+    return 0
+end

--- a/src/build/windows/installer.wxs
+++ b/src/build/windows/installer.wxs
@@ -7,12 +7,7 @@
       <Directory Id="ProgramFilesFolder">
         <Directory Id="INSTALLDIR" Name="Pioneer">
           <Component Id="PioneerBinaries" Guid="12345678-1234-1234-1234-123456789ABD">
-            <File Source="build\\Pioneer_windows-x64\\Applications\\Pioneer\\bin\\SearchDIA.exe" />
-            <File Source="build\\Pioneer_windows-x64\\Applications\\Pioneer\\bin\\BuildSpecLib.exe" />
-            <File Source="build\\Pioneer_windows-x64\\Applications\\Pioneer\\bin\\GetSearchParams.exe" />
-            <File Source="build\\Pioneer_windows-x64\\Applications\\Pioneer\\bin\\GetBuildLibParams.exe" />
-            <File Source="build\\Pioneer_windows-x64\\Applications\\Pioneer\\bin\\convertMzML.exe" />
-            <File Source="build\\Pioneer_windows-x64\\Applications\\Pioneer\\bin\\ParseSpecLib.exe" />
+            <File Source="build\\Pioneer_windows-x64\\Applications\\Pioneer\\bin\\pioneer.exe" />
           </Component>
         </Directory>
       </Directory>


### PR DESCRIPTION
## Summary
- add new `main_pioneer` entry point wrapping the existing functionality
- compile app with only one executable `pioneer`
- adjust Windows installer for the single binary
- document the new command in the quick start guide
- include the CLI in Pioneer.jl

## Testing
- `julia --project=. -e 'using Pkg; Pkg.instantiate()'` *(fails: could not download due to 403)*
- `julia --project=. test/runtests.jl` *(fails: Package Arrow is required but not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687c2c148c8c8325a3e7d777033bad14