### PR TITLE
Bundle artifacts into compiled apps

### DIFF
--- a/.github/workflows/build_app_linux.yml
+++ b/.github/workflows/build_app_linux.yml
@@ -74,6 +74,7 @@ jobs:
               incremental=false, force=true,
               executables=[first_exe => first_main],
               cpu_target="generic",
+              include_lazy_artifacts=true,
               precompile_execution_file="src/build/snoop.jl");
 
             for (exe, main) in executables[2:end]
@@ -83,6 +84,7 @@ jobs:
                 incremental=false, force=true,
                 executables=[exe => main],
                 cpu_target="generic",
+                include_lazy_artifacts=true,
                 precompile_execution_file="src/build/snoop.jl");
 
               cp("build/temp_$exe/bin/$exe",

--- a/.github/workflows/build_app_macos.yml
+++ b/.github/workflows/build_app_macos.yml
@@ -120,6 +120,7 @@ jobs:
                 "SearchDIA" => "main_SearchDIA",
                 "convertMzML" => "main_convertMzML"
               ],
+              include_lazy_artifacts=true,
               precompile_execution_file="src/build/snoop.jl",
             );
           '

--- a/.github/workflows/build_app_windows.yml
+++ b/.github/workflows/build_app_windows.yml
@@ -67,6 +67,7 @@ jobs:
                 "SearchDIA" => "main_SearchDIA",
                 "convertMzML" => "main_convertMzML"
               ],
+              include_lazy_artifacts=true,
               precompile_execution_file="src/build/snoop.jl",
             );
           '


### PR DESCRIPTION
## Summary
- include lazy artifacts in PackageCompiler builds so MKL and IntelOpenMP ship with binaries

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(failed: GitError Code:ERROR, Class:HTTP, proxy returned unexpected status: 403)*

------
https://chatgpt.com/codex/tasks/task_e_688fa3cb452c83259ee928967cbb575f