### PR TITLE
refactor: separate release workflow

### DIFF
--- a/.github/workflows/build_app_linux.yml
+++ b/.github/workflows/build_app_linux.yml
@@ -1,21 +1,20 @@
-name: Build & Release Linux
+name: Build Linux
 
 on:
   push:
     branches:
       - main
       - develop
-    tags:
-      - 'v*.*.*'
   pull_request:
     branches:
       - main
       - develop
   workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Release tag (e.g., v1.2.3)'
-        required: false
+  workflow_call:
+    outputs:
+      version:
+        description: 'Build version'
+        value: ${{ jobs.build.outputs.version }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -166,32 +165,3 @@ jobs:
           path: |
             Pioneer-${{ steps.get_version.outputs.version }}-${{ matrix.identifier }}.deb
             Pioneer-${{ steps.get_version.outputs.version }}-${{ matrix.identifier }}.zip
-
-  release:
-    name: Publish GitHub Release
-    needs: build
-    runs-on: ubuntu-latest
-    if: >
-      needs.build.outputs.version != 'v0.0.0' && (
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
-        (github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '')
-      )
-    permissions:
-      contents: write
-      actions:  read
-
-    steps:
-      - name: Checkout just the publish-release action
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          sparse-checkout: |
-            .github/actions/publish-release
-          sparse-checkout-cone-mode: true
-
-      - name: Publish Release
-        uses: ./.github/actions/publish-release
-        with:
-          version: ${{ needs.build.outputs.version }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_app_macos.yml
+++ b/.github/workflows/build_app_macos.yml
@@ -1,21 +1,20 @@
-name: Build & Release macOS
+name: Build macOS
 
 on:
   push:
     branches:
       - main
       - develop
-    tags:
-      - 'v*.*.*'
   pull_request:
     branches:
       - main
       - develop
   workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Release tag (e.g., v1.2.3)'
-        required: false
+  workflow_call:
+    outputs:
+      version:
+        description: 'Build version'
+        value: ${{ jobs.build.outputs.version }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -269,32 +268,3 @@ jobs:
         with:
           name: Pioneer-${{ matrix.identifier }}-pkg
           path: Pioneer-${{ steps.get_version.outputs.version }}-${{ matrix.identifier }}.pkg
-
-  release:
-    name: Publish GitHub Release
-    needs: build
-    runs-on: ubuntu-latest
-    if: >
-      needs.build.outputs.version != 'v0.0.0' && (
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
-        (github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '')
-      )
-    permissions:
-      contents: write
-      actions:  read
-
-    steps:
-      - name: Checkout just the publish-release action
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          sparse-checkout: |
-            .github/actions/publish-release
-          sparse-checkout-cone-mode: true
-
-      - name: Publish Release
-        uses: ./.github/actions/publish-release
-        with:
-          version: ${{ needs.build.outputs.version }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_app_windows.yml
+++ b/.github/workflows/build_app_windows.yml
@@ -1,21 +1,20 @@
-name: Build & Release Windows
+name: Build Windows
 
 on:
   push:
     branches:
       - main
       - develop
-    tags:
-      - 'v*.*.*'
   pull_request:
     branches:
       - main
       - develop
   workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Release tag (e.g., v1.2.3)'
-        required: false
+  workflow_call:
+    outputs:
+      version:
+        description: 'Build version'
+        value: ${{ jobs.build.outputs.version }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -213,32 +212,3 @@ jobs:
           path: |
             Pioneer-${{ steps.get_version.outputs.version }}-${{ matrix.identifier }}.msi
             Pioneer-${{ steps.get_version.outputs.version }}-${{ matrix.identifier }}.zip
-
-  release:
-    name: Publish GitHub Release
-    needs: build
-    runs-on: ubuntu-latest
-    if: >
-      needs.build.outputs.version != 'v0.0.0' && (
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
-        (github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '')
-      )
-    permissions:
-      contents: write
-      actions:  read
-
-    steps:
-      - name: Checkout just the publish-release action
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          sparse-checkout: |
-            .github/actions/publish-release
-          sparse-checkout-cone-mode: true
-
-      - name: Publish Release
-        uses: ./.github/actions/publish-release
-        with:
-          version: ${{ needs.build.outputs.version }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+jobs:
+  linux:
+    uses: ./.github/workflows/build_app_linux.yml
+  macos:
+    uses: ./.github/workflows/build_app_macos.yml
+  windows:
+    uses: ./.github/workflows/build_app_windows.yml
+
+  publish:
+    name: Publish GitHub Release
+    needs:
+      - linux
+      - macos
+      - windows
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - name: Checkout just the publish-release action
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          sparse-checkout: |
+            .github/actions/publish-release
+          sparse-checkout-cone-mode: true
+      - name: Publish Release
+        uses: ./.github/actions/publish-release
+        with:
+          version: ${{ needs.linux.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/src/development/ci_cd_workflow.md
+++ b/docs/src/development/ci_cd_workflow.md
@@ -8,7 +8,8 @@ The repository uses several workflows:
 
 - `tests.yml` – run the test suite on Ubuntu
 - `docs.yml` – build docs for pull requests, tags, and manual runs; deploy docs from `main` and `v*` tags
-- `build_app_linux.yml`, `build_app_macos.yml`, `build_app_windows.yml` – build and package applications
+- `build_app_linux.yml`, `build_app_macos.yml`, `build_app_windows.yml` – build and package applications; reusable via `workflow_call`
+- `release.yml` – orchestrate cross-platform builds and publish GitHub releases for tags
 - `CompatHelper.yml` – update package compatibility constraints (scheduled daily)
 - `TagBot.yml` – tag releases and interact with the Julia package registry
 - `registrator.yml` – run Registrator to open a registration PR in the Julia General registry
@@ -28,9 +29,10 @@ The repository uses several workflows:
 Manual dispatches allow running workflows on demand.
 
 | Workflow | Condition | Tests | Build Docs | Deploy Docs | Compile | Release | Purpose |
-|----------|-----------|-------|------|--------|---------|---------|---------|
+|----------|-----------|-------|-----------|-------------|---------|---------|---------|
 | `registrator.yml` | Julia registration success | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | Release new version |
-| `tests.yml`, `docs.yml`, `build_app_*` | `v*.*.*` | :white_check_mark: | :white_check_mark: | :white_check_mark:  | :white_check_mark: | :white_check_mark: | Manually rerun or troubleshoot |
+| `release.yml` | `v*.*.*` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | Build & publish release |
+| `tests.yml`, `docs.yml`, `build_app_*` | `v*.*.*` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | Manually rerun or troubleshoot |
 | `tests.yml`, `docs.yml`, `build_app_*` | no tag | :white_check_mark: | :white_check_mark: | `develop` | :white_check_mark: | :x: | Test/build dev version |
   
 ## Release Process
@@ -41,7 +43,7 @@ To cut a new release:
 2. Merge that change into the `main` branch.
 3. Manually trigger `registrator.yml`, which runs `JuliaRegistries/Registrator@v1` to open or update a registration pull request in the Julia General registry.
 4. After the registry PR is merged, `TagBot` creates a tag and GitHub release.
-5. The tag triggers the docs workflow to build and deploy versioned documentation and the platform build workflows (`build_app_linux.yml`, `build_app_macos.yml`, `build_app_windows.yml`), which compile the application and attach the artifacts to the release.
+5. The tag triggers the docs workflow to build and deploy versioned documentation and the `release.yml` workflow. The release workflow calls the platform build workflows (`build_app_linux.yml`, `build_app_macos.yml`, `build_app_windows.yml`) to compile the application and attach the artifacts to the GitHub release.
 
 ## Pre-releases
 


### PR DESCRIPTION
## Summary
- remove release jobs from OS build workflows
- add release workflow that triggers on tagged pushes and dispatch
- expose build artifacts via workflow_call outputs for reuse

## Testing
- `pre-commit run --files .github/workflows/build_app_linux.yml .github/workflows/build_app_macos.yml .github/workflows/build_app_windows.yml .github/workflows/release.yml` *(failed: command not found)*
- `apt-get update` *(failed: 403 Forbidden for Ubuntu repositories)*
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68988c6e80408325b7b506f8319293a1