### PR TITLE
Remove experimental params-empirical CLI subcommand

### DIFF
--- a/src/Routines/BuildSpecLib.jl
+++ b/src/Routines/BuildSpecLib.jl
@@ -19,7 +19,6 @@
 
 # Entry point for PackageCompiler
 function main_BuildSpecLib(argv=ARGS)::Cint
-    println("Raw arguments: ", argv)
     settings = ArgParseSettings(; autofix_names = true)
     @add_arg_table! settings begin
         "params_path"
@@ -27,7 +26,6 @@ function main_BuildSpecLib(argv=ARGS)::Cint
             arg_type = String
     end
     parsed_args = parse_args(argv, settings; as_symbols = true)
-    println("Parsed arguments: ", parsed_args)
     try
         BuildSpecLib(parsed_args[:params_path])
     catch

--- a/src/Routines/GenerateParams.jl
+++ b/src/Routines/GenerateParams.jl
@@ -17,7 +17,6 @@
 
 # Entry point for PackageCompiler
 function main_GetSearchParams(argv=ARGS)::Cint
-    println("Raw arguments: ", argv)
     settings = ArgParseSettings(; autofix_names = true)
     @add_arg_table! settings begin
         "library_path"
@@ -35,7 +34,6 @@ function main_GetSearchParams(argv=ARGS)::Cint
             default = joinpath(pwd(), "search_parameters.json")
     end
     parsed_args = parse_args(argv, settings; as_symbols = true)
-    println("Parsed arguments: ", parsed_args)
     params_path = parsed_args[:params_path]
     try
        GetSearchParams(parsed_args[:library_path],
@@ -52,7 +50,6 @@ end
 
 # Entry point for PackageCompiler
 function main_GetBuildLibParams(argv=ARGS)::Cint
-    println("Raw arguments: ", argv)
     settings = ArgParseSettings(; autofix_names = true)
     @add_arg_table! settings begin
         "out_dir"
@@ -70,7 +67,6 @@ function main_GetBuildLibParams(argv=ARGS)::Cint
             default = joinpath(pwd(), "buildspeclib_params.json")
     end
     parsed_args = parse_args(argv, settings; as_symbols = true)
-    println("Parsed arguments: ", parsed_args)
     params_path = parsed_args[:params_path]
     try
         GetBuildLibParams(parsed_args[:out_dir],
@@ -86,7 +82,6 @@ end
 
 # Entry point for PackageCompiler
 function main_GetParseSpecLibParams(argv=ARGS)::Cint
-    println("Raw arguments: ", argv)
     settings = ArgParseSettings(; autofix_names = true)
     @add_arg_table! settings begin
         "input_lib_path"
@@ -101,7 +96,6 @@ function main_GetParseSpecLibParams(argv=ARGS)::Cint
             default = joinpath(pwd(), "parsespeclib_params.json")
     end
     parsed_args = parse_args(argv, settings; as_symbols = true)
-    println("Parsed arguments: ", parsed_args)
     params_path = parsed_args[:params_path]
     try
         GetParseSpecLibParams(parsed_args[:input_lib_path], 

--- a/src/Routines/ParseSpecLib.jl
+++ b/src/Routines/ParseSpecLib.jl
@@ -19,7 +19,6 @@
 
 # Entry point for PackageCompiler
 function main_ParseSpecLib(argv=ARGS)::Cint
-    println("Raw arguments: ", argv)
     settings = ArgParseSettings(; autofix_names = true)
     @add_arg_table! settings begin
         "params_path"
@@ -27,7 +26,6 @@ function main_ParseSpecLib(argv=ARGS)::Cint
             arg_type = String
     end
     parsed_args = parse_args(argv, settings; as_symbols = true)
-    println("Parsed arguments: ", parsed_args)
     try
         ParseSpecLib(parsed_args[:params_path])
     catch

--- a/src/Routines/SearchDIA.jl
+++ b/src/Routines/SearchDIA.jl
@@ -17,7 +17,6 @@
 
 # Entry point for PackageCompiler
 function main_SearchDIA(argv=ARGS)::Cint
-    println("Raw arguments: ", argv)
     settings = ArgParseSettings(; autofix_names = true)
     @add_arg_table! settings begin
         "params_path"
@@ -25,7 +24,6 @@ function main_SearchDIA(argv=ARGS)::Cint
             arg_type = String
     end
     parsed_args = parse_args(argv, settings; as_symbols = true)
-    println("Parsed arguments: ", parsed_args)
     try
         SearchDIA(parsed_args[:params_path])
     catch

--- a/src/Routines/mzmlConverter/convertMzML.jl
+++ b/src/Routines/mzmlConverter/convertMzML.jl
@@ -17,7 +17,6 @@
 
 # Entry point for PackageCompiler
 function main_convertMzML(argv=ARGS)::Cint
-    println("Raw arguments: ", argv)
     settings = ArgParseSettings(; autofix_names = true)
     @add_arg_table! settings begin
         "mzml_dir"
@@ -30,9 +29,8 @@ function main_convertMzML(argv=ARGS)::Cint
             required = false
     end
     parsed_args = parse_args(argv, settings; as_symbols = true)
-    println("Parsed arguments: ", parsed_args)
     try
-        convertMzML(parsed_args[:mzml_dir]; 
+        convertMzML(parsed_args[:mzml_dir];
                     skip_scan_header = parsed_args[:skip_header])
     catch
         Base.invokelatest(Base.display_error, Base.catch_stack())

--- a/src/build/CLI/pioneer
+++ b/src/build/CLI/pioneer
@@ -6,7 +6,7 @@ if [ -z "$JULIA_NUM_THREADS" ]; then
 fi
 
 # Valid subcommands
-VALID_COMMANDS="search predict empirical params-search params-predict params-empirical convert-raw convert-mzml"
+VALID_COMMANDS="search predict empirical params-search params-predict convert-raw convert-mzml"
 
 show_help() {
     echo "Pioneer - Mass Spectrometry Data Analysis"
@@ -28,9 +28,6 @@ show_help() {
     echo "  params-predict <library_outpath> <lib_name> <fasta_path> [--params-path <params_out_path>]"
     echo "                                              Generate library build parameter template."
     echo "                                              Default params output path: ./buildspeclib_params.json"
-    echo "  params-empirical <empirical_lib_path> <library_outpath> [--params-path <params_out_path>]"
-    echo "                                              Generate parse parameter template"
-    echo "                                              Default params output path: ./parsespeclib_params.json"
     echo "  convert-raw <data_path> [options]"
     echo "                                              Convert Thermo RAW files"
     echo "  convert-mzml <data_path> [skip_header]"
@@ -124,9 +121,6 @@ case "$SUBCOMMAND" in
     empirical)
         SUBCOMMAND="ParseSpecLib"
         ;;
-    params-empirical)
-        SUBCOMMAND="GetParseSpecLibParams"
-        ;;
     params-search)
         SUBCOMMAND="GetSearchParams"
         ;;
@@ -152,5 +146,4 @@ SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
 
 # Call the actual Pioneer executable with subcommand and its arguments
 # The executables are in the bin/ subdirectory relative to the script location
-echo "Executing: $SCRIPT_DIR/bin/$SUBCOMMAND ${SUBCOMMAND_ARGS[@]}"
 exec "$SCRIPT_DIR/bin/$SUBCOMMAND" "${SUBCOMMAND_ARGS[@]}"

--- a/src/build/CLI/pioneer.bat
+++ b/src/build/CLI/pioneer.bat
@@ -7,7 +7,7 @@ set SCRIPT_DIR=%~dp0
 
 set SUBCOMMAND=
 set SUBCOMMAND_ARGS=
-set VALID_COMMANDS=search predict empirical params-search params-predict params-empirical convert-raw convert-mzml
+set VALID_COMMANDS=search predict empirical params-search params-predict convert-raw convert-mzml
 
 :parse_args
 if "%~1"=="" goto check_subcommand
@@ -107,9 +107,6 @@ echo                                                 Default params output path:
 echo   params-predict ^<library_outpath^> ^<lib_name^> ^<fasta_path^> [--params-path ^<params_out_path^>]
 echo                                                 Generate library build parameter template
 echo                                                 Default params output path: ./buildspeclib_params.json
-echo   params-empirical ^<empirical_lib_path^> ^<library_outpath^> [--params-path ^<params_out_path^>]
-echo                                                 Generate parse parameter template
-echo                                                 Default params output path: ./parsespeclib_params.json
 echo   convert-raw ^<data_path^> [options]
 echo                                                 Convert Thermo RAW files
 echo   convert-mzml ^<data_path^> [skip_header]
@@ -139,7 +136,6 @@ rem Map aliases to canonical executable names
 if /I "%SUBCOMMAND%"=="search" set SUBCOMMAND=SearchDIA
 if /I "%SUBCOMMAND%"=="predict" set SUBCOMMAND=BuildSpecLib
 if /I "%SUBCOMMAND%"=="empirical" set SUBCOMMAND=ParseSpecLib
-if /I "%SUBCOMMAND%"=="params-empirical" set SUBCOMMAND=GetParseSpecLibParams
 if /I "%SUBCOMMAND%"=="params-search" set SUBCOMMAND=GetSearchParams
 if /I "%SUBCOMMAND%"=="params-predict" set SUBCOMMAND=GetBuildLibParams
 if /I "%SUBCOMMAND%"=="convert-mzml" set SUBCOMMAND=convertMzML
@@ -149,7 +145,6 @@ if /I "%SUBCOMMAND%"=="convert-raw" set SUBCOMMAND=PioneerConverter
 :run_pioneer
 rem The executables are in the bin\ subdirectory
 set "EXEC=%SCRIPT_DIR%bin\%SUBCOMMAND%.exe"
-echo Executing: "%EXEC%" %SUBCOMMAND_ARGS%
 if "%SUBCOMMAND_ARGS%"=="" (
     "%EXEC%"
 ) else (


### PR DESCRIPTION
## Summary
- drop `params-empirical` from wrapper scripts and help text
- strip debug command-echoing from CLI wrappers
- remove argument-debug prints from executable entrypoints

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: GitError(Code:ERROR, Class:HTTP, proxy returned unexpected status: 403))*

------
https://chatgpt.com/codex/tasks/task_e_688f8388691c83258f1aba6760f87ab4