### PR TITLE
Support run-specific RT coefficients in SearchDIA

### DIFF
--- a/.github/workflows/build_app_windows.yml
+++ b/.github/workflows/build_app_windows.yml
@@ -129,6 +129,13 @@ jobs:
         run: |
           Copy-Item src\build\CLI\pioneer.bat build\Pioneer_${{ matrix.identifier }}/Applications/Pioneer/
 
+      - name: Bundle 7-Zip for gzip extraction
+        shell: pwsh
+        run: |
+          $sevenZipUrl = "https://www.7-zip.org/a/7zr.exe"
+          Invoke-WebRequest -Uri $sevenZipUrl -OutFile 7z.exe
+          Copy-Item 7z.exe "build\Pioneer_${{ matrix.identifier }}\Applications\Pioneer\bin\7z.exe"
+
       - name: Normalize version for MSI
         id: semver
         shell: pwsh

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -506,7 +506,9 @@ function summarize_results!(
         i = 1
         for (pid, val) in pairs(precursor_dict)
             i += 1
-            setPredIrt!(search_context, pid, getIrt(getPrecursors(getSpecLib(search_context)))[pid])
+            if !haskey(getPredIrt(search_context), pid)
+                setPredIrt!(search_context, pid, getIrt(getPrecursors(getSpecLib(search_context)))[pid])
+            end
             partner_pid = getPartnerPrecursorIdx(precursors)[pid]
             if ismissing(partner_pid)
                 continue
@@ -516,15 +518,21 @@ function summarize_results!(
             # Otherwise if the partner was ID'ed, it should keep its original predicted iRT
             if !haskey(precursor_dict, partner_pid)
                 insert!(precursor_dict, partner_pid, val)
-                setPredIrt!(search_context, partner_pid, getIrt(getPrecursors(getSpecLib(search_context)))[pid])
+                if !haskey(getPredIrt(search_context), partner_pid)
+                    setPredIrt!(search_context, partner_pid, getIrt(getPrecursors(getSpecLib(search_context)))[pid])
+                end
             else
-                setPredIrt!(search_context, partner_pid, getIrt(getPrecursors(getSpecLib(search_context)))[partner_pid])
+                if !haskey(getPredIrt(search_context), partner_pid)
+                    setPredIrt!(search_context, partner_pid, getIrt(getPrecursors(getSpecLib(search_context)))[partner_pid])
+                end
             end
-            
+
         end
     else
         for (pid, val) in pairs(precursor_dict)
-            setPredIrt!(search_context, pid, getIrt(getPrecursors(getSpecLib(search_context)))[pid])
+            if !haskey(getPredIrt(search_context), pid)
+                setPredIrt!(search_context, pid, getIrt(getPrecursors(getSpecLib(search_context)))[pid])
+            end
         end
     end
 

--- a/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/ParameterTuningSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/ParameterTuningSearch.jl
@@ -225,6 +225,7 @@ function init_search_results(::ParameterTuningSearchParameters, search_context::
         Vector{Float32}(),
         Vector{Float32}(),
         Vector{Float32}(),
+        Vector{Float32}(),
         Plots.Plot[],
         Plots.Plot[],
         qc_dir

--- a/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/utils.jl
@@ -291,12 +291,13 @@ function fit_irt_model(
 end
 
 """
-    optimize_rt_weights(rt::Vector{Float32}, irt::Vector{Float32}, coefs::Vector{NTuple{4,Float32}})
+    optimize_rt_weights(rt::Vector{Float32}, irt::Vector{Float32}, coefs::Vector{NTuple{4,Float32}}; λ)
 
 Determine run-specific weights that minimize the PSM-count-weighted average
-coefficient of variation of predicted iRT values across 20 RT bins.
+coefficient of variation of predicted iRT values across 20 RT bins while
+penalizing large weights via an L2 regularization term.
 """
-function optimize_rt_weights(rt::Vector{Float32}, irt::Vector{Float32}, coefs::Vector{NTuple{4,Float32}})
+function optimize_rt_weights(rt::Vector{Float32}, irt::Vector{Float32}, coefs::Vector{NTuple{4,Float32}}; λ::Float64 = 0.1)
     n_bins = 20
     min_rt, max_rt = minimum(rt), maximum(rt)
     edges = collect(LinRange(min_rt, max_rt, n_bins + 1))
@@ -325,7 +326,7 @@ function optimize_rt_weights(rt::Vector{Float32}, irt::Vector{Float32}, coefs::V
                 end
             end
         end
-        return cv_sum / max(total, 1)
+        return cv_sum / max(total, 1) + λ * sum(abs2, w)
     end
 
     result = Optim.optimize(objective, zeros(4), Optim.NelderMead())

--- a/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/utils.jl
@@ -280,7 +280,7 @@ function fit_irt_model(
         residuals_rs = irt_observed_rs .- valid_psms[!,:irt_predicted_run_specific]
         irt_mad_rs = mad(residuals_rs, normalize=false)::Float32
         println("Original spline MAD: ", irt_mad_orig)
-        println("Run-specific spline MAD: ", irt_mad_rs)
+        println("Run-specific spline MAD: ", irt_mad_rs, "\n\n")
 
         return (final_model, valid_psms[!,:rt], valid_psms[!,:irt_predicted_run_specific], irt_mad_rs, original_model, valid_psms[!,:irt_predicted], weights)
     else
@@ -297,7 +297,7 @@ Determine run-specific weights that minimize Gaussian-weighted squared
 differences of run-specific iRT predictions for PSM pairs within a limited
 retention-time window.  An L2 penalty discourages large weights.
 """
-function optimize_rt_weights(rt::Vector{Float32}, irt::Vector{Float32}, coefs::Vector{NTuple{4,Float32}}; λ::Float64 = 0.1)
+function optimize_rt_weights(rt::Vector{Float32}, irt::Vector{Float32}, coefs::Vector{NTuple{4,Float32}}; λ::Float64 = 0.0)
     order = sortperm(rt)
     rt_sorted = rt[order]
     irt_sorted = irt[order]
@@ -305,8 +305,8 @@ function optimize_rt_weights(rt::Vector{Float32}, irt::Vector{Float32}, coefs::V
     temp = similar(irt_sorted)
 
     rt_range = maximum(rt_sorted) - minimum(rt_sorted)
-    sigma = max(rt_range / 10, eps(Float32))
-    window = 3sigma
+    sigma = max(rt_range / 1000, eps(Float32))
+    window = 1sigma
 
     function objective(w)
         @inbounds for i in eachindex(irt_sorted)

--- a/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/utils.jl
@@ -16,13 +16,13 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 """
-    add_tuning_search_columns!(psms::DataFrame, MS_TABLE::Arrow.Table,
+    add_tuning_search_columns!(psms::DataFrame, MS_TABLE::MassSpecData,
                              prec_is_decoy::Arrow.BoolVector{Bool},
                              prec_irt::Arrow.Primitive{T, Vector{T}},
                              prec_charge::Arrow.Primitive{UInt8, Vector{UInt8}},
-                             scan_retention_time::AbstractVector{Float32},
-                             tic::AbstractVector{Float32},
-                             prec_rt_coefs::Union{Nothing, AbstractVector}=nothing) where {T<:AbstractFloat}
+                             scan_retention_time,
+                             tic,
+                             prec_rt_coefs=nothing) where {T<:AbstractFloat}
 
 Adds essential columns to PSM DataFrame for parameter tuning analysis.
 
@@ -32,8 +32,9 @@ Adds essential columns to PSM DataFrame for parameter tuning analysis.
 - `prec_is_decoy`: Boolean vector indicating decoy status
 - `prec_irt`: Vector of iRT values
 - `prec_charge`: Vector of precursor charges
-- `scan_retention_time`: Vector of scan retention times
-- `tic`: Vector of total ion currents
+ - `scan_retention_time`: Vector of scan retention times
+ - `tic`: Vector of total ion currents
+ - `prec_rt_coefs`: Optional vector of run-specific RT coefficients
 
 # Added Columns
 - Basic metrics: RT, iRT predicted, charge, TIC
@@ -42,13 +43,14 @@ Adds essential columns to PSM DataFrame for parameter tuning analysis.
 
 Uses parallel processing for efficiency through data chunking.
 """
-function add_tuning_search_columns!(psms::DataFrame, 
-                                MS_TABLE::MassSpecData, 
-                                prec_is_decoy::Arrow.BoolVector{Bool},
-                                prec_irt::Arrow.Primitive{T, Vector{T}},
-                                prec_charge::Arrow.Primitive{UInt8, Vector{UInt8}},
-                                scan_retention_time::AbstractVector{Float32},
-                                tic::AbstractVector{Float32}) where {T<:AbstractFloat}
+function add_tuning_search_columns!(psms::DataFrame,
+                                    MS_TABLE::MassSpecData,
+                                    prec_is_decoy::Arrow.BoolVector{Bool},
+                                    prec_irt::Arrow.Primitive{T, Vector{T}},
+                                    prec_charge::Arrow.Primitive{UInt8, Vector{UInt8}},
+                                    scan_retention_time,
+                                    tic,
+                                    prec_rt_coefs=nothing) where {T<:AbstractFloat}
     
     N = size(psms, 1)
     decoys = zeros(Bool, N);

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
@@ -272,7 +272,6 @@ function summarize_results!(
                        end) => :prec_prob)
             transform!(groupby(merged_df, :precursor_idx),
                        :prec_prob => (p -> logodds(p, sqrt_n_runs)) => :global_prob)
-            prob_col == :_filtered_prob && select!(merged_df, Not(:_filtered_prob)) # drop temp trace prob TODO maybe we want this for getting best traces
 
             # Write updated data back to individual files
             for (idx, ref) in enumerate(second_pass_refs)

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
@@ -214,26 +214,23 @@ function apply_mbr_filter!(
     fdr_scale_factor::Float32,
 )
     n = nrow(merged_df)
-
-    # 1) compute trace_qval locally
+    
+    # 1) compute q-values only for non-transfer candidates
+    candidate_mask = merged_df.MBR_transfer_candidate
+    non_mbr_mask = .!candidate_mask
     trace_qval = Vector{Float32}(undef, n)
     get_qvalues!(
-        merged_df.prob,
-        merged_df.target,
-        trace_qval;
-        fdr_scale_factor = fdr_scale_factor
+        merged_df.prob[non_mbr_mask],
+        merged_df.target[non_mbr_mask],
+        trace_qval[non_mbr_mask];
+        fdr_scale_factor = fdr_scale_factor,
     )
 
-    # 2) build boolean masks locally
-    candidate_mask = 
-        (trace_qval .> params.q_value_threshold) .& 
-        .!ismissing.(merged_df.MBR_is_best_decoy)
-
-    bad_mask =
-        candidate_mask .& (
+    # 2) identify bad transfers
+    bad_mask = candidate_mask .& (
         (merged_df.target .& coalesce.(merged_df.MBR_is_best_decoy, false)) .|
         (merged_df.decoy  .& .!coalesce.(merged_df.MBR_is_best_decoy, true))
-        )
+    )
 
     # 3) compute threshold using the local bad_mask
     τ = get_ftr_threshold(
@@ -241,14 +238,14 @@ function apply_mbr_filter!(
         merged_df.target,
         bad_mask,
         params.max_MBR_false_transfer_rate;
-        mask = candidate_mask
+        mask = candidate_mask,
     )
 
     # 4) one fused pass to clamp probs
     merged_df._filtered_prob = ifelse.(
         candidate_mask .& (merged_df.MBR_prob .< τ),
         0.0f0,
-        merged_df.MBR_prob
+        merged_df.MBR_prob,
     )
 
     # if downstream code expects a Symbol for the prob-column

--- a/src/utils/ML/ftrUtilities.jl
+++ b/src/utils/ML/ftrUtilities.jl
@@ -49,6 +49,8 @@ function get_ftr_threshold(scores::AbstractVector{U},
         end
     end
 
+    println(best_count, " ", τ, " ",  transfer_cum, " ",  target_cum, " ", transfer_cum / target_cum, " ", alpha, "\n\n")
+
     return τ
 end
 


### PR DESCRIPTION
## Summary
- detect and access run-specific RT coefficients in precursor tables
- optimize run-specific retention time weights and store run-specific iRT predictions
- plot original vs run-specific RT alignments and propagate predictions through search context
- simplify coefficient detection to use the standardized `:coefficients` column

## Testing
- `julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.test()'` *(fails: command not found: julia)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68adc4d805648325ab37d52090e2534e