### PR TITLE
Implement ArgParse CLI for subcommands

### DIFF
--- a/.github/workflows/build_app_linux.yml
+++ b/.github/workflows/build_app_linux.yml
@@ -65,7 +65,8 @@ jobs:
               "ParseSpecLib" => "main_ParseSpecLib",
               "BuildSpecLib" => "main_BuildSpecLib",
               "SearchDIA" => "main_SearchDIA",
-              "convertMzML" => "main_convertMzML"
+              "convertMzML" => "main_convertMzML",
+              "PioneerCLI" => "main_pioneer"
             ]
 
             first_exe, first_main = first(executables)

--- a/.github/workflows/build_app_macos.yml
+++ b/.github/workflows/build_app_macos.yml
@@ -118,7 +118,8 @@ jobs:
                 "ParseSpecLib" => "main_ParseSpecLib",
                 "BuildSpecLib" => "main_BuildSpecLib",
                 "SearchDIA" => "main_SearchDIA",
-                "convertMzML" => "main_convertMzML"
+                "convertMzML" => "main_convertMzML",
+                "PioneerCLI" => "main_pioneer"
               ],
               precompile_execution_file="src/build/snoop.jl",
             );

--- a/.github/workflows/build_app_windows.yml
+++ b/.github/workflows/build_app_windows.yml
@@ -65,7 +65,8 @@ jobs:
                 "ParseSpecLib" => "main_ParseSpecLib",
                 "BuildSpecLib" => "main_BuildSpecLib",
                 "SearchDIA" => "main_SearchDIA",
-                "convertMzML" => "main_convertMzML"
+                "convertMzML" => "main_convertMzML",
+                "PioneerCLI" => "main_pioneer"
               ],
               precompile_execution_file="src/build/snoop.jl",
             );

--- a/src/Pioneer.jl
+++ b/src/Pioneer.jl
@@ -126,5 +126,5 @@ const KOINA_URLS = Dict(
 
 
 
-export SearchDIA, BuildSpecLib, ParseSpecLib, GetSearchParams, GetBuildLibParams, GetParseSpecLibParams, convertMzML
+export SearchDIA, BuildSpecLib, ParseSpecLib, GetSearchParams, GetBuildLibParams, GetParseSpecLibParams, convertMzML, main_pioneer
 end

--- a/src/Routines/BuildSpecLib.jl
+++ b/src/Routines/BuildSpecLib.jl
@@ -18,9 +18,16 @@
 # src/BuildSpecLib.jl
 
 # Entry point for PackageCompiler
-function main_BuildSpecLib()::Cint
+function main_BuildSpecLib(argv=ARGS)::Cint
+    s = ArgParseSettings()
+    @add_arg_table s begin
+        "params_path"
+            help = "Path to BuildSpecLib parameters JSON file"
+            arg_type = String
+    end
+    parsed_args = parse_args(argv, s; as_symbols = true)
     try
-        BuildSpecLib(ARGS[1])
+        BuildSpecLib(parsed_args[:params_path])
     catch
         Base.invokelatest(Base.display_error, Base.catch_stack())
         return 1

--- a/src/Routines/GenerateParams.jl
+++ b/src/Routines/GenerateParams.jl
@@ -16,13 +16,30 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 # Entry point for PackageCompiler
-function main_GetSearchParams()::Cint
+function main_GetSearchParams(argv=ARGS)::Cint
+    s = ArgParseSettings()
+    @add_arg_table s begin
+        "library_path"
+            help = "Path to spectral library (.poin)"
+            arg_type = String
+        "ms_data_path"
+            help = "Directory containing MS data"
+            arg_type = String
+        "results_path"
+            help = "Output directory for search results"
+            arg_type = String
+        "--params-path"
+            help = "Output path for generated parameters file"
+            arg_type = String
+            default = joinpath(pwd(), "search_parameters.json")
+    end
+    parsed_args = parse_args(argv, s; as_symbols = true)
+    params_path = parsed_args[:"params-path"]
     try
-        GetSearchParams(ARGS[1], # library path
-                        ARGS[2], # MS data path
-                        ARGS[3], # results path
-                        params_path = length(ARGS) >= 4 ? ARGS[4] : missing # params json output path
-        )
+        GetSearchParams(parsed_args[:library_path],
+                        parsed_args[:ms_data_path],
+                        parsed_args[:results_path];
+                        params_path=params_path)
     catch
         Base.invokelatest(Base.display_error, Base.catch_stack())
         return 1
@@ -32,13 +49,30 @@ end
 
 
 # Entry point for PackageCompiler
-function main_GetBuildLibParams()::Cint
+function main_GetBuildLibParams(argv=ARGS)::Cint
+    s = ArgParseSettings()
+    @add_arg_table s begin
+        "out_dir"
+            help = "Output directory for library"
+            arg_type = String
+        "lib_name"
+            help = "Name of the library"
+            arg_type = String
+        "fasta_dir"
+            help = "Directory containing FASTA files"
+            arg_type = String
+        "--params-path"
+            help = "Output path for generated parameters file"
+            arg_type = String
+            default = joinpath(pwd(), "buildspeclib_params.json")
+    end
+    parsed_args = parse_args(argv, s; as_symbols = true)
+    params_path = parsed_args[:"params-path"]
     try
-        GetBuildLibParams(ARGS[1], # library output path
-                          ARGS[2], # library name
-                          ARGS[3], # fasta path
-                          params_path = length(ARGS) >= 4 ? ARGS[4] : missing # params json output path
-        )
+        GetBuildLibParams(parsed_args[:out_dir],
+                          parsed_args[:lib_name],
+                          parsed_args[:fasta_dir];
+                          params_path=params_path)
     catch
         Base.invokelatest(Base.display_error, Base.catch_stack())
         return 1
@@ -47,10 +81,25 @@ function main_GetBuildLibParams()::Cint
 end
 
 # Entry point for PackageCompiler
-function main_GetParseSpecLibParams()::Cint
+function main_GetParseSpecLibParams(argv=ARGS)::Cint
+    s = ArgParseSettings()
+    @add_arg_table s begin
+        "input_lib_path"
+            help = "Input empirical library TSV"
+            arg_type = String
+        "output_lib_path"
+            help = "Output path for processed library"
+            arg_type = String
+        "--params-path"
+            help = "Output path for generated parameters file"
+            arg_type = String
+            default = joinpath(pwd(), "parsespeclib_params.json")
+    end
+    parsed_args = parse_args(argv, s; as_symbols = true)
+    params_path = parsed_args[:"params-path"]
     try
-        GetParseSpecLibParams(ARGS[1], ARGS[2];
-            params_path = length(ARGS) >= 3 ? ARGS[3] : missing)
+        GetParseSpecLibParams(parsed_args[:input_lib_path], parsed_args[:output_lib_path];
+            params_path = params_path)
     catch
         Base.invokelatest(Base.display_error, Base.catch_stack())
         return 1

--- a/src/Routines/ParseSpecLib.jl
+++ b/src/Routines/ParseSpecLib.jl
@@ -18,9 +18,16 @@
 # src/ParseSpecLib.jl
 
 # Entry point for PackageCompiler
-function main_ParseSpecLib()::Cint
+function main_ParseSpecLib(argv=ARGS)::Cint
+    s = ArgParseSettings()
+    @add_arg_table s begin
+        "params_path"
+            help = "Path to ParseSpecLib parameters JSON file"
+            arg_type = String
+    end
+    parsed_args = parse_args(argv, s; as_symbols = true)
     try
-        ParseSpecLib(ARGS[1])
+        ParseSpecLib(parsed_args[:params_path])
     catch
         Base.invokelatest(Base.display_error, Base.catch_stack())
         return 1

--- a/src/Routines/PioneerCLI.jl
+++ b/src/Routines/PioneerCLI.jl
@@ -8,26 +8,17 @@ function main_pioneer()::Cint
     args = ARGS[2:end]
     try
         if cmd == "searchdia"
-            length(args) == 1 || error("SearchDIA requires one argument")
-            SearchDIA(args[1])
+            return main_SearchDIA(args)
         elseif cmd == "buildspeclib"
-            length(args) == 1 || error("BuildSpecLib requires one argument")
-            BuildSpecLib(args[1])
+            return main_BuildSpecLib(args)
         elseif cmd == "parsespeclib"
-            length(args) == 1 || error("ParseSpecLib requires one argument")
-            ParseSpecLib(args[1])
+            return main_ParseSpecLib(args)
         elseif cmd == "getsearchparams"
-            length(args) >= 3 || error("GetSearchParams requires at least three arguments")
-            params_path = length(args) >= 4 ? args[4] : missing
-            GetSearchParams(args[1], args[2], args[3]; params_path=params_path)
+            return main_GetSearchParams(args)
         elseif cmd == "getbuildlibparams"
-            length(args) >= 3 || error("GetBuildLibParams requires at least three arguments")
-            params_path = length(args) >= 4 ? args[4] : missing
-            GetBuildLibParams(args[1], args[2], args[3]; params_path=params_path)
+            return main_GetBuildLibParams(args)
         elseif cmd == "convertmzml"
-            length(args) >= 1 || error("convertMzML requires at least one argument")
-            skip_scan_header = length(args) >= 2 ? parse(Bool, args[2]) : true
-            convertMzML(args[1]; skip_scan_header=skip_scan_header)
+            return main_convertMzML(args)
         else
             println("Unknown subcommand: $cmd")
             return 1

--- a/src/Routines/PioneerCLI.jl
+++ b/src/Routines/PioneerCLI.jl
@@ -1,23 +1,53 @@
-function main_pioneer()::Cint
-    if isempty(ARGS)
-        println("Usage: pioneer <subcommand> [args...]")
-        println("Available subcommands: searchdia, buildspeclib, parsespeclib, getsearchparams, getbuildlibparams, convertmzml")
+function main_pioneer(argv=ARGS)::Cint
+    s = ArgParseSettings()
+    s.prog = "pioneer"
+    s.description = "Pioneer - Mass Spectrometry Data Analysis"
+    s.epilog = "Subcommands:\n" *
+        "  search\n" *
+        "  predict\n" *
+        "  empirical\n" *
+        "  search-config\n" *
+        "  predict-config\n" *
+        "  empirical-config\n" *
+        "  convert-mzml\n\n" *
+        "For subcommand-specific help: pioneer <subcommand> --help"
+    @add_arg_table s begin
+        "--threads"
+            help = "Set number of Julia threads"
+            arg_type = Int
+            required = false
+    end
+
+    parsed, extra = parse_args(argv, s; as_symbols=true, skip_extra_args=true)
+
+    if haskey(parsed, :threads) && parsed[:threads] !== nothing
+        ENV["JULIA_NUM_THREADS"] = string(parsed[:threads])
+    elseif get(ENV, "JULIA_NUM_THREADS", "") == ""
+        ENV["JULIA_NUM_THREADS"] = "auto"
+    end
+
+    if isempty(extra)
+        println("Subcommand required\n")
+        print_usage(s)
         return 1
     end
-    cmd = lowercase(ARGS[1])
-    args = ARGS[2:end]
+
+    cmd = lowercase(first(extra))
+    args = extra[2:end]
     try
-        if cmd == "searchdia"
+        if cmd == "search"
             return main_SearchDIA(args)
-        elseif cmd == "buildspeclib"
+        elseif cmd == "predict"
             return main_BuildSpecLib(args)
-        elseif cmd == "parsespeclib"
+        elseif cmd == "empirical"
             return main_ParseSpecLib(args)
-        elseif cmd == "getsearchparams"
+        elseif cmd == "search-config"
             return main_GetSearchParams(args)
-        elseif cmd == "getbuildlibparams"
+        elseif cmd == "predict-config"
             return main_GetBuildLibParams(args)
-        elseif cmd == "convertmzml"
+        elseif cmd == "empirical-config"
+            return main_GetParseSpecLibParams(args)
+        elseif cmd == "convert-mzml"
             return main_convertMzML(args)
         else
             println("Unknown subcommand: $cmd")

--- a/src/Routines/SearchDIA.jl
+++ b/src/Routines/SearchDIA.jl
@@ -16,9 +16,16 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 # Entry point for PackageCompiler
-function main_SearchDIA()::Cint
+function main_SearchDIA(argv=ARGS)::Cint
+    s = ArgParseSettings()
+    @add_arg_table s begin
+        "params_path"
+            help = "Path to search parameters JSON file"
+            arg_type = String
+    end
+    parsed_args = parse_args(argv, s; as_symbols = true)
     try
-        SearchDIA(ARGS[1])
+        SearchDIA(parsed_args[:params_path])
     catch
         Base.invokelatest(Base.display_error, Base.catch_stack())
         return 1

--- a/src/Routines/mzmlConverter/convertMzML.jl
+++ b/src/Routines/mzmlConverter/convertMzML.jl
@@ -16,11 +16,21 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 # Entry point for PackageCompiler
-function main_convertMzML()::Cint
+function main_convertMzML(argv=ARGS)::Cint
+    s = ArgParseSettings()
+    @add_arg_table s begin
+        "mzml_dir"
+            help = "Directory containing mzML files"
+            arg_type = String
+        "skip_header"
+            help = "Skip scan header (true/false)"
+            arg_type = Bool
+            default = true
+            required = false
+    end
+    parsed_args = parse_args(argv, s; as_symbols = true)
     try
-        convertMzML(ARGS[1], # input data path
-                    skip_scan_header = length(ARGS) >= 2 ? parse(Bool, ARGS[2]) : true # skip scan header
-        )
+        convertMzML(parsed_args[:mzml_dir]; skip_scan_header = parsed_args[:skip_header])
     catch
         Base.invokelatest(Base.display_error, Base.catch_stack())
         return 1

--- a/src/build/scripts/pioneer
+++ b/src/build/scripts/pioneer
@@ -1,25 +1,20 @@
 #!/bin/bash
 
-# Set default threads to auto if not specified
+# Default to automatic threading if JULIA_NUM_THREADS is not set
 if [ -z "$JULIA_NUM_THREADS" ]; then
     export JULIA_NUM_THREADS=auto
 fi
 
-# Valid subcommands
-VALID_COMMANDS="search predict empirical search-config predict-config empirical-config convert-mzml"
-
-# Parse command line arguments for thread override
-SUBCOMMAND=""
-SUBCOMMAND_ARGS=()
-
+ARGS=()
 while [[ $# -gt 0 ]]; do
     case $1 in
         --threads)
             if [[ -n "$2" && "$2" != --* ]]; then
                 export JULIA_NUM_THREADS="$2"
                 shift 2
+                continue
             else
-                echo "Error: --threads requires a value"
+                echo "Error: --threads requires a value" >&2
                 exit 1
             fi
             ;;
@@ -27,104 +22,13 @@ while [[ $# -gt 0 ]]; do
             export JULIA_NUM_THREADS="${1#*=}"
             shift
             ;;
-        --help|-h)
-            echo "Pioneer - Mass Spectrometry Data Analysis"
-            echo ""
-            echo "Usage: pioneer [options] <subcommand> [subcommand-args...]"
-            echo ""
-            echo "Options:"
-            echo "  --threads N        Set number of Julia threads (default: auto)"
-            echo "  --threads=N        Alternative syntax for setting threads"
-            echo "  --help, -h         Show this help message"
-            echo ""
-            echo "Subcommands:"
-            echo "  search <path_to_config.json>                Perform DIA search analysis"
-            echo "  predict <path_to_config.json>               Predict spectral library"
-            echo "  empirical <path_to_config.json>             Parse spectral library"
-            echo "  search-config <path_to_spectral_lib> <path_to_ms_data> <path_to_search_results> [config_output_path]"
-            echo "                                              Generate search parameter template."
-            echo "                                              Default config output path: ./search_parameters.json"
-            echo "  predict-config <output_path_to_spectral_lib> <lib_name> <path_to_fasta_dir> [config_output_path]"
-            echo "                                              Generate library build parameter template."
-            echo "                                              Default config output path: ./buildspeclib_params.json"
-            echo "  empirical-config <input_path_to_empirical_lib> <output_path_to_spectral_lib> [config_output_path]"
-            echo "                                              Generate parse parameter template"
-            echo "                                              Default config output path: ./parsespeclib_params.json"
-            echo "  convert-mzml <path_to_mzml_dir> [skip_header]"
-            echo "                                              Convert mzML files"
-            
-            echo ""
-            echo "Examples:"
-            echo "  pioneer predict-config yeast.poin yeast fasta/ predict_config.json"
-            echo "  pioneer predict predict_config.json"
-            echo "  pioneer search-config yeast.poin data/ results/ search_config.json"
-            echo "  pioneer search search_config.json                                        # Use auto threading"
-            echo "  pioneer --threads=8 search search_config.json                            # Use 8 threads"
-            echo ""
-            echo "For subcommand-specific help:"
-            echo "  pioneer <subcommand> --help"
-            exit 0
-            ;;
-        -*)
-            echo "Error: Unknown option $1"
-            echo "Use --help for usage information"
-            exit 1
-            ;;
         *)
-            # First non-option argument should be the subcommand
-            if [[ -z "$SUBCOMMAND" ]]; then
-                # Check if it's a valid subcommand
-                if [[ " $VALID_COMMANDS " =~ " $1 " ]]; then
-                    SUBCOMMAND="$1"
-                else
-                    echo "Error: Unknown subcommand '$1'"
-                    echo "Valid subcommands: $VALID_COMMANDS"
-                    echo "Use --help for usage information"
-                    exit 1
-                fi
-            else
-                # All remaining arguments go to the subcommand
-                SUBCOMMAND_ARGS+=("$1")
-            fi
+            ARGS+=("$1")
             shift
             ;;
     esac
 done
 
-# Check if subcommand was provided
-if [[ -z "$SUBCOMMAND" ]]; then
-    echo "Error: Subcommand required"
-    echo "Valid subcommands: $VALID_COMMANDS"
-    echo "Use --help for usage information"
-    exit 1
-fi
-
-# Map aliases to the canonical executable names
-case "$SUBCOMMAND" in
-    search)
-        SUBCOMMAND="SearchDIA"
-        ;;
-    predict)
-        SUBCOMMAND="BuildSpecLib"
-        ;;
-    empirical)
-        SUBCOMMAND="ParseSpecLib"
-        ;;
-    empirical-config)
-        SUBCOMMAND="GetParseSpecLibParams"
-        ;;
-    search-config)
-        SUBCOMMAND="GetSearchParams"
-        ;;
-    predict-config)
-        SUBCOMMAND="GetBuildLibParams"
-        ;;
-    convert-mzml)
-        SUBCOMMAND="convertMzML"
-        ;;
-esac
-
-# Resolve the actual script location, handling symlinks
 SCRIPT_PATH="$0"
 while [ -L "$SCRIPT_PATH" ]; do
     SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
@@ -133,6 +37,4 @@ while [ -L "$SCRIPT_PATH" ]; do
 done
 SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
 
-# Call the actual Pioneer executable with subcommand and its arguments
-# The executables are in the bin/ subdirectory relative to the script location
-exec "$SCRIPT_DIR/bin/$SUBCOMMAND" "${SUBCOMMAND_ARGS[@]}"
+exec "$SCRIPT_DIR/bin/PioneerCLI" "${ARGS[@]}"

--- a/src/build/scripts/pioneer.bat
+++ b/src/build/scripts/pioneer.bat
@@ -4,13 +4,11 @@ setlocal enabledelayedexpansion
 if "%JULIA_NUM_THREADS%"=="" set JULIA_NUM_THREADS=auto
 
 set SCRIPT_DIR=%~dp0
+set CLI=%SCRIPT_DIR%bin\PioneerCLI.exe
+set ARGS=
 
-set SUBCOMMAND=
-set SUBCOMMAND_ARGS=
-set VALID_COMMANDS=search predict empirical search-config predict-config empirical-config convert-mzml
-
-:parse_args
-if "%~1"=="" goto check_subcommand
+:parse
+if "%~1"=="" goto run
 if "%~1"=="--threads" (
     if "%~2"=="" (
         echo Error: --threads requires a value
@@ -19,114 +17,26 @@ if "%~1"=="--threads" (
     set JULIA_NUM_THREADS=%~2
     shift
     shift
-    goto parse_args
+    goto parse
 )
-if "%~1"=="--help" goto show_help
-if "%~1"=="-h" goto show_help
-if "%~1"=="-help" goto show_help
-if "%~1"=="/?" goto show_help
-
-rem Check for --threads=value format
-echo %~1 | findstr /C:"--threads=" >nul
-if !errorlevel! equ 0 (
-    set THREADS_ARG=%~1
-    set JULIA_NUM_THREADS=!THREADS_ARG:--threads=!
-    shift
-    goto parse_args
-)
-
-rem Check for unknown options
-echo %~1 | findstr /R "^-" >nul
-if !errorlevel! equ 0 (
-    echo Error: Unknown option %~1
-    echo Use --help for usage information
-    exit /b 1
-)
-
-rem First non-option argument should be subcommand
-if "%SUBCOMMAND%"=="" (
-    rem Check if it's a valid subcommand
-    echo %VALID_COMMANDS% | findstr /C:"%~1" >nul
-    if !errorlevel! equ 0 (
-        set SUBCOMMAND=%~1
-    ) else (
-        echo Error: Unknown subcommand '%~1'
-        echo Valid subcommands: %VALID_COMMANDS%
-        echo Use --help for usage information
-        exit /b 1
+for /f "tokens=1,2 delims==" %%A in ("%~1") do (
+    if "%%A"=="--threads" (
+        set JULIA_NUM_THREADS=%%B
+        shift
+        goto parse
     )
+)
+if defined ARGS (
+    set ARGS=%ARGS% %~1
 ) else (
-    rem All remaining arguments go to the subcommand
-    if "%SUBCOMMAND_ARGS%"=="" (
-        set SUBCOMMAND_ARGS=%~1
-    ) else (
-        set SUBCOMMAND_ARGS=%SUBCOMMAND_ARGS% %~1
-    )
+    set ARGS=%~1
 )
 shift
-goto parse_args
+goto parse
 
-:show_help
-echo Pioneer - Mass Spectrometry Data Analysis
-echo.
-echo Usage: pioneer [options] ^<subcommand^> [subcommand-args...]
-echo.
-echo Options:
-echo   --threads N        Set number of Julia threads (default: auto)
-echo   --threads=N        Alternative syntax for setting threads
-echo   --help, -h         Show this help message
-echo.
-echo Subcommands:
-echo   search ^<path_to_config.json^>                Perform DIA search analysis
-echo   predict ^<path_to_config.json^>               Predict spectral library
-echo   empirical ^<path_to_config.json^>             Parse spectral library
-echo   search-config ^<path_to_spectral_lib^> ^<path_to_ms_data^> ^<path_to_search_results^> [config_output_path]
-echo                                                 Generate search parameter template
-echo                                                 Default config output path: ./search_parameters.json
-echo   predict-config ^<output_path_to_spectral_lib^> ^<lib_name^> ^<path_to_fasta_dir^> [config]
-echo                                                 Generate library build parameter template
-echo                                                 Default config output path: ./buildspeclib_params.json
-echo   empirical-config ^<input_path_to_empirical_lib^> ^<output_path_to_spectral_lib^> [config_output_path]
-echo                                                 Generate parse parameter template
-echo                                                 Default config output path: ./parsespeclib_params.json"
-echo   convert-mzml ^<path_to_mzml_dir^> [skip_header]
-echo                                                 Convert mzML files
-echo.
-echo Examples:
-echo   pioneer predict-config yeast.poin yeast fasta/ predict_config.json
-echo   pioneer predict predict_config.json
-echo   pioneer search-config yeast.poin data/ results/ search_config.json
-echo   pioneer search config.json                    # Use auto threading
-echo   pioneer --threads=8 search config.json        # Use 8 threads
-echo.
-echo For subcommand-specific help:
-echo   pioneer ^<subcommand^> --help
-exit /b 0
-
-
-:check_subcommand
-if "%SUBCOMMAND%"=="" (
-    echo Error: Subcommand required
-    echo Valid subcommands: %VALID_COMMANDS%
-    echo Use --help for usage information
-    exit /b 1
-)
-
-rem Map aliases to canonical executable names
-if /I "%SUBCOMMAND%"=="search" set SUBCOMMAND=SearchDIA
-if /I "%SUBCOMMAND%"=="predict" set SUBCOMMAND=BuildSpecLib
-if /I "%SUBCOMMAND%"=="empirical" set SUBCOMMAND=ParseSpecLib
-if /I "%SUBCOMMAND%"=="empirical-config" set SUBCOMMAND=GetParseSpecLibParams
-if /I "%SUBCOMMAND%"=="search-config" set SUBCOMMAND=GetSearchParams
-if /I "%SUBCOMMAND%"=="predict-config" set SUBCOMMAND=GetBuildLibParams
-if /I "%SUBCOMMAND%"=="convert-mzml" set SUBCOMMAND=convertMzML
-
-
-:run_pioneer
-rem The executables are in the bin\ subdirectory
-set "EXEC=%SCRIPT_DIR%bin\%SUBCOMMAND%.exe"
-if "%SUBCOMMAND_ARGS%"=="" (
-    "%EXEC%"
+:run
+if defined ARGS (
+    "%CLI%" %ARGS%
 ) else (
-    "%EXEC%" %SUBCOMMAND_ARGS%
+    "%CLI%"
 )


### PR DESCRIPTION
## Summary
- add optional argv parameter to all `main_*` entrypoints
- use ArgParse defaults to emit config paths in help output
- forward arguments from `main_pioneer` directly to subcommands

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: HTTP 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688c0d7a0d488325a7146f43b98bb523