### PR TITLE
docs: refresh quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,61 +9,29 @@
 ## Documentation
 See [documentation for full installation and usage instructions.](https://nwamsley1.github.io/Pioneer.jl/dev)
 
-## Installation and Usage
+## Installation
 Download the installer for your operating system from the [releases page](https://github.com/nwamsley1/Pioneer.jl/releases). The installer adds a `pioneer` command to your `PATH`. On the first run, Windows and Linux download IntelOpenMP and MKL; macOS performs a Gatekeeper security check.
 
 ```bash
 pioneer --help
 ```
 Lists subcommands such as `predict`, `params-predict`, `search`, `params-search`, `convert-raw`, and `convert-mzml`.
-A typical workflow is:
+
+## Quick Start
+Pioneer uses [PioneerConverter](https://github.com/nwamsley1/PioneerConverter) to convert vendor RAW files to Arrow format. A minimal end-to-end workflow is:
 
 ```bash
-pioneer params-predict out_dir lib_name fasta_dir
-pioneer predict buildspeclib_params.json
+pioneer params-predict lib_dir lib_name fasta_dir --params-path=predict_params.json
+pioneer predict predict_params.json
 pioneer convert-raw raw_dir
-pioneer params-search library.poin ms_data results
-pioneer search search_parameters.json
+pioneer params-search library.poin ms_data_dir results_dir --params-path=search_params.json
+pioneer search search_params.json
 ```
 
-`params-predict` and `params-search` write template JSON files. Review and edit these
-configurations before running `predict` or `search`. See the
+`params-predict` and `params-search` write template JSON files. Review and edit these configurations before running `predict` or `search`. See the
 [Parameter Configuration](https://nwamsley1.github.io/Pioneer.jl/dev/user_guide/parameters/)
 guide for available options.
 
-## Development
-To work on Pioneer itself:
-
-```bash
-git clone https://github.com/nwamsley1/Pioneer.jl.git
-cd Pioneer.jl
-julia --project=dev
-```
-
-```julia
-pkg> develop ./
-julia> using Revise, Pioneer
-```
-
-Install [PioneerConverter](https://github.com/nwamsley1/PioneerConverter) to convert Thermo RAW files to Arrow format before calling functions like `GetBuildLibParams`, `BuildSpecLib`, `GetSearchParams`, and `SearchDIA` directly.
-
-| Subcommand       | Julia function   |
-|------------------|------------------|
-| `params-predict` | `GetBuildLibParams` |
-| `predict`        | `BuildSpecLib`     |
-| `params-search`  | `GetSearchParams`  |
-| `search`         | `SearchDIA`        |
-| `convert-raw`    | `PioneerConverter` |
-| `convert-mzml`   | `convertMzML`      |
-
-Developers can invoke these functions directly:
-
-```julia
-params = GetBuildLibParams(out_dir, lib_name, fasta_dir)
-BuildSpecLib(params)
-params = GetSearchParams("library.poin", "ms_data", "results")
-SearchDIA(params)
-```
 
 ## Introduction
 

--- a/docs/src/user_guide/quickstart.md
+++ b/docs/src/user_guide/quickstart.md
@@ -1,19 +1,20 @@
 # Quick Start Tutorial
 
 ## Basic Workflow
-Pioneer performs two major steps:
-1. Build in silico spectral libraries using FASTA files and the [Koina](https://koina.wilhelmlab.org/) server.
-2. Search DIA experiments using a spectral library and the MS data files.
+Pioneer performs three major steps:
+1. Convert vendor MS files into the Arrow format using [PioneerConverter](https://github.com/nwamsley1/PioneerConverter).
+2. Build in silico spectral libraries using FASTA files and the [Koina](https://koina.wilhelmlab.org/) server.
+3. Search DIA experiments using a spectral library and the MS data files.
 
 ## Pioneer Converter
 Pioneer operates on MS/MS data stored in the [Apache Arrow IPC format](https://arrow.apache.org/docs/python/ipc.html).
-Use the bundled PioneerConverter via the CLI to convert Thermo RAW files:
+Use the bundled [PioneerConverter](https://github.com/nwamsley1/PioneerConverter) via the CLI to convert Thermo RAW files:
 
 ```bash
 pioneer convert-raw /path/to/raw/or/folder
 ```
 
-This subcommand accepts either a single `.raw` file or a directory of files. See the PioneerConverter repository for additional options such as thread count and output paths.
+This subcommand accepts either a single `.raw` file or a directory of files. See the [PioneerConverter repository](https://github.com/nwamsley1/PioneerConverter) for additional options such as thread count and output paths.
 
 ## MzML to Arrow IPC (Sciex)
 For mzML-formatted data, use:
@@ -34,11 +35,11 @@ Subcommands include `search`, `predict`, `params-search`, `params-predict`, `con
 A minimal end-to-end workflow is:
 
 ```bash
-pioneer params-predict out_dir lib_name fasta_dir
-pioneer predict buildspeclib_params.json
+pioneer params-predict lib_dir lib_name fasta_dir --params-path=predict_params.json
+pioneer predict predict_params.json
 pioneer convert-raw raw_dir
-pioneer params-search library.poin ms_data results
-pioneer search search_parameters.json
+pioneer params-search library.poin ms_data_dir results_dir --params-path=search_params.json
+pioneer search search_params.json
 ```
 
 This sequence builds a predicted spectral library, converts vendor files to Arrow, generates search parameters, and searches the experiment.


### PR DESCRIPTION
## Summary
- clarify workflow to include Arrow conversion via PioneerConverter
- use placeholder directories with `--params-path` options in quick start examples
- trim README to user-focused quick start

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: proxy returned unexpected status 403)*

------
https://chatgpt.com/codex/tasks/task_e_6890f83f164c83259c9dbec84cda81e7