### PR TITLE
feat: track paired precursors for training and export CV probabilities

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -496,6 +496,7 @@ function summarize_results!(
     map_retention_times!(search_context, results, params)
     # Process precursors
     precursor_dict = get_best_precursors_accross_runs!(search_context, results, params)
+    passing_precursors = Set{UInt32}(keys(precursor_dict))
 
     if params.match_between_runs==true
         #######
@@ -532,6 +533,7 @@ function summarize_results!(
     end
 
     setPrecursorDict!(search_context, precursor_dict)
+    setFirstPassPrecursors!(search_context, passing_precursors)
     # Calculate RT indices
     create_rt_indices!(search_context, results, precursor_dict, params)
     

--- a/src/Routines/SearchDIA/SearchMethods/SearchTypes.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SearchTypes.jl
@@ -222,6 +222,7 @@ mutable struct SearchContext{N,L<:SpectralLibrary,M<:MassSpecDataReference}
     irt_rt_map::Dict{Int64, RtConversionModel}
     rt_irt_map::Dict{Int64, RtConversionModel}
     precursor_dict::Base.Ref{Dictionary}
+    first_pass_precursors::Base.Ref{Set{UInt32}}
     rt_index_paths::Base.Ref{Vector{String}}
     irt_errors::Dict{Int64, Float32}
     irt_obs::Dict{UInt32, Float32}
@@ -259,9 +260,10 @@ mutable struct SearchContext{N,L<:SpectralLibrary,M<:MassSpecDataReference}
             Dict{Int64, MassErrorModel}(),
             Dict{Int64, MassErrorModel}(),
             Dict{Int64, NceModel}(), Ref(100000.0f0), 10.0f0,
-            Dict{Int64, RtConversionModel}(), 
-            Dict{Int64, RtConversionModel}(), 
-            Ref{Dictionary}(), 
+            Dict{Int64, RtConversionModel}(),
+            Dict{Int64, RtConversionModel}(),
+            Ref{Dictionary}(),
+            Ref(Set{UInt32}()),
             Ref{Vector{String}}(),
             Dict{Int64, Float32}(),
             Dict{UInt32, Float32}(),
@@ -393,6 +395,7 @@ getParsedFileName(s::SearchContext, ms_file_idx::Int64) = getParsedFileName(s.ma
 getIrtRtMap(s::SearchContext) = s.irt_rt_map
 getRtIrtMap(s::SearchContext) = s.rt_irt_map
 getPrecursorDict(s::SearchContext) = s.precursor_dict[]
+getFirstPassPrecursors(s::SearchContext) = s.first_pass_precursors[]
 getRtIndexPaths(s::SearchContext) = s.rt_index_paths[]
 getIrtErrors(s::SearchContext) = s.irt_errors
 getPredIrt(s::SearchContext) = s.irt_obs
@@ -499,6 +502,7 @@ end
 function setPrecursorDict!(s::SearchContext, dict::Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_irt::Float32, mean_irt::Union{Missing, Float32}, var_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32}})
     s.precursor_dict[] = dict
 end
+setFirstPassPrecursors!(s::SearchContext, ids::Set{UInt32}) = (s.first_pass_precursors[] = ids)
 setRtIndexPaths!(s::SearchContext, paths::Vector{String}) = (s.rt_index_paths[] = paths)
 setHuberDelta!(s::SearchContext, delta::Float32) = (s.huber_delta[] = delta)
 function setIrtErrors!(s::SearchContext, errs::Dictionary{Int64, Float32})

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -822,7 +822,9 @@ function add_features!(psms::DataFrame,
     TIC = zeros(Float16, N);
 
     #tic = MS_TABLE[:TIC]::Arrow.Primitive{Union{Missing, Float32}, Vector{Float32}}
-    precursor_idx::Vector{UInt32} = psms[!,:precursor_idx] 
+    precursor_idx::Vector{UInt32} = psms[!,:precursor_idx]
+    first_pass_set = getFirstPassPrecursors(search_context)
+    psms[!, :MBR_is_paired] = .!in.(precursor_idx, Ref(first_pass_set))
     scan_idx::Vector{UInt32} = psms[!,:scan_idx]
     #masses = MS_TABLE[:mz_array]::Arrow.List{Union{Missing, SubArray{Union{Missing, Float32}, 1, Arrow.Primitive{Union{Missing, Float32}, Vector{Float32}}, Tuple{UnitRange{Int64}}, true}}, Int64, Arrow.Primitive{Union{Missing, Float32}, Vector{Float32}}}
     #longest_y::Vector{UInt8} = psms[!,:longest_y]

--- a/src/utils/ML/percolatorSortOf.jl
+++ b/src/utils/ML/percolatorSortOf.jl
@@ -53,8 +53,10 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
     prob_test   = zeros(Float32, nrow(psms))  # final CV predictions
     prob_train  = zeros(Float32, nrow(psms))  # temporary, used during training
     MBR_estimates = zeros(Float32, nrow(psms)) # optional MBR layer
-    prob_iter2 = zeros(Float32, nrow(psms))
-    prob_iter3 = zeros(Float32, nrow(psms))
+    prob_iter2_train = zeros(Float32, nrow(psms))
+    prob_iter2_test  = zeros(Float32, nrow(psms))
+    prob_iter3_train = zeros(Float32, nrow(psms))
+    prob_iter3_test  = zeros(Float32, nrow(psms))
 
     unique_cv_folds = unique(psms[!, :cv_fold])
     models = Dict{UInt8, Vector{EvoTrees.EvoTree}}()
@@ -140,11 +142,11 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
             psms_test[!,:prob] = prob_test[test_idx]
 
             if itr == 2
-                prob_iter2[train_idx] = prob_train[train_idx]
-                prob_iter2[test_idx] = prob_test[test_idx]
+                prob_iter2_train[train_idx] = prob_train[train_idx]
+                prob_iter2_test[test_idx] = prob_test[test_idx]
             elseif itr == 3
-                prob_iter3[train_idx] = prob_train[train_idx]
-                prob_iter3[test_idx] = prob_test[test_idx]
+                prob_iter3_train[train_idx] = prob_train[train_idx]
+                prob_iter3_test[test_idx] = prob_test[test_idx]
             end
 
             if match_between_runs
@@ -187,7 +189,8 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
     end
 
     if debug_cv_dir !== nothing
-        write_cv_debug_files(psms, prob_iter2, prob_iter3,
+        write_cv_debug_files(psms, prob_iter2_train, prob_iter2_test,
+                             prob_iter3_train, prob_iter3_test,
                              fold_indices, train_indices, debug_cv_dir)
     end
 
@@ -195,8 +198,10 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
 end
 
 function write_cv_debug_files(psms::DataFrame,
-                              prob_iter2::AbstractVector,
-                              prob_iter3::AbstractVector,
+                              prob_iter2_train::AbstractVector,
+                              prob_iter2_test::AbstractVector,
+                              prob_iter3_train::AbstractVector,
+                              prob_iter3_test::AbstractVector,
                               fold_indices::Dict{UInt8, Vector{Int}},
                               train_indices::Dict{UInt8, Vector{Int}},
                               out_dir::AbstractString)
@@ -231,8 +236,8 @@ function write_cv_debug_files(psms::DataFrame,
             :run => psms.run[train_idx],
             :charge => psms.charge[train_idx],
             :target => psms.target[train_idx],
-            :prob_2nd_iteration => prob_iter2[train_idx],
-            :prob_3rd_iteration => prob_iter3[train_idx],
+            :prob_2nd_iteration => prob_iter2_train[train_idx],
+            :prob_3rd_iteration => prob_iter3_train[train_idx],
             :MBR_candidate => psms.MBR_transfer_candidate[train_idx],
         )
         if seq_col !== nothing
@@ -250,8 +255,8 @@ function write_cv_debug_files(psms::DataFrame,
             :run => psms.run[test_idx],
             :charge => psms.charge[test_idx],
             :target => psms.target[test_idx],
-            :prob_2nd_iteration => prob_iter2[test_idx],
-            :prob_3rd_iteration => prob_iter3[test_idx],
+            :prob_2nd_iteration => prob_iter2_test[test_idx],
+            :prob_3rd_iteration => prob_iter3_test[test_idx],
             :MBR_candidate => psms.MBR_transfer_candidate[test_idx],
         )
         if seq_col !== nothing

--- a/src/utils/ML/percolatorSortOf.jl
+++ b/src/utils/ML/percolatorSortOf.jl
@@ -30,7 +30,8 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
                   iter_scheme::Vector{Int} = [100, 200, 200],
                   print_importance::Bool = false,
                   show_progress::Bool = true,
-                  verbose_logging::Bool = false)
+                  verbose_logging::Bool = false,
+                  debug_cv_dir::Union{Nothing, AbstractString} = nothing)
 
     
     #Faster if sorted first
@@ -52,6 +53,8 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
     prob_test   = zeros(Float32, nrow(psms))  # final CV predictions
     prob_train  = zeros(Float32, nrow(psms))  # temporary, used during training
     MBR_estimates = zeros(Float32, nrow(psms)) # optional MBR layer
+    prob_iter2 = zeros(Float32, nrow(psms))
+    prob_iter3 = zeros(Float32, nrow(psms))
 
     unique_cv_folds = unique(psms[!, :cv_fold])
     models = Dict{UInt8, Vector{EvoTrees.EvoTree}}()
@@ -136,6 +139,14 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
             prob_test[test_idx] = predict(bst, psms_test)
             psms_test[!,:prob] = prob_test[test_idx]
 
+            if itr == 2
+                prob_iter2[train_idx] = prob_train[train_idx]
+                prob_iter2[test_idx] = prob_test[test_idx]
+            elseif itr == 3
+                prob_iter3[train_idx] = prob_train[train_idx]
+                prob_iter3[test_idx] = prob_test[test_idx]
+            end
+
             if match_between_runs
                 update_mbr_features!(psms_train, psms_test, prob_test,
                                      test_idx, itr, mbr_start_iter,
@@ -174,14 +185,58 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
     else
         psms[!, :prob] = prob_test
     end
-    
+
+    if debug_cv_dir !== nothing
+        write_cv_debug_files(psms, prob_iter2, prob_iter3,
+                             fold_indices, train_indices, debug_cv_dir)
+    end
+
     return models
 end
 
-function sort_of_percolator_out_of_memory!(psms::DataFrame, 
+function write_cv_debug_files(psms::DataFrame,
+                              prob_iter2::AbstractVector,
+                              prob_iter3::AbstractVector,
+                              fold_indices::Dict{UInt8, Vector{Int}},
+                              train_indices::Dict{UInt8, Vector{Int}},
+                              out_dir::AbstractString)
+    isdir(out_dir) || mkpath(out_dir)
+    for (fold, test_idx) in pairs(fold_indices)
+        train_idx = train_indices[fold]
+        train_df = DataFrame(
+            train_or_test = fill("train", length(train_idx)),
+            precursor_id = psms.precursor_idx[train_idx],
+            sequence = psms.sequence[train_idx],
+            mods = psms.mods[train_idx],
+            run = psms.run[train_idx],
+            charge = psms.charge[train_idx],
+            target = psms.target[train_idx],
+            prob_2nd_iteration = prob_iter2[train_idx],
+            prob_3rd_iteration = prob_iter3[train_idx],
+            MBR_candidate = psms.MBR_transfer_candidate[train_idx],
+        )
+        CSV.write(joinpath(out_dir, "cv_fold_$(fold)_train.tsv"), train_df; delim='\t')
+
+        test_df = DataFrame(
+            train_or_test = fill("test", length(test_idx)),
+            precursor_id = psms.precursor_idx[test_idx],
+            sequence = psms.sequence[test_idx],
+            mods = psms.mods[test_idx],
+            run = psms.run[test_idx],
+            charge = psms.charge[test_idx],
+            target = psms.target[test_idx],
+            prob_2nd_iteration = prob_iter2[test_idx],
+            prob_3rd_iteration = prob_iter3[test_idx],
+            MBR_candidate = psms.MBR_transfer_candidate[test_idx],
+        )
+        CSV.write(joinpath(out_dir, "cv_fold_$(fold)_test.tsv"), test_df; delim='\t')
+    end
+end
+
+function sort_of_percolator_out_of_memory!(psms::DataFrame,
                     file_paths::Vector{String},
                     features::Vector{Symbol},
-                    match_between_runs::Bool = true; 
+                    match_between_runs::Bool = true;
                     max_q_value_xgboost_rescore::Float32 = 0.01f0,
                     max_q_value_xgboost_mbr_rescore::Float32 = 0.20f0,
                     min_PEP_neg_threshold_xgboost_rescore::Float32 = 0.90f0,
@@ -630,13 +685,19 @@ function get_training_data_for_iteration!(
     min_PEP_neg_threshold_xgboost_rescore::Float32,
     last_iter::Bool
 )
-   
+
+    psms_train_filtered = if match_between_runs && !last_iter && hasproperty(psms_train, :MBR_is_paired)
+        psms_train[.!psms_train.MBR_is_paired, :]
+    else
+        psms_train
+    end
+
     if itr == 1
-        # Train on all precursors during first iteration. 
-        return copy(psms_train)
+        # Train on all precursors during first iteration.
+        return copy(psms_train_filtered)
     else
         # Do a shallow copy to avoid overwriting target/decoy labels
-        psms_train_itr = copy(psms_train)
+        psms_train_itr = copy(psms_train_filtered)
 
         # Convert the worst-scoring targets to negatives using PEP estimate
         order = sortperm(psms_train_itr.prob, rev=true)

--- a/src/utils/ML/percolatorSortOf.jl
+++ b/src/utils/ML/percolatorSortOf.jl
@@ -201,34 +201,66 @@ function write_cv_debug_files(psms::DataFrame,
                               train_indices::Dict{UInt8, Vector{Int}},
                               out_dir::AbstractString)
     isdir(out_dir) || mkpath(out_dir)
+    seq_col = if hasproperty(psms, :sequence)
+        :sequence
+    elseif hasproperty(psms, :modified_sequence)
+        :modified_sequence
+    elseif hasproperty(psms, :peptide)
+        :peptide
+    else
+        nothing
+    end
+
+    mods_data = if hasproperty(psms, :mods)
+        psms.mods
+    elseif hasproperty(psms, :structural_mods) && hasproperty(psms, :isotopic_mods)
+        string.(coalesce.(psms.structural_mods, ""), coalesce.(psms.isotopic_mods, ""))
+    elseif hasproperty(psms, :structural_mods)
+        psms.structural_mods
+    elseif hasproperty(psms, :isotopic_mods)
+        psms.isotopic_mods
+    else
+        nothing
+    end
+
     for (fold, test_idx) in pairs(fold_indices)
         train_idx = train_indices[fold]
-        train_df = DataFrame(
-            train_or_test = fill("train", length(train_idx)),
-            precursor_id = psms.precursor_idx[train_idx],
-            sequence = psms.sequence[train_idx],
-            mods = psms.mods[train_idx],
-            run = psms.run[train_idx],
-            charge = psms.charge[train_idx],
-            target = psms.target[train_idx],
-            prob_2nd_iteration = prob_iter2[train_idx],
-            prob_3rd_iteration = prob_iter3[train_idx],
-            MBR_candidate = psms.MBR_transfer_candidate[train_idx],
+        train_cols = Dict(
+            :train_or_test => fill("train", length(train_idx)),
+            :precursor_id => psms.precursor_idx[train_idx],
+            :run => psms.run[train_idx],
+            :charge => psms.charge[train_idx],
+            :target => psms.target[train_idx],
+            :prob_2nd_iteration => prob_iter2[train_idx],
+            :prob_3rd_iteration => prob_iter3[train_idx],
+            :MBR_candidate => psms.MBR_transfer_candidate[train_idx],
         )
+        if seq_col !== nothing
+            train_cols[:sequence] = psms[train_idx, seq_col]
+        end
+        if mods_data !== nothing
+            train_cols[:mods] = mods_data[train_idx]
+        end
+        train_df = DataFrame(train_cols)
         CSV.write(joinpath(out_dir, "cv_fold_$(fold)_train.tsv"), train_df; delim='\t')
 
-        test_df = DataFrame(
-            train_or_test = fill("test", length(test_idx)),
-            precursor_id = psms.precursor_idx[test_idx],
-            sequence = psms.sequence[test_idx],
-            mods = psms.mods[test_idx],
-            run = psms.run[test_idx],
-            charge = psms.charge[test_idx],
-            target = psms.target[test_idx],
-            prob_2nd_iteration = prob_iter2[test_idx],
-            prob_3rd_iteration = prob_iter3[test_idx],
-            MBR_candidate = psms.MBR_transfer_candidate[test_idx],
+        test_cols = Dict(
+            :train_or_test => fill("test", length(test_idx)),
+            :precursor_id => psms.precursor_idx[test_idx],
+            :run => psms.run[test_idx],
+            :charge => psms.charge[test_idx],
+            :target => psms.target[test_idx],
+            :prob_2nd_iteration => prob_iter2[test_idx],
+            :prob_3rd_iteration => prob_iter3[test_idx],
+            :MBR_candidate => psms.MBR_transfer_candidate[test_idx],
         )
+        if seq_col !== nothing
+            test_cols[:sequence] = psms[test_idx, seq_col]
+        end
+        if mods_data !== nothing
+            test_cols[:mods] = mods_data[test_idx]
+        end
+        test_df = DataFrame(test_cols)
         CSV.write(joinpath(out_dir, "cv_fold_$(fold)_test.tsv"), test_df; delim='\t')
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -171,5 +171,6 @@ end
     include("./utils/FileOperations/io/test_arrow_operations_basic.jl")
     include("./utils/FileOperations/core/test_core_references_basic.jl")
     include("./utils/FileOperations/streaming/test_stream_sorted_merge_basic.jl")
-    
+    include("./utils/test_percolator_sort_of.jl")
+
 end

--- a/test/utils/test_percolator_sort_of.jl
+++ b/test/utils/test_percolator_sort_of.jl
@@ -25,7 +25,12 @@ using Pioneer: get_training_data_for_iteration!, write_cv_debug_files
 end
 
 @testset "write cv fold debug files" begin
-    psms = DataFrame(
+    prob2 = Float32[0.1, 0.2]
+    prob3 = Float32[0.3, 0.4]
+    fold_indices = Dict(UInt8(1) => [1], UInt8(2) => [2])
+    train_indices = Dict(UInt8(1) => [2], UInt8(2) => [1])
+
+    psms1 = DataFrame(
         precursor_idx = UInt32[1, 2],
         sequence = ["PEPTIDE", "PEPTIDER"],
         mods = ["", ""],
@@ -34,19 +39,26 @@ end
         target = Bool[true, false],
         MBR_transfer_candidate = Bool[false, true],
     )
-    prob2 = Float32[0.1, 0.2]
-    prob3 = Float32[0.3, 0.4]
-    fold_indices = Dict(UInt8(1) => [1], UInt8(2) => [2])
-    train_indices = Dict(UInt8(1) => [2], UInt8(2) => [1])
     mktempdir() do dir
-        write_cv_debug_files(psms, prob2, prob3, fold_indices, train_indices, dir)
-        train_path = joinpath(dir, "cv_fold_1_train.tsv")
-        test_path = joinpath(dir, "cv_fold_1_test.tsv")
-        @test isfile(train_path)
-        @test isfile(test_path)
-        train_df = DataFrame(CSV.File(train_path; delim='\t'))
-        test_df = DataFrame(CSV.File(test_path; delim='\t'))
-        @test :target in names(train_df)
-        @test :target in names(test_df)
+        write_cv_debug_files(psms1, prob2, prob3, fold_indices, train_indices, dir)
+        df = DataFrame(CSV.File(joinpath(dir, "cv_fold_1_train.tsv"); delim='\t'))
+        @test :sequence in names(df)
+        @test :mods in names(df)
+    end
+
+    psms2 = DataFrame(
+        precursor_idx = UInt32[1, 2],
+        structural_mods = ["", "(Oxidation[M])"],
+        isotopic_mods = ["", ""],
+        run = ["run1", "run2"],
+        charge = [2, 3],
+        target = Bool[true, false],
+        MBR_transfer_candidate = Bool[false, true],
+    )
+    mktempdir() do dir
+        write_cv_debug_files(psms2, prob2, prob3, fold_indices, train_indices, dir)
+        df = DataFrame(CSV.File(joinpath(dir, "cv_fold_1_train.tsv"); delim='\t'))
+        @test :sequence ∉ names(df)
+        @test :mods in names(df)
     end
 end

--- a/test/utils/test_percolator_sort_of.jl
+++ b/test/utils/test_percolator_sort_of.jl
@@ -1,0 +1,52 @@
+using Test
+using DataFrames
+using CSV
+using Pioneer: get_training_data_for_iteration!, write_cv_debug_files
+
+@testset "filter paired precursors" begin
+    psms = DataFrame(
+        prob = Float32[0.9, 0.8, 0.1],
+        target = Bool[true, true, false],
+        q_value = Float32[0.0, 0.0, 1.0],
+        MBR_is_best_decoy = Bool[false, false, false],
+        MBR_max_pair_prob = Float32[0.9, 0.8, 0.1],
+        MBR_is_missing = Bool[false, false, false],
+        MBR_is_paired = Bool[false, true, false]
+    )
+
+    res1 = get_training_data_for_iteration!(psms, 1, true, 1.0f0, 0.2f0, 2.0f0, false)
+    @test nrow(res1) == 2
+
+    res2 = get_training_data_for_iteration!(psms, 2, true, 1.0f0, 0.2f0, 2.0f0, false)
+    @test nrow(res2) == 2
+
+    res_last = get_training_data_for_iteration!(psms, 2, true, 1.0f0, 0.2f0, 2.0f0, true)
+    @test nrow(res_last) == 3
+end
+
+@testset "write cv fold debug files" begin
+    psms = DataFrame(
+        precursor_idx = UInt32[1, 2],
+        sequence = ["PEPTIDE", "PEPTIDER"],
+        mods = ["", ""],
+        run = ["run1", "run2"],
+        charge = [2, 3],
+        target = Bool[true, false],
+        MBR_transfer_candidate = Bool[false, true],
+    )
+    prob2 = Float32[0.1, 0.2]
+    prob3 = Float32[0.3, 0.4]
+    fold_indices = Dict(UInt8(1) => [1], UInt8(2) => [2])
+    train_indices = Dict(UInt8(1) => [2], UInt8(2) => [1])
+    mktempdir() do dir
+        write_cv_debug_files(psms, prob2, prob3, fold_indices, train_indices, dir)
+        train_path = joinpath(dir, "cv_fold_1_train.tsv")
+        test_path = joinpath(dir, "cv_fold_1_test.tsv")
+        @test isfile(train_path)
+        @test isfile(test_path)
+        train_df = DataFrame(CSV.File(train_path; delim='\t'))
+        test_df = DataFrame(CSV.File(test_path; delim='\t'))
+        @test :target in names(train_df)
+        @test :target in names(test_df)
+    end
+end

--- a/test/utils/test_percolator_sort_of.jl
+++ b/test/utils/test_percolator_sort_of.jl
@@ -25,8 +25,10 @@ using Pioneer: get_training_data_for_iteration!, write_cv_debug_files
 end
 
 @testset "write cv fold debug files" begin
-    prob2 = Float32[0.1, 0.2]
-    prob3 = Float32[0.3, 0.4]
+    prob2_train = Float32[0.1, 0.2]
+    prob2_test = Float32[0.3, 0.4]
+    prob3_train = Float32[0.5, 0.6]
+    prob3_test = Float32[0.7, 0.8]
     fold_indices = Dict(UInt8(1) => [1], UInt8(2) => [2])
     train_indices = Dict(UInt8(1) => [2], UInt8(2) => [1])
 
@@ -40,10 +42,16 @@ end
         MBR_transfer_candidate = Bool[false, true],
     )
     mktempdir() do dir
-        write_cv_debug_files(psms1, prob2, prob3, fold_indices, train_indices, dir)
-        df = DataFrame(CSV.File(joinpath(dir, "cv_fold_1_train.tsv"); delim='\t'))
-        @test :sequence in names(df)
-        @test :mods in names(df)
+        write_cv_debug_files(psms1, prob2_train, prob2_test,
+                             prob3_train, prob3_test,
+                             fold_indices, train_indices, dir)
+        df_train = DataFrame(CSV.File(joinpath(dir, "cv_fold_1_train.tsv"); delim='\t'))
+        df_test = DataFrame(CSV.File(joinpath(dir, "cv_fold_1_test.tsv"); delim='\t'))
+        @test :sequence in names(df_train)
+        @test :mods in names(df_train)
+        @test df_train.prob_2nd_iteration[1] == prob2_train[2]
+        @test df_test.prob_2nd_iteration[1] == prob2_test[1]
+        @test df_train.prob_2nd_iteration[1] != df_test.prob_2nd_iteration[1]
     end
 
     psms2 = DataFrame(
@@ -56,7 +64,9 @@ end
         MBR_transfer_candidate = Bool[false, true],
     )
     mktempdir() do dir
-        write_cv_debug_files(psms2, prob2, prob3, fold_indices, train_indices, dir)
+        write_cv_debug_files(psms2, prob2_train, prob2_test,
+                             prob3_train, prob3_test,
+                             fold_indices, train_indices, dir)
         df = DataFrame(CSV.File(joinpath(dir, "cv_fold_1_train.tsv"); delim='\t'))
         @test :sequence ∉ names(df)
         @test :mods in names(df)


### PR DESCRIPTION
## Summary
- track precursors passing first search before MBR pairing
- label paired precursors and skip them in early training iterations
- add test for filtering paired precursors
- export CV fold train/test TSVs with iteration probabilities, target flags, and MBR candidate markers

## Testing
- `julia --project -e 'using Pkg; Pkg.instantiate()'` *(fails: command not found: julia)*
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: command not found: julia)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fd2af1f4832585c2206477bcb1cc