### PR TITLE
Ensure PioneerConverter asset resolution uses GitHub token

### DIFF
--- a/.github/workflows/build_app_linux.yml
+++ b/.github/workflows/build_app_linux.yml
@@ -102,14 +102,19 @@ jobs:
         run: |
           mkdir -p converter
           PATTERN="${{ matrix.identifier }}"
-          ASSET=$(curl -sL https://api.github.com/repos/nwamsley1/PioneerConverter/releases/latest \
+          ASSET=$(curl -fsSL \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            https://api.github.com/repos/nwamsley1/PioneerConverter/releases/latest \
             | jq -r --arg PATTERN "$PATTERN" '.assets[]
               | select(.name|test("PioneerConverter-"+$PATTERN+".*\\.zip"))
               | .name' | head -n1)
+
           if [[ -z "$ASSET" ]]; then
-            echo "ERROR: No asset for $PATTERN" >&2
+            echo "Error: ASSET not found"
             exit 1
           fi
+
           curl -L "https://github.com/nwamsley1/PioneerConverter/releases/latest/download/$ASSET" \
             -o converter.zip
           unzip -q converter.zip -d converter

--- a/.github/workflows/build_app_macos.yml
+++ b/.github/workflows/build_app_macos.yml
@@ -165,10 +165,19 @@ jobs:
           else
             PATTERN="osx-arm64"
           fi
-          ASSET=$(curl -sL https://api.github.com/repos/nwamsley1/PioneerConverter/releases/latest \
+          ASSET=$(curl -fsSL \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            https://api.github.com/repos/nwamsley1/PioneerConverter/releases/latest \
             | jq -r --arg PATTERN "$PATTERN" '.assets[]
               | select(.name | test("PioneerConverter-"+$PATTERN+".*\\.zip"))
               | .name' | head -n1)
+
+          if [[ -z "$ASSET" ]]; then
+            echo "Error: ASSET not found"
+            exit 1
+          fi
+
           curl -L "https://github.com/nwamsley1/PioneerConverter/releases/latest/download/$ASSET" \
             -o converter.zip
           unzip -q converter.zip -d converter

--- a/.github/workflows/build_app_windows.yml
+++ b/.github/workflows/build_app_windows.yml
@@ -107,10 +107,14 @@ jobs:
           $dir = "converter"
           New-Item -ItemType Directory -Force -Path $dir | Out-Null
           $pattern = "win-x64"
-          $json = Invoke-WebRequest -Uri https://api.github.com/repos/nwamsley1/PioneerConverter/releases/latest |
+          $headers = @{ Accept = 'application/vnd.github+json'; Authorization = 'Bearer ${{ github.token }}' }
+          $json = Invoke-WebRequest -Uri https://api.github.com/repos/nwamsley1/PioneerConverter/releases/latest -Headers $headers |
                   Select-Object -ExpandProperty Content | ConvertFrom-Json
           $asset = ($json.assets | Where-Object { $_.name -like "*$pattern*.zip" } | Select-Object -First 1).name
-          if (-not $asset) { throw "No asset found matching $pattern" }
+          if (-not $asset) {
+            Write-Error "Error: ASSET not found"
+            exit 1
+          }
           Invoke-WebRequest -Uri "https://github.com/nwamsley1/PioneerConverter/releases/latest/download/$asset" -OutFile converter.zip
           Expand-Archive -Path converter.zip -DestinationPath $dir
           $subdir = Get-ChildItem -Path $dir -Directory | Select-Object -First 1


### PR DESCRIPTION
## Summary
- add authentication and error handling when fetching PioneerConverter assets across build workflows

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6898afd1bb0c83258aa96dfa76de8d33