### PR TITLE
Use run-specific iRT weights for feature calculation

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/ParameterTuningSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/ParameterTuningSearch.jl
@@ -185,20 +185,7 @@ function set_rt_to_irt_model!(
 
     weights = model[7]
     if weights !== nothing
-        precs = getPrecursors(getSpecLib(search_context))
-        base = getIrt(precs)
-        if hasRtCoefficients(precs)
-            coefs = getRtCoefficients(precs)
-            for pid in 1:length(base)
-                c = coefs[pid]
-                rs = base[pid] + c[1]*weights[1] + c[2]*weights[2] + c[3]*weights[3] + c[4]*weights[4]
-                setPredIrt!(search_context, UInt32(pid), rs)
-            end
-        else
-            for pid in 1:length(base)
-                setPredIrt!(search_context, UInt32(pid), base[pid])
-            end
-        end
+        setRtRunSpecificWeights!(search_context, ms_file_idx, weights)
     end
 end
 
@@ -359,7 +346,8 @@ function process_search_results!(
         # Update models in search context
         setMassErrorModel!(search_context, ms_file_idx, getMassErrorModel(results))
         
-        setRtIrtMap!(search_context, getRtToIrtModel(results), ms_file_idx)
+        setRtIrtMap!(search_context, getRtToIrtModelOriginal(results), ms_file_idx)
+        setRtIrtMapRunSpecific!(search_context, getRtToIrtModel(results), ms_file_idx)
     catch
         setFailedIndicator!(getMSData(search_context), ms_file_idx, true)
         nothing

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/SecondPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/SecondPassSearch.jl
@@ -386,13 +386,13 @@ function process_search_results!(
         
         psms[!, :ms1_features_missing] = miss_mask
         #Add additional features for final analysis
-        add_features!(
+            add_features!(
             psms,
             search_context,
             getTICs(spectra),
             getMzArrays(spectra),
             ms_file_idx,
-            getRtIrtModel(search_context, ms_file_idx),
+            getRtIrtModelRunSpecific(search_context, ms_file_idx),
             getPrecursorDict(search_context)
         )
 

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -765,6 +765,16 @@ function get_isotopes_captured!(chroms::DataFrame,
 end
 
 
+PrecToIrtType = Dictionary{UInt32,
+    NamedTuple{
+        (:best_prob, :best_ms_file_idx, :best_scan_idx, :best_irt,
+         :mean_irt, :var_irt, :n, :mz),
+        Tuple{Float32, UInt32, UInt32, Float32,
+              Union{Missing, Float32}, Union{Missing, Float32},
+              Union{Missing, UInt16}, Float32}
+    }
+}
+
 """
     add_features!(psms::DataFrame, search_context::SearchContext, ...)
 
@@ -776,14 +786,13 @@ Add feature columns to PSMs for scoring and analysis.
 - Intensity metrics
 - Spectrum characteristics
 """
-function add_features!(psms::DataFrame, 
+function add_features!(psms::DataFrame,
                         search_context::SearchContext,
-                                    tic::AbstractVector{Float32},
-                                    masses::AbstractArray,
-                                    ms_file_idx::Integer,
-                                    rt_to_irt_interp::RtConversionModel,
-                                    prec_id_to_irt::Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_irt::Float32, mean_irt::Union{Missing, Float32}, var_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32}}
-                                    )
+                        tic::AbstractVector{Float32},
+                        masses::AbstractArray,
+                        ms_file_idx::Integer,
+                        rt_to_irt_interp::RtConversionModel,
+                        prec_id_to_irt::PrecToIrtType)
 
     precursor_sequence = getSequence(getPrecursors(getSpecLib(search_context)))#[:sequence],
     structural_mods = getStructuralMods(getPrecursors(getSpecLib(search_context)))#[:structural_mods],


### PR DESCRIPTION
## Summary
- Track run-specific RT models and weights in the search context
- Preserve original iRT mapping for index searches while applying run-specific predictions in features
- Compute run-specific iRT predictions and errors in first and second pass searches

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: proxy returned unexpected status: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68adf0c235b08325a3df7af59995ecc8