### PR TITLE
Support run-specific RT weights for Sundial coefficient libraries in SearchDIA

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -280,17 +280,22 @@ function process_file!(
         rt_model::RtConversionModel,
         ms_file_idx::Int64
     )
+        precursors = getPrecursors(getSpecLib(search_context))
+        rt_coeffs = hasRtCoefficients(precursors) ? getRtCoefficients(precursors) : nothing
+        rt_weights = haskey(getRtWeights(search_context), ms_file_idx) ? getRtWeights(search_context, ms_file_idx) : nothing
         add_main_search_columns!(
             psms,
             getModel(rt_model),
-            getStructuralMods(getPrecursors(getSpecLib(search_context))),
-            getMissedCleavages(getPrecursors(getSpecLib(search_context))),
-            getIsDecoy(getPrecursors(getSpecLib(search_context))),
-            getIrt(getPrecursors(getSpecLib(search_context))),
-            getCharge(getPrecursors(getSpecLib(search_context))),
+            getStructuralMods(precursors),
+            getMissedCleavages(precursors),
+            getIsDecoy(precursors),
+            getIrt(precursors),
+            getCharge(precursors),
             getRetentionTimes(spectra),
             getTICs(spectra),
-            getMzArrays(spectra)
+            getMzArrays(spectra),
+            rt_coeffs,
+            rt_weights
         )
         # Calculate RT values
         psms[!, :irt_observed] = rt_model.(psms[!, :rt])

--- a/src/Routines/SearchDIA/SearchMethods/SearchTypes.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SearchTypes.jl
@@ -205,6 +205,7 @@ mutable struct SearchContext{N,L<:SpectralLibrary,M<:MassSpecDataReference}
     # Results and paths
     irt_rt_map::Dict{Int64, RtConversionModel}
     rt_irt_map::Dict{Int64, RtConversionModel}
+    rt_weights::Dict{Int64, Vector{Float32}}
     precursor_dict::Base.Ref{Dictionary}
     rt_index_paths::Base.Ref{Vector{String}}
     irt_errors::Dict{Int64, Float32}
@@ -243,9 +244,10 @@ mutable struct SearchContext{N,L<:SpectralLibrary,M<:MassSpecDataReference}
             Dict{Int64, MassErrorModel}(),
             Dict{Int64, MassErrorModel}(),
             Dict{Int64, NceModel}(), Ref(100000.0f0), 10.0f0,
-            Dict{Int64, RtConversionModel}(), 
-            Dict{Int64, RtConversionModel}(), 
-            Ref{Dictionary}(), 
+            Dict{Int64, RtConversionModel}(),
+            Dict{Int64, RtConversionModel}(),
+            Dict{Int64, Vector{Float32}}(),
+            Ref{Dictionary}(),
             Ref{Vector{String}}(),
             Dict{Int64, Float32}(),
             Dict{UInt32, Float32}(),
@@ -459,6 +461,10 @@ Get RT to iRT conversion model for MS file index. Returns identity model if not 
 function getRtIrtModel(s::SearchContext)
    return s.rt_irt_map
 end
+
+getRtWeights(s::SearchContext) = s.rt_weights
+getRtWeights(s::SearchContext, index::I) where {I<:Integer} = s.rt_weights[index]
+setRtWeights!(s::SearchContext, index::I, weights::Vector{Float32}) where {I<:Integer} = (s.rt_weights[index] = weights)
 
 """
    getNceModelModel(s::SearchContext, index::Integer)

--- a/src/structs/LibraryIon.jl
+++ b/src/structs/LibraryIon.jl
@@ -809,4 +809,7 @@ end
 getPairIdx(lp::LibraryPrecursors) = lp.data[:pair_id]
 getPlex(lp::PlexedLibraryPrecursors)::Arrow.Primitive{I, Vector{I}} where {I<:Integer} = lp.data[:plex]
 
+hasRtCoefficients(lp::LibraryPrecursors) = (:rt_coefficients in Tables.schema(lp.data).names)
+getRtCoefficients(lp::LibraryPrecursors) = lp.data[:rt_coefficients]
+
 


### PR DESCRIPTION
## Summary
- detect and load `rt_coefficients` from Sundial libraries
- compute run-specific RT weights during parameter tuning and store per run
- use run-specific weights to derive iRT features while keeping original predictions for index search

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: proxy returned unexpected status 403)*

------
https://chatgpt.com/codex/tasks/task_e_68acd71c9f0c8325a17a1f4866926f99