### PR TITLE
Refit RT spline after Sundial weighting

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -281,21 +281,17 @@ function process_file!(
         ms_file_idx::Int64
     )
         precursors = getPrecursors(getSpecLib(search_context))
-        rt_coeffs = hasRtCoefficients(precursors) ? getRtCoefficients(precursors) : nothing
-        rt_weights = haskey(getRtWeights(search_context), ms_file_idx) ? getRtWeights(search_context, ms_file_idx) : nothing
         add_main_search_columns!(
             psms,
             getModel(rt_model),
             getStructuralMods(precursors),
             getMissedCleavages(precursors),
             getIsDecoy(precursors),
-            getIrt(precursors),
+            getPredIrt(search_context),
             getCharge(precursors),
             getRetentionTimes(spectra),
             getTICs(spectra),
-            getMzArrays(spectra),
-            rt_coeffs,
-            rt_weights
+            getMzArrays(spectra)
         )
         # Calculate RT values
         psms[!, :irt_observed] = rt_model.(psms[!, :rt])


### PR DESCRIPTION
## Summary
- Refit RT→iRT spline using Sundial-adjusted predictions and recompute MAD
- Persist weight-adjusted iRT predictions in search context for all precursors
- Simplify first-pass column building by using precomputed iRT predictions and dropping runtime Sundial adjustments

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: HTTP 403 when cloning dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1cf5fa48832585cfc8c770c2d3dc