### PR TITLE
Fix depot path when running CLI tools

### DIFF
--- a/docs/src/user_guide/installation.md
+++ b/docs/src/user_guide/installation.md
@@ -53,6 +53,30 @@ To install Pioneer for development, clone the github repository and use in a loc
    pkg> test
    ```
 
+### 2a. Set a Writable Julia Depot
+Pioneer stores package data in Julia's *depot* directory. If the installer places
+Pioneer under `/usr/local` or another system location, the default depot may be
+read-only, resulting in errors like
+
+```text
+InitError(mod=:TZData, error=Base.IOError(msg="mkdir(…/scratchspaces): permission denied (EACCES)"))
+```
+
+Ensure the environment variable `JULIA_DEPOT_PATH` points to a directory you own
+(for example `~/.julia`):
+
+```bash
+export JULIA_DEPOT_PATH="$HOME/.julia"
+```
+
+Add the line above to your shell profile if you want it to persist across
+sessions.
+
+The `pioneer` wrapper installed with the application automatically sets
+`JULIA_DEPOT_PATH` to `~/.julia` when the variable is unset. If you invoke the
+compiled subcommands directly, be sure to set `JULIA_DEPOT_PATH` yourself to
+avoid permission errors.
+
 !!! note "'note'"
     On the first attempt ```using Pioneer``` requires an internet connection, and it may take several minutes to download and install dependencies.
 

--- a/src/Routines/BuildSpecLib.jl
+++ b/src/Routines/BuildSpecLib.jl
@@ -19,6 +19,9 @@
 
 # Entry point for PackageCompiler
 function main_BuildSpecLib()::Cint
+    if !haskey(ENV, "JULIA_DEPOT_PATH")
+        ENV["JULIA_DEPOT_PATH"] = joinpath(homedir(), ".julia")
+    end
     try
         BuildSpecLib(ARGS[1])
     catch

--- a/src/Routines/GenerateParams.jl
+++ b/src/Routines/GenerateParams.jl
@@ -17,6 +17,9 @@
 
 # Entry point for PackageCompiler
 function main_GetSearchParams()::Cint
+    if !haskey(ENV, "JULIA_DEPOT_PATH")
+        ENV["JULIA_DEPOT_PATH"] = joinpath(homedir(), ".julia")
+    end
     try
         GetSearchParams(ARGS[1], # library path
                         ARGS[2], # MS data path
@@ -33,6 +36,9 @@ end
 
 # Entry point for PackageCompiler
 function main_GetBuildLibParams()::Cint
+    if !haskey(ENV, "JULIA_DEPOT_PATH")
+        ENV["JULIA_DEPOT_PATH"] = joinpath(homedir(), ".julia")
+    end
     try
         GetBuildLibParams(ARGS[1], # library output path
                           ARGS[2], # library name
@@ -48,6 +54,9 @@ end
 
 # Entry point for PackageCompiler
 function main_GetParseSpecLibParams()::Cint
+    if !haskey(ENV, "JULIA_DEPOT_PATH")
+        ENV["JULIA_DEPOT_PATH"] = joinpath(homedir(), ".julia")
+    end
     try
         GetParseSpecLibParams(ARGS[1], ARGS[2];
             params_path = length(ARGS) >= 3 ? ARGS[3] : missing)

--- a/src/Routines/ParseSpecLib.jl
+++ b/src/Routines/ParseSpecLib.jl
@@ -19,6 +19,9 @@
 
 # Entry point for PackageCompiler
 function main_ParseSpecLib()::Cint
+    if !haskey(ENV, "JULIA_DEPOT_PATH")
+        ENV["JULIA_DEPOT_PATH"] = joinpath(homedir(), ".julia")
+    end
     try
         ParseSpecLib(ARGS[1])
     catch

--- a/src/Routines/SearchDIA.jl
+++ b/src/Routines/SearchDIA.jl
@@ -17,6 +17,9 @@
 
 # Entry point for PackageCompiler
 function main_SearchDIA()::Cint
+    if !haskey(ENV, "JULIA_DEPOT_PATH")
+        ENV["JULIA_DEPOT_PATH"] = joinpath(homedir(), ".julia")
+    end
     try
         SearchDIA(ARGS[1])
     catch

--- a/src/Routines/mzmlConverter/convertMzML.jl
+++ b/src/Routines/mzmlConverter/convertMzML.jl
@@ -17,6 +17,9 @@
 
 # Entry point for PackageCompiler
 function main_convertMzML()::Cint
+    if !haskey(ENV, "JULIA_DEPOT_PATH")
+        ENV["JULIA_DEPOT_PATH"] = joinpath(homedir(), ".julia")
+    end
     try
         convertMzML(ARGS[1], # input data path
                     skip_scan_header = length(ARGS) >= 2 ? parse(Bool, ARGS[2]) : true # skip scan header

--- a/src/build/scripts/pioneer
+++ b/src/build/scripts/pioneer
@@ -5,6 +5,13 @@ if [ -z "$JULIA_NUM_THREADS" ]; then
     export JULIA_NUM_THREADS=auto
 fi
 
+# Default the Julia depot to a user-writable location if not already set. This
+# ensures packages can create necessary scratch spaces when Pioneer is
+# installed system-wide.
+if [ -z "$JULIA_DEPOT_PATH" ]; then
+    export JULIA_DEPOT_PATH="$HOME/.julia"
+fi
+
 # Valid subcommands
 VALID_COMMANDS="search predict empirical search-config predict-config empirical-config convert-mzml"
 


### PR DESCRIPTION
## Summary
- default the Julia depot from compiled entrypoints when unset
- mention the automatic depot path in the install docs

## Testing
- ❌ `julia --project=. -e 'using Pkg; Pkg.test()'` (command not found)

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6889023d64e883259e678480f1c704c7