### PR TITLE
Use run-specific iRT weights for feature calculation

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -304,9 +304,7 @@ function process_file!(
             end, psms[!, :precursor_idx])
         end
         # Map weighted predictions through run-specific spline
-        irt_to_rt_rs = get(
-            getIrtRtMapRunSpecific(search_context), ms_file_idx, IdentityModel()
-        )
+        irt_to_rt_rs = getIrtRtModelRunSpecific(search_context, ms_file_idx)
         psms[!, :irt_predicted_run_specific] = rt_model.(
             irt_to_rt_rs.(psms[!, :irt_predicted_run_specific])
         )

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -254,7 +254,7 @@ function process_file!(
             )
         end
 
-        rt_model = getRtIrtModel(search_context, ms_file_idx)
+        rt_model = getRtIrtModelRunSpecific(search_context, ms_file_idx)
         # Add columns
         add_psm_columns!(psms, spectra, search_context, rt_model, ms_file_idx)
         
@@ -292,9 +292,25 @@ function process_file!(
             getTICs(spectra),
             getMzArrays(spectra)
         )
-        # Calculate RT values
+        # Calculate RT values using run-specific model and weights
         psms[!, :irt_observed] = rt_model.(psms[!, :rt])
-        psms[!, :irt_error] = Float16.(abs.(psms[!, :irt_observed] .- psms[!, :irt_predicted]))
+        weights = getRtRunSpecificWeights(search_context, ms_file_idx)
+        psms[!, :irt_predicted_run_specific] = psms[!, :irt_predicted]
+        if (weights !== nothing) && hasRtCoefficients(getPrecursors(getSpecLib(search_context)))
+            coefs = getRtCoefficients(getPrecursors(getSpecLib(search_context)))
+            psms[!, :irt_predicted_run_specific] .+= map(idx -> begin
+                c = coefs[Int(idx)]
+                c[1]*weights[1] + c[2]*weights[2] + c[3]*weights[3] + c[4]*weights[4]
+            end, psms[!, :precursor_idx])
+        end
+        # Map weighted predictions through run-specific spline
+        irt_to_rt_rs = get(
+            getIrtRtMapRunSpecific(search_context), ms_file_idx, IdentityModel()
+        )
+        psms[!, :irt_predicted_run_specific] = rt_model.(
+            irt_to_rt_rs.(psms[!, :irt_predicted_run_specific])
+        )
+        psms[!, :irt_error] = Float16.(abs.(psms[!, :irt_observed] .- psms[!, :irt_predicted_run_specific]))
         psms[!, :charge2] = UInt8.(psms[!, :charge] .== 2)
         psms[!, :ms_file_idx] .= UInt32(ms_file_idx)
     end

--- a/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/ParameterTuningSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/ParameterTuningSearch.jl
@@ -185,20 +185,7 @@ function set_rt_to_irt_model!(
 
     weights = model[7]
     if weights !== nothing
-        precs = getPrecursors(getSpecLib(search_context))
-        base = getIrt(precs)
-        if hasRtCoefficients(precs)
-            coefs = getRtCoefficients(precs)
-            for pid in 1:length(base)
-                c = coefs[pid]
-                rs = base[pid] + c[1]*weights[1] + c[2]*weights[2] + c[3]*weights[3] + c[4]*weights[4]
-                setPredIrt!(search_context, UInt32(pid), rs)
-            end
-        else
-            for pid in 1:length(base)
-                setPredIrt!(search_context, UInt32(pid), base[pid])
-            end
-        end
+        setRtRunSpecificWeights!(search_context, ms_file_idx, weights)
     end
 end
 
@@ -358,8 +345,16 @@ function process_search_results!(
         
         # Update models in search context
         setMassErrorModel!(search_context, ms_file_idx, getMassErrorModel(results))
-        
-        setRtIrtMap!(search_context, getRtToIrtModel(results), ms_file_idx)
+
+        setRtIrtMap!(search_context, getRtToIrtModelOriginal(results), ms_file_idx)
+        setRtIrtMapRunSpecific!(search_context, getRtToIrtModel(results), ms_file_idx)
+        irt_rt_rs = SplineRtConversionModel(UniformSpline(
+            results.rt,
+            results.irt,
+            getSplineDegree(params),
+            getSplineNKnots(params),
+        ))
+        setIrtRtMapRunSpecific!(search_context, irt_rt_rs, ms_file_idx)
     catch
         setFailedIndicator!(getMSData(search_context), ms_file_idx, true)
         nothing

--- a/src/Routines/SearchDIA/SearchMethods/SearchTypes.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SearchTypes.jl
@@ -205,6 +205,9 @@ mutable struct SearchContext{N,L<:SpectralLibrary,M<:MassSpecDataReference}
     # Results and paths
     irt_rt_map::Dict{Int64, RtConversionModel}
     rt_irt_map::Dict{Int64, RtConversionModel}
+    rt_irt_map_run_specific::Dict{Int64, RtConversionModel}
+    irt_rt_map_run_specific::Dict{Int64, RtConversionModel}
+    rt_run_specific_weights::Dict{Int64, Vector{Float32}}
     precursor_dict::Base.Ref{Dictionary}
     rt_index_paths::Base.Ref{Vector{String}}
     irt_errors::Dict{Int64, Float32}
@@ -243,9 +246,12 @@ mutable struct SearchContext{N,L<:SpectralLibrary,M<:MassSpecDataReference}
             Dict{Int64, MassErrorModel}(),
             Dict{Int64, MassErrorModel}(),
             Dict{Int64, NceModel}(), Ref(100000.0f0), 10.0f0,
-            Dict{Int64, RtConversionModel}(), 
-            Dict{Int64, RtConversionModel}(), 
-            Ref{Dictionary}(), 
+            Dict{Int64, RtConversionModel}(),
+            Dict{Int64, RtConversionModel}(),
+            Dict{Int64, RtConversionModel}(),
+            Dict{Int64, RtConversionModel}(),
+            Dict{Int64, Vector{Float32}}(),
+            Ref{Dictionary}(),
             Ref{Vector{String}}(),
             Dict{Int64, Float32}(),
             Dict{UInt32, Float32}(),
@@ -377,6 +383,8 @@ getMs1MassErrPlotFolder(s::SearchContext) = s.ms1_mass_err_plot_folder[]
 getParsedFileName(s::SearchContext, ms_file_idx::Int64) = getParsedFileName(s.mass_spec_data_reference, ms_file_idx)
 getIrtRtMap(s::SearchContext) = s.irt_rt_map
 getRtIrtMap(s::SearchContext) = s.rt_irt_map
+getRtIrtMapRunSpecific(s::SearchContext) = s.rt_irt_map_run_specific
+getIrtRtMapRunSpecific(s::SearchContext) = s.irt_rt_map_run_specific
 getPrecursorDict(s::SearchContext) = s.precursor_dict[]
 getRtIndexPaths(s::SearchContext) = s.rt_index_paths[]
 getIrtErrors(s::SearchContext) = s.irt_errors
@@ -386,6 +394,24 @@ getPredIrt(s::SearchContext, prec_idx::UInt32) = s.irt_obs[prec_idx]
 getHuberDelta(s::SearchContext) = s.huber_delta[]
 setPredIrt!(s::SearchContext, prec_idx::Int64, irt::Float32) = s.irt_obs[prec_idx] = irt
 setPredIrt!(s::SearchContext, prec_idx::UInt32, irt::Float32) = s.irt_obs[prec_idx] = irt
+function getRtIrtModelRunSpecific(s::SearchContext, index::I) where {I<:Integer}
+   if haskey(s.rt_irt_map_run_specific, index)
+       return s.rt_irt_map_run_specific[index]
+   else
+       return IdentityModel()
+   end
+end
+
+function getIrtRtModelRunSpecific(s::SearchContext, index::I) where {I<:Integer}
+    if haskey(s.irt_rt_map_run_specific, index)
+        return s.irt_rt_map_run_specific[index]
+    else
+        return IdentityModel()
+    end
+end
+function getRtRunSpecificWeights(s::SearchContext, index::I) where {I<:Integer}
+    return get(s.rt_run_specific_weights, index, nothing)
+end
 getLibraryTargetCount(s::SearchContext) = s.n_library_targets
 getLibraryDecoyCount(s::SearchContext) = s.n_library_decoys
 getLibraryFdrScaleFactor(s::SearchContext) = s.library_fdr_scale_factor
@@ -480,6 +506,15 @@ function setIrtRtMap!(s::SearchContext, rcm::RtConversionModel, index::I) where 
 end
 function setRtIrtMap!(s::SearchContext, rcm::RtConversionModel, index::I) where {I<:Integer}
     s.rt_irt_map[index] = rcm
+end
+function setRtIrtMapRunSpecific!(s::SearchContext, rcm::RtConversionModel, index::I) where {I<:Integer}
+    s.rt_irt_map_run_specific[index] = rcm
+end
+function setIrtRtMapRunSpecific!(s::SearchContext, rcm::RtConversionModel, index::I) where {I<:Integer}
+    s.irt_rt_map_run_specific[index] = rcm
+end
+function setRtRunSpecificWeights!(s::SearchContext, index::I, w::Vector{Float32}) where {I<:Integer}
+    s.rt_run_specific_weights[index] = w
 end
 function setPrecursorDict!(s::SearchContext, dict::Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_irt::Float32, mean_irt::Union{Missing, Float32}, var_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32}})
     s.precursor_dict[] = dict

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/SecondPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/SecondPassSearch.jl
@@ -386,13 +386,13 @@ function process_search_results!(
         
         psms[!, :ms1_features_missing] = miss_mask
         #Add additional features for final analysis
-        add_features!(
+            add_features!(
             psms,
             search_context,
             getTICs(spectra),
             getMzArrays(spectra),
             ms_file_idx,
-            getRtIrtModel(search_context, ms_file_idx),
+            getRtIrtModelRunSpecific(search_context, ms_file_idx),
             getPrecursorDict(search_context)
         )
 

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -765,6 +765,16 @@ function get_isotopes_captured!(chroms::DataFrame,
 end
 
 
+PrecToIrtType = Dictionary{UInt32,
+    NamedTuple{
+        (:best_prob, :best_ms_file_idx, :best_scan_idx, :best_irt,
+         :mean_irt, :var_irt, :n, :mz),
+        Tuple{Float32, UInt32, UInt32, Float32,
+              Union{Missing, Float32}, Union{Missing, Float32},
+              Union{Missing, UInt16}, Float32}
+    }
+}
+
 """
     add_features!(psms::DataFrame, search_context::SearchContext, ...)
 
@@ -776,19 +786,24 @@ Add feature columns to PSMs for scoring and analysis.
 - Intensity metrics
 - Spectrum characteristics
 """
-function add_features!(psms::DataFrame, 
+function add_features!(psms::DataFrame,
                         search_context::SearchContext,
-                                    tic::AbstractVector{Float32},
-                                    masses::AbstractArray,
-                                    ms_file_idx::Integer,
-                                    rt_to_irt_interp::RtConversionModel,
-                                    prec_id_to_irt::Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_irt::Float32, mean_irt::Union{Missing, Float32}, var_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32}}
-                                    )
+                        tic::AbstractVector{Float32},
+                        masses::AbstractArray,
+                        ms_file_idx::Integer,
+                        rt_to_irt_interp::RtConversionModel,
+                        prec_id_to_irt::PrecToIrtType)
 
     precursor_sequence = getSequence(getPrecursors(getSpecLib(search_context)))#[:sequence],
     structural_mods = getStructuralMods(getPrecursors(getSpecLib(search_context)))#[:structural_mods],
     prec_mz = getMz(getPrecursors(getSpecLib(search_context)))#[:mz],
     prec_irt = getIrt(getPrecursors(getSpecLib(search_context)))#[:irt],
+    rt_coefs = hasRtCoefficients(getPrecursors(getSpecLib(search_context))) ?
+        getRtCoefficients(getPrecursors(getSpecLib(search_context))) : nothing,
+    weights = getRtRunSpecificWeights(search_context, ms_file_idx),
+    irt_to_rt_rs = get(
+        getIrtRtMapRunSpecific(search_context), ms_file_idx, IdentityModel()
+    ),
     prec_charge = getCharge(getPrecursors(getSpecLib(search_context)))#[:prec_charge],
     entrap_group_ids = getEntrapmentGroupId(getPrecursors(getSpecLib(search_context)))
     precursor_missed_cleavage = getMissedCleavages(getPrecursors(getSpecLib(search_context)))#[:missed_cleavages],
@@ -852,15 +867,21 @@ function add_features!(psms::DataFrame,
                 prec_idx = precursor_idx[i]
                 entrap_group_id[i] = entrap_group_ids[prec_idx]
                 irt_obs[i] = rt_to_irt_interp(rt[i])
-                irt_pred[i] = getPredIrt(search_context, prec_idx)#prec_irt[prec_idx]
+                pred = prec_irt[Int(prec_idx)]
+                if (weights !== nothing) && (rt_coefs !== nothing)
+                    c = rt_coefs[Int(prec_idx)]
+                    pred += c[1]*weights[1] + c[2]*weights[2] + c[3]*weights[3] + c[4]*weights[4]
+                end
+                pred = rt_to_irt_interp(irt_to_rt_rs(pred))
+                irt_pred[i] = pred
                 #irt_diff[i] = abs(irt_obs[i] - first(prec_id_to_irt[prec_idx]))
                 irt_diff[i] = abs(irt_obs[i] - prec_id_to_irt[prec_idx].best_irt)
                 if !ms1_missing[i]
-                    ms1_irt_diff[i] = abs(rt_to_irt_interp(ms1_rt[i]) - getPredIrt(search_context, prec_idx))
+                    ms1_irt_diff[i] = abs(rt_to_irt_interp(ms1_rt[i]) - pred)
                 else
                     ms1_irt_diff[i] = 0f0
                 end
-                irt_error[i] = abs(irt_obs[i] - irt_pred[i])
+                irt_error[i] = abs(irt_obs[i] - pred)
 
                 missed_cleavage[i] = precursor_missed_cleavage[prec_idx]
                 #sequence[i] = precursor_sequence[prec_idx]

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -794,19 +794,17 @@ function add_features!(psms::DataFrame,
                         rt_to_irt_interp::RtConversionModel,
                         prec_id_to_irt::PrecToIrtType)
 
-    precursor_sequence = getSequence(getPrecursors(getSpecLib(search_context)))#[:sequence],
-    structural_mods = getStructuralMods(getPrecursors(getSpecLib(search_context)))#[:structural_mods],
-    prec_mz = getMz(getPrecursors(getSpecLib(search_context)))#[:mz],
-    prec_irt = getIrt(getPrecursors(getSpecLib(search_context)))#[:irt],
+    precursor_sequence = getSequence(getPrecursors(getSpecLib(search_context))) # [:sequence]
+    structural_mods = getStructuralMods(getPrecursors(getSpecLib(search_context))) # [:structural_mods]
+    prec_mz = getMz(getPrecursors(getSpecLib(search_context))) # [:mz]
+    prec_irt = getIrt(getPrecursors(getSpecLib(search_context))) # [:irt]
     rt_coefs = hasRtCoefficients(getPrecursors(getSpecLib(search_context))) ?
-        getRtCoefficients(getPrecursors(getSpecLib(search_context))) : nothing,
-    weights = getRtRunSpecificWeights(search_context, ms_file_idx),
-    irt_to_rt_rs = get(
-        getIrtRtMapRunSpecific(search_context), ms_file_idx, IdentityModel()
-    ),
-    prec_charge = getCharge(getPrecursors(getSpecLib(search_context)))#[:prec_charge],
+        getRtCoefficients(getPrecursors(getSpecLib(search_context))) : nothing
+    weights = getRtRunSpecificWeights(search_context, ms_file_idx)
+    irt_to_rt_rs = getIrtRtModelRunSpecific(search_context, ms_file_idx)
+    prec_charge = getCharge(getPrecursors(getSpecLib(search_context))) # [:prec_charge]
     entrap_group_ids = getEntrapmentGroupId(getPrecursors(getSpecLib(search_context)))
-    precursor_missed_cleavage = getMissedCleavages(getPrecursors(getSpecLib(search_context)))#[:missed_cleavages],
+    precursor_missed_cleavage = getMissedCleavages(getPrecursors(getSpecLib(search_context))) # [:missed_cleavages]
     precursor_pair_idxs = getPairIdx(getPrecursors(getSpecLib(search_context)))
     #filter!(x -> x.best_scan, psms);
     filter!(x->x.weight>0, psms);


### PR DESCRIPTION
## Summary
- Track run-specific RT<iRT and iRT<RT splines in the search context
- Generate and store run-specific inverse splines during parameter tuning
- Derive observed and predicted iRT features exclusively from run-specific splines

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: proxy returned unexpected status: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68adf0c235b08325a3df7af59995ecc8