### PR TITLE
feat: skip paired additions during early training

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -518,7 +518,17 @@ function summarize_results!(
             # If the partner needs to be added, then give it the irt of the currently identified precursor
             # Otherwise if the partner was ID'ed, it should keep its original predicted iRT
             if !haskey(precursor_dict, partner_pid)
-                insert!(precursor_dict, partner_pid, val)
+                insert!(precursor_dict, partner_pid, (
+                    best_prob = val.best_prob,
+                    best_ms_file_idx = val.best_ms_file_idx,
+                    best_scan_idx = val.best_scan_idx,
+                    best_irt = val.best_irt,
+                    mean_irt = val.mean_irt,
+                    var_irt = val.var_irt,
+                    n = val.n,
+                    mz = val.mz,
+                    passed_first_search = false
+                ))
                 setPredIrt!(search_context, partner_pid, getIrt(getPrecursors(getSpecLib(search_context)))[pid])
             else
                 setPredIrt!(search_context, partner_pid, getIrt(getPrecursors(getSpecLib(search_context)))[partner_pid])

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
@@ -54,14 +54,15 @@ function get_best_precursors_accross_runs(
                          )
 
     function readPSMs!(
-        prec_to_best_prob::Dictionary{UInt32, @NamedTuple{ best_prob::Float32, 
+        prec_to_best_prob::Dictionary{UInt32, @NamedTuple{ best_prob::Float32,
                                                     best_ms_file_idx::UInt32,
                                                     best_scan_idx::UInt32,
-                                                    best_irt::Float32, 
-                                                    mean_irt::Union{Missing, Float32}, 
-                                                    var_irt::Union{Missing, Float32}, 
-                                                    n::Union{Missing, UInt16}, 
-                                                    mz::Float32}},
+                                                    best_irt::Float32,
+                                                    mean_irt::Union{Missing, Float32},
+                                                    var_irt::Union{Missing, Float32},
+                                                    n::Union{Missing, UInt16},
+                                                    mz::Float32,
+                                                    passed_first_search::Bool}},
         precursor_idxs::AbstractVector{UInt32},
         q_values::AbstractVector{Float16},
         probs::AbstractVector{Float32},
@@ -91,7 +92,7 @@ function get_best_precursors_accross_runs(
             #Keep a running mean irt for instances below q-val threshold
             if haskey(prec_to_best_prob, precursor_idx)
                 # Update existing precursor entry
-                best_prob, best_ms_file_idx, best_scan_idx, best_irt, old_mean_irt, var_irt, old_n, mz = prec_to_best_prob[precursor_idx] 
+                best_prob, best_ms_file_idx, best_scan_idx, best_irt, old_mean_irt, var_irt, old_n, mz, passed_first_search = prec_to_best_prob[precursor_idx]
                 
                 # Update best match if current is better
                 if (best_prob < prob)
@@ -105,37 +106,40 @@ function get_best_precursors_accross_runs(
                 mean_irt += old_mean_irt
                 n += old_n 
                 prec_to_best_prob[precursor_idx] = (
-                                                best_prob = prob, 
+                                                best_prob = prob,
                                                 best_ms_file_idx = best_ms_file_idx,
                                                 best_scan_idx = best_scan_idx,
                                                 best_irt = irt,
-                                                mean_irt = mean_irt, 
+                                                mean_irt = mean_irt,
                                                 var_irt = var_irt,
                                                 n = n,
-                                                mz = mz)
+                                                mz = mz,
+                                                passed_first_search = passed_first_search)
             else
                 # Create new precursor entry
                 val = (best_prob = prob,
                         best_ms_file_idx = ms_file_idx,
-                        best_scan_idx = scan_idx, 
+                        best_scan_idx = scan_idx,
                         best_irt = irt,
-                        mean_irt = mean_irt, 
+                        mean_irt = mean_irt,
                         var_irt = var_irt,
                         n = n,
-                        mz = mz)
+                        mz = mz,
+                        passed_first_search = true)
                 insert!(prec_to_best_prob, precursor_idx, val)
             end
         end
     end
     function getVariance!(
-        prec_to_best_prob::Dictionary{UInt32, @NamedTuple{ best_prob::Float32, 
+        prec_to_best_prob::Dictionary{UInt32, @NamedTuple{ best_prob::Float32,
                                                     best_ms_file_idx::UInt32,
                                                     best_scan_idx::UInt32,
-                                                    best_irt::Float32, 
-                                                    mean_irt::Union{Missing, Float32}, 
-                                                    var_irt::Union{Missing, Float32}, 
-                                                    n::Union{Missing, UInt16}, 
-                                                    mz::Float32}},
+                                                    best_irt::Float32,
+                                                    mean_irt::Union{Missing, Float32},
+                                                    var_irt::Union{Missing, Float32},
+                                                    n::Union{Missing, UInt16},
+                                                    mz::Float32,
+                                                    passed_first_search::Bool}},
         precursor_idxs::AbstractVector{UInt32},
         q_values::AbstractVector{Float16},
         rts::AbstractVector{Float32},
@@ -154,30 +158,32 @@ function get_best_precursors_accross_runs(
             end
             if haskey(prec_to_best_prob, precursor_idx)
                 # Update variance calculation
-                best_prob, best_ms_file_idx, best_scan_idx, best_irt, mean_irt, var_irt, n, mz = prec_to_best_prob[precursor_idx] 
+                best_prob, best_ms_file_idx, best_scan_idx, best_irt, mean_irt, var_irt, n, mz, passed_first_search = prec_to_best_prob[precursor_idx]
                 var_irt += (irt - mean_irt/n)^2
                 prec_to_best_prob[precursor_idx] = (
-                    best_prob = best_prob, 
+                    best_prob = best_prob,
                     best_ms_file_idx= best_ms_file_idx,
                     best_scan_idx = best_scan_idx,
                     best_irt = best_irt,
-                    mean_irt = mean_irt, 
+                    mean_irt = mean_irt,
                     var_irt = var_irt,
                     n = n,
-                    mz = mz)
+                    mz = mz,
+                    passed_first_search = passed_first_search)
 
             end
         end
     end
     # Initialize dictionary to store best precursor matches
-    prec_to_best_prob = Dictionary{UInt32, @NamedTuple{ best_prob::Float32, 
+    prec_to_best_prob = Dictionary{UInt32, @NamedTuple{ best_prob::Float32,
                                                         best_ms_file_idx::UInt32,
                                                         best_scan_idx::UInt32,
-                                                        best_irt::Float32, 
-                                                        mean_irt::Union{Missing, Float32}, 
-                                                        var_irt::Union{Missing, Float32}, 
-                                                        n::Union{Missing, UInt16}, 
-                                                        mz::Float32}}()
+                                                        best_irt::Float32,
+                                                        mean_irt::Union{Missing, Float32},
+                                                        var_irt::Union{Missing, Float32},
+                                                        n::Union{Missing, UInt16},
+                                                        mz::Float32,
+                                                        passed_first_search::Bool}}()
 
     # First pass: collect best matches and mean iRT
 

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
@@ -464,15 +464,16 @@ function get_irt_errs(
                             median_fwhm::Float32,
                             mad_fwhm::Float32
                         }},
-    prec_to_irt::Dictionary{UInt32, 
-    @NamedTuple{best_prob::Float32, 
-                best_ms_file_idx::UInt32, 
-                best_scan_idx::UInt32, 
-                best_irt::Float32, 
-                mean_irt::Union{Missing, Float32}, 
-                var_irt::Union{Missing, Float32}, 
-                n::Union{Missing, UInt16}, 
-                mz::Float32}}
+    prec_to_irt::Dictionary{UInt32,
+    @NamedTuple{best_prob::Float32,
+                best_ms_file_idx::UInt32,
+                best_scan_idx::UInt32,
+                best_irt::Float32,
+                mean_irt::Union{Missing, Float32},
+                var_irt::Union{Missing, Float32},
+                n::Union{Missing, UInt16},
+                mz::Float32,
+                passed_first_search::Bool}}
     ,
     params::FirstPassSearchParameters
 )

--- a/src/Routines/SearchDIA/SearchMethods/SearchTypes.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SearchTypes.jl
@@ -496,7 +496,7 @@ end
 function setRtIrtMap!(s::SearchContext, rcm::RtConversionModel, index::I) where {I<:Integer}
     s.rt_irt_map[index] = rcm
 end
-function setPrecursorDict!(s::SearchContext, dict::Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_irt::Float32, mean_irt::Union{Missing, Float32}, var_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32}})
+function setPrecursorDict!(s::SearchContext, dict::Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_irt::Float32, mean_irt::Union{Missing, Float32}, var_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32, passed_first_search::Bool}})
     s.precursor_dict[] = dict
 end
 setRtIndexPaths!(s::SearchContext, paths::Vector{String}) = (s.rt_index_paths[] = paths)

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -776,13 +776,13 @@ Add feature columns to PSMs for scoring and analysis.
 - Intensity metrics
 - Spectrum characteristics
 """
-function add_features!(psms::DataFrame, 
+function add_features!(psms::DataFrame,
                         search_context::SearchContext,
                                     tic::AbstractVector{Float32},
                                     masses::AbstractArray,
                                     ms_file_idx::Integer,
                                     rt_to_irt_interp::RtConversionModel,
-                                    prec_id_to_irt::Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_irt::Float32, mean_irt::Union{Missing, Float32}, var_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32}}
+                                    prec_id_to_irt::Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_irt::Float32, mean_irt::Union{Missing, Float32}, var_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32, passed_first_search::Bool}}
                                     )
 
     precursor_sequence = getSequence(getPrecursors(getSpecLib(search_context)))#[:sequence],
@@ -820,6 +820,7 @@ function add_features!(psms::DataFrame,
     prec_mzs = zeros(Float32, size(psms, 1));
     Mox = zeros(UInt8, N);
     TIC = zeros(Float16, N);
+    passed_first_search = falses(N);
 
     #tic = MS_TABLE[:TIC]::Arrow.Primitive{Union{Missing, Float32}, Vector{Float32}}
     precursor_idx::Vector{UInt32} = psms[!,:precursor_idx] 
@@ -866,6 +867,7 @@ function add_features!(psms::DataFrame,
                 #sequence[i] = precursor_sequence[prec_idx]
                 sequence_length[i] = length(replace(precursor_sequence[prec_idx], r"\(.*?\)" => ""))#replace.(sequence[i], "M(ox)" => "M");
                 Mox[i] = countMOX(structural_mods[prec_idx])::UInt8
+                passed_first_search[i] = prec_id_to_irt[prec_idx].passed_first_search
                 #sequence_length[i] = length(stripped_sequence[i])
                 TIC[i] = Float16(log2(tic[scan_idx[i]]))
                 adjusted_intensity_explained[i] = Float16(log2(TIC[i]) + log2_intensity_explained[i]);
@@ -888,6 +890,7 @@ function add_features!(psms::DataFrame,
     #psms[!,:sequence] = sequence
     #psms[!,:stripped_sequence] = stripped_sequence
     psms[!,:Mox] = Mox
+    psms[!,:passed_first_search] = passed_first_search
     psms[!,:sequence_length] = sequence_length
 
     psms[!,:tic] = TIC

--- a/src/utils/ML/percolatorSortOf.jl
+++ b/src/utils/ML/percolatorSortOf.jl
@@ -632,11 +632,14 @@ function get_training_data_for_iteration!(
 )
    
     if itr == 1
-        # Train on all precursors during first iteration. 
-        return copy(psms_train)
+        # Train only on precursors that passed the first search.
+        return copy(psms_train[psms_train.passed_first_search .== true, :])
     else
         # Do a shallow copy to avoid overwriting target/decoy labels
         psms_train_itr = copy(psms_train)
+        if !(match_between_runs && last_iter)
+            psms_train_itr = psms_train_itr[psms_train_itr.passed_first_search .== true, :]
+        end
 
         # Convert the worst-scoring targets to negatives using PEP estimate
         order = sortperm(psms_train_itr.prob, rev=true)

--- a/test/UnitTests/percolatorTrainingDataTests.jl
+++ b/test/UnitTests/percolatorTrainingDataTests.jl
@@ -1,0 +1,43 @@
+# Copyright (C) 2024 Nathan Wamsley
+#
+# This file is part of Pioneer.jl
+#
+# Pioneer.jl is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using Test
+using DataFrames
+using Pioneer: get_training_data_for_iteration!
+
+@testset "training data filtering" begin
+    psms = DataFrame(
+        prob = Float32[0.9, 0.8, 0.7, 0.6],
+        target = Bool[true, false, true, false],
+        q_value = zeros(Float32, 4),
+        MBR_is_best_decoy = falses(4),
+        MBR_max_pair_prob = Float32[0.9, 0.9, 0.9, 0.9],
+        MBR_is_missing = falses(4),
+        passed_first_search = Bool[true, true, false, false]
+    )
+
+    iter1 = get_training_data_for_iteration!(psms, 1, true, 0.01f0, 0.2f0, 0.9f0, false)
+    @test all(iter1.passed_first_search)
+    @test nrow(iter1) == 2
+
+    iter2 = get_training_data_for_iteration!(psms, 2, true, 0.01f0, 0.2f0, 0.9f0, false)
+    @test all(iter2.passed_first_search)
+    @test nrow(iter2) == 2
+
+    iter3 = get_training_data_for_iteration!(psms, 3, true, 0.01f0, 0.2f0, 0.9f0, true)
+    @test nrow(iter3) == 4
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -158,6 +158,7 @@ end
     include("./UnitTests/FastaDigestTests.jl")
     include("./UnitTests/FastaEntryConstructorsTests.jl")
     include("./UnitTests/BuildPionLibTest.jl")
+    include("./UnitTests/percolatorTrainingDataTests.jl")
     # include("./utils/FileOperations/test_file_operations_suite.jl")  # File doesn't exist
     include("./UnitTests/RazoQuadModel.jl")
     


### PR DESCRIPTION
## Summary
- track whether precursors passed the initial search or were added as MBR pairs
- exclude paired additions from early ML training iterations
- test training data filtering for MBR iterations

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c574ed13588325890e6b35593a2abe