### PR TITLE
Split PioneerConverter bin and lib directories in build workflows

### DIFF
--- a/.github/workflows/build_app_linux.yml
+++ b/.github/workflows/build_app_linux.yml
@@ -113,7 +113,9 @@ jobs:
           find converter -maxdepth 3 -print
           echo "Listing of converter/*/bin:"
           ls converter/*/bin || true
-          cp -r "converter/PioneerConverter-${PATTERN}/"* "build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/bin/"
+          cp -r "converter/PioneerConverter-${PATTERN}/bin/"* "build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/bin/"
+          mkdir -p "build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/lib"
+          cp -r "converter/PioneerConverter-${PATTERN}/lib/"* "build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/lib/"
 
       - name: Add wrapper scripts
         shell: bash

--- a/.github/workflows/build_app_macos.yml
+++ b/.github/workflows/build_app_macos.yml
@@ -144,7 +144,9 @@ jobs:
           find converter -maxdepth 3 -print
           echo "Listing of converter/*/bin:"
           ls converter/*/bin || true
-          cp -r "converter/PioneerConverter-${PATTERN}/"* "build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/bin/"
+          cp -r "converter/PioneerConverter-${PATTERN}/bin/"* "build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/bin/"
+          mkdir -p "build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/lib"
+          cp -r "converter/PioneerConverter-${PATTERN}/lib/"* "build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/lib/"
 
       - name: Add wrapper scripts
         shell: bash

--- a/.github/workflows/build_app_windows.yml
+++ b/.github/workflows/build_app_windows.yml
@@ -82,7 +82,9 @@ jobs:
           Invoke-WebRequest -Uri "https://github.com/DennisGoldfarb/PioneerConverter/releases/latest/download/$asset" -OutFile converter.zip
           Expand-Archive -Path converter.zip -DestinationPath $dir
           $subdir = Get-ChildItem -Path $dir -Directory | Select-Object -First 1
-          Copy-Item "$($subdir.FullName)\*" "build\Pioneer_${{ matrix.identifier }}\Applications\Pioneer\bin\" -Recurse
+          Copy-Item "$($subdir.FullName)\bin\*" "build\Pioneer_${{ matrix.identifier }}\Applications\Pioneer\bin\" -Recurse
+          New-Item -ItemType Directory -Force -Path "build\Pioneer_${{ matrix.identifier }}\Applications\Pioneer\lib" | Out-Null
+          Copy-Item "$($subdir.FullName)\lib\*" "build\Pioneer_${{ matrix.identifier }}\Applications\Pioneer\lib\" -Recurse
 
 
       - name: Add wrapper scripts


### PR DESCRIPTION
## Summary
- Ensure Windows installer copies PioneerConverter bin and lib directories separately.
- Update Linux build workflow to place PioneerConverter binaries in bin and shared libraries in lib.
- Apply same bin/lib separation for macOS build workflow.

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: proxy returned unexpected status 403 when cloning dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688ed5505808832583176492cc8640a1