### PR TITLE
Use MBR probability for ranking IDs

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
@@ -245,14 +245,14 @@ function apply_mbr_filter!(
     )
 
     # 4) one fused pass to clamp probs
-    merged_df._filtered_prob = ifelse.(
+    merged_df.prob = ifelse.(
         candidate_mask .& (merged_df.MBR_prob .< τ),
         0.0f0,
         merged_df.MBR_prob
     )
 
-    # if downstream code expects a Symbol for the prob-column
-    return :_filtered_prob
+    # downstream code uses the updated :prob column
+    return :prob
 end
 
 """


### PR DESCRIPTION
## Summary
- Clamp MBR probabilities directly into `:prob`
- Use the updated probability for precursor and global ranking

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ccf171bc8325b12ea4a91052093c