### PR TITLE
Fix Registrator workflow action path

### DIFF
--- a/.github/workflows/Register.yml
+++ b/.github/workflows/Register.yml
@@ -1,0 +1,20 @@
+name: Register
+
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  Registrator:
+    if: github.event_name == 'workflow_dispatch' || github.event.comment.body == '@JuliaRegistries/Registrator register'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/Registrator.jl@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add a Registrator workflow that uses `JuliaRegistries/Registrator.jl@v1`

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689a0f0cacb08325b50487439c0cb661