### PR TITLE
Add predicted signal overlap features

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
@@ -77,6 +77,7 @@ const ADVANCED_FEATURE_SET = [
     :tic,
     :num_scans,
     :smoothness,
+    :predicted_signal_overlap,
     :rt_diff,
     :ms1_irt_diff,
     :weight_ms1,
@@ -108,7 +109,7 @@ const REDUCED_FEATURE_SET = [
     :max_matched_residual, :max_unmatched_residual, :max_gof,
     :fitted_spectral_contrast, :spectral_contrast, :max_matched_ratio,
     :err_norm, :poisson, :weight, :log2_intensity_explained, :tic, :num_scans,
-    :smoothness, :percent_theoretical_ignored, :scribe, :max_scribe,
+    :smoothness, :predicted_signal_overlap, :percent_theoretical_ignored, :scribe, :max_scribe,
     # MS1 features
     :weight_ms1, :gof_ms1, :max_matched_residual_ms1, :max_unmatched_residual_ms1,
     :fitted_spectral_contrast_ms1, :error_ms1, :m0_error_ms1, :n_iso_ms1,

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/score_psms.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/score_psms.jl
@@ -327,11 +327,12 @@ function train_xgboost_model_in_memory(
     features = [f for f in model_config.features if hasproperty(best_psms, f)]
     if match_between_runs
         append!(features, [
-            :MBR_num_runs, 
+            :MBR_num_runs,
             :MBR_max_pair_prob,
-            :MBR_log2_weight_ratio, 
+            :MBR_log2_weight_ratio,
             :MBR_log2_explained_ratio,
-            :MBR_rv_coefficient, 
+            :MBR_log2_predicted_signal_overlap_ratio,
+            :MBR_rv_coefficient,
             :MBR_best_irt_diff,
             :MBR_is_missing
         ])
@@ -672,6 +673,7 @@ function score_precursor_isotope_traces_out_of_memory!(
             :MBR_max_pair_prob,
             :MBR_log2_weight_ratio,
             :MBR_log2_explained_ratio,
+            :MBR_log2_predicted_signal_overlap_ratio,
             :MBR_is_missing
             ])
     end

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/SecondPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/SecondPassSearch.jl
@@ -330,6 +330,8 @@ function process_search_results!(
         filter!(row -> row.precursor_fraction_transmitted >= params.min_fraction_transmitted, psms)
         #filter!(row -> first(row.isotopes_captured) > 2, psms)
 
+        compute_signal_overlap_fraction!(psms)
+
         # Initialize columns for best scan selection and summary statistics
         psms[!,:best_scan] = zeros(Bool, size(psms, 1));
         init_summary_columns!(psms);

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -931,6 +931,7 @@ function init_summary_columns!(
         (:max_matched_ratio,        Float16)
         (:num_scans,        UInt16)
         (:smoothness,        Float32)
+        (:predicted_signal_overlap, Float32)
         (:weights,        Vector{Float32})
         (:irts,         Vector{Float32})
         ];
@@ -947,6 +948,25 @@ function init_summary_columns!(
             end
         end
         return psms
+end
+
+function compute_signal_overlap_fraction!(psms::DataFrame)
+    if nrow(psms) == 0
+        return psms
+    end
+
+    grouped = groupby(psms, :scan_idx)
+    transform!(grouped, :weight => ((w) -> begin
+        total = sum(w)
+        if total <= 0f0
+            fill(0f0, length(w))
+        else
+            overlap = (total .- w) ./ total
+            Float32.(clamp.(overlap, 0f0, 1f0))
+        end
+    end) => :signal_overlap_fraction)
+
+    return psms
 end
 
 """
@@ -1023,19 +1043,29 @@ function get_summary_scores!(
     
     @inbounds @fastmath for i in range(1, length(weight))
         if length(weight) == 1
-            smoothness = (-2*weight[i] / weight[apex_scan])^2
+            smoothness = (-2 * weight[i] / weight[apex_scan])^2
         else
             if (i == 1)
-                smoothness += (((weight[i+1] - weight[i]) / (psms.rt[i+1] - psms.rt[i]) + (-weight[i]) / (psms.rt[i+1] - psms.rt[i])) / weight[apex_scan]) ^2
+                smoothness += (((weight[i+1] - weight[i]) / (psms.rt[i+1] - psms.rt[i]) + (-weight[i]) / (psms.rt[i+1] - psms.rt[i])) / weight[apex_scan])^2
             elseif (i > 1) & (i < length(weight))
-                smoothness += (((weight[i-1] - weight[i]) / (psms.rt[i] - psms.rt[i-1]) + (weight[i+1]-weight[i]) / (psms.rt[i+1] - psms.rt[i])) / weight[apex_scan]) ^2
+                smoothness += (((weight[i-1] - weight[i]) / (psms.rt[i] - psms.rt[i-1]) + (weight[i+1] - weight[i]) / (psms.rt[i+1] - psms.rt[i])) / weight[apex_scan])^2
             elseif (i == length(weight))
-                smoothness += (((weight[i-1] - weight[i]) / (psms.rt[i] - psms.rt[i-1]) + (-weight[i]) / (psms.rt[i] - psms.rt[i-1])) / weight[apex_scan]) ^2
+                smoothness += (((weight[i-1] - weight[i]) / (psms.rt[i] - psms.rt[i-1]) + (-weight[i]) / (psms.rt[i] - psms.rt[i-1])) / weight[apex_scan])^2
             end
         end
     end
 
-   
+    overlaps = psms[!, :signal_overlap_fraction]
+    total_signal = 0.0f0
+    overlapped_signal = 0.0f0
+    @inbounds @fastmath for i in range(1, length(weight))
+        w = weight[i]
+        total_signal += w
+        overlapped_signal += w * overlaps[i]
+    end
+
+    predicted_overlap = total_signal > 0f0 ? overlapped_signal / total_signal : 0f0
+    predicted_overlap = clamp(Float32(predicted_overlap), 0f0, 1f0)
 
     psms.max_gof[apex_scan] = max_gof
     psms.max_matched_ratio[apex_scan] = max_matched_ratio
@@ -1047,6 +1077,7 @@ function get_summary_scores!(
     psms.max_y_ions[apex_scan] = max_y_ions
     psms.num_scans[apex_scan] = length(weight)
     psms.smoothness[apex_scan] = smoothness
+    psms.predicted_signal_overlap[apex_scan] = predicted_overlap
     psms.weights[apex_scan] = weight
     psms.irts[apex_scan] = irts
     psms.best_scan[apex_scan] = true

--- a/src/utils/ML/percolatorSortOf.jl
+++ b/src/utils/ML/percolatorSortOf.jl
@@ -582,6 +582,7 @@ function summarize_precursors!(psms::AbstractDataFrame; q_cutoff::Float32 = 0.01
                 sub_psms.MBR_is_best_decoy[i]           = true
                 sub_psms.MBR_log2_weight_ratio[i]       = -1.0f0
                 sub_psms.MBR_log2_explained_ratio[i]    = -1.0f0
+                sub_psms.MBR_log2_predicted_signal_overlap_ratio[i] = -1.0f0
                 sub_psms.MBR_max_pair_prob[i]           = -1.0f0
                 sub_psms.MBR_is_missing[i]              = true
                 continue
@@ -598,6 +599,10 @@ function summarize_precursors!(psms::AbstractDataFrame; q_cutoff::Float32 = 0.01
             sub_psms.MBR_rv_coefficient[i] = MBR_rv_coefficient(best_log2_weights_padded, best_iRTs_padded, weights_padded, iRTs_padded)
             sub_psms.MBR_log2_weight_ratio[i] = log2(sub_psms.weight[i] / sub_psms.weight[best_idx])
             sub_psms.MBR_log2_explained_ratio[i] = sub_psms.log2_intensity_explained[i] - sub_psms.log2_intensity_explained[best_idx]
+            best_overlap = sub_psms.predicted_signal_overlap[best_idx]
+            current_overlap = sub_psms.predicted_signal_overlap[i]
+            ratio = (best_overlap + 1f-6) / (current_overlap + 1f-6)
+            sub_psms.MBR_log2_predicted_signal_overlap_ratio[i] = log2(ratio)
             sub_psms.MBR_is_best_decoy[i] = sub_psms.decoy[best_idx]
         end
     end
@@ -617,6 +622,7 @@ function initialize_prob_group_features!(
         psms[!, :MBR_best_irt_diff]             = zeros(Float32, n)
         psms[!, :MBR_log2_weight_ratio]         = zeros(Float32, n)
         psms[!, :MBR_log2_explained_ratio]      = zeros(Float32, n)
+        psms[!, :MBR_log2_predicted_signal_overlap_ratio] = zeros(Float32, n)
         psms[!, :MBR_rv_coefficient]            = zeros(Float32, n)
         psms[!, :MBR_is_best_decoy]             = trues(n)
         psms[!, :MBR_num_runs]                  = zeros(Int32, n)


### PR DESCRIPTION
## Summary
- calculate per-scan signal-overlap fractions and summarize them as a `predicted_signal_overlap` feature on precursor traces
- expose the new feature to XGBoost/probit scoring and derive a matching MBR log2 ratio for cross-run transfers

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: unable to download StatsFuns.jl because proxy returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c9885ea0fc83259ea389733300896d