### PR TITLE
Handle updated PioneerConverter zip layout in CI workflows

### DIFF
--- a/.github/workflows/build_app_linux.yml
+++ b/.github/workflows/build_app_linux.yml
@@ -107,7 +107,8 @@ jobs:
           fi
           curl -L "https://github.com/DennisGoldfarb/PioneerConverter/releases/latest/download/$ASSET" -o converter.zip
           unzip -q converter.zip -d converter
-          cp -r "converter/PioneerConverter-${PATTERN}/"* "build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/bin/"
+          cp converter/*/bin/PioneerConverter.exe "build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/bin/"
+          cp -r converter/*/lib/* "build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/lib/"
 
       - name: Add wrapper scripts
         shell: bash

--- a/.github/workflows/build_app_macos.yml
+++ b/.github/workflows/build_app_macos.yml
@@ -137,7 +137,8 @@ jobs:
             grep -o "Binary-PioneerConverter${PATTERN}-[^\"]*\.zip" | head -n 1)
           curl -L "https://github.com/DennisGoldfarb/PioneerConverter/releases/latest/download/$ASSET" -o converter.zip
           unzip -q converter.zip -d converter
-          cp converter/PioneerConverter build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/bin/
+          cp converter/*/bin/PioneerConverter.exe build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/bin/
+          cp -r converter/*/lib/* build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/lib/
 
       - name: Add wrapper scripts
         shell: bash

--- a/.github/workflows/build_app_windows.yml
+++ b/.github/workflows/build_app_windows.yml
@@ -82,7 +82,8 @@ jobs:
           Invoke-WebRequest -Uri "https://github.com/DennisGoldfarb/PioneerConverter/releases/latest/download/$asset" -OutFile converter.zip
           Expand-Archive -Path converter.zip -DestinationPath $dir
           $subdir = Get-ChildItem -Path $dir -Directory | Select-Object -First 1
-          Copy-Item "$($subdir.FullName)\*" "build\Pioneer_${{ matrix.identifier }}\Applications\Pioneer\bin\" -Recurse
+          Copy-Item "$($subdir.FullName)\bin\PioneerConverter.exe" "build\Pioneer_${{ matrix.identifier }}\Applications\Pioneer\bin\"
+          Copy-Item "$($subdir.FullName)\lib\*" "build\Pioneer_${{ matrix.identifier }}\Applications\Pioneer\lib\" -Recurse
 
 
       - name: Add wrapper scripts


### PR DESCRIPTION
## Summary
- adapt build workflows to new PioneerConverter zip structure with separate bin and lib
- ensure executable goes to `bin` and dependencies to `lib` for Linux, macOS, and Windows

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(failed: proxy returned unexpected status: 403 while fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688e493bda088325a0e5cb4d521e4c40