### PR TITLE
feat: add sequence permutation scoring features

### DIFF
--- a/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
+++ b/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
@@ -15,6 +15,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+using SpecialFunctions: loggamma
+
+const MAX_FLOAT32 = floatmax(Float32)
+const LOG_MAX_FLOAT32 = log(Float64(MAX_FLOAT32))
+const ASCII_A = Int('A')
+const ALPHABET_LENGTH = 26
+
 abstract type ScoredPSM{H,L<:AbstractFloat} <: PSM end
 
 
@@ -78,11 +85,12 @@ struct ComplexScoredPSM{H,L<:AbstractFloat} <: ScoredPSM{H,L}
     max_matched_residual::L
     max_unmatched_residual::L 
     fitted_manhattan_distance::L 
-    matched_ratio::L 
+    matched_ratio::L
     percent_theoretical_ignored::L
     scribe::L
     #entropy_score::L
     weight::H
+    sequence_permutation_count::Float32
 
     #Non-scores/Labels
     precursor_idx::UInt32
@@ -115,6 +123,117 @@ struct Ms1ScoredPSM{H,L<:AbstractFloat} <: ScoredPSM{H,L}
     precursor_idx::UInt32
     ms_file_idx::UInt32
     scan_idx::UInt32
+end
+
+@inline function collect_cleavage_positions(mask::NTuple{4, UInt64}, seq_length::Int, orientation::Symbol)
+    positions = Int[]
+    for (block_idx, block) in enumerate(mask)
+        value = block
+        base_offset = (block_idx - 1) * 64
+        while value != 0
+            tz = trailing_zeros(value)
+            frag_index = base_offset + tz + 1
+            cleavage = orientation === :b ? frag_index : seq_length - frag_index
+            if 1 <= cleavage < seq_length
+                push!(positions, cleavage)
+            end
+            value &= value - 1
+        end
+    end
+    return positions
+end
+
+@inline function log_segment_permutations(seq::AbstractString, start_idx::Int, end_idx::Int)
+    segment_length = end_idx - start_idx + 1
+    if segment_length <= 1
+        return 0.0
+    end
+
+    counts = zeros(Int, ALPHABET_LENGTH)
+    extra_counts = nothing
+
+    for idx in start_idx:end_idx
+        aa = seq[idx]
+        alpha_idx = Int(aa) - ASCII_A + 1
+        if 1 <= alpha_idx <= ALPHABET_LENGTH
+            counts[alpha_idx] += 1
+        else
+            if extra_counts === nothing
+                extra_counts = Dict{Char, Int}()
+            end
+            extra_counts[aa] = get(extra_counts, aa, 0) + 1
+        end
+    end
+
+    log_perm = loggamma(segment_length + 1)
+    for count in counts
+        if count > 1
+            log_perm -= loggamma(count + 1)
+        end
+    end
+
+    if extra_counts !== nothing
+        for count in values(extra_counts)
+            if count > 1
+                log_perm -= loggamma(count + 1)
+            end
+        end
+    end
+
+    return log_perm
+end
+
+@inline function log_to_float32(log_perm::Float64)
+    if log_perm <= 0
+        return Float32(1)
+    elseif log_perm > LOG_MAX_FLOAT32
+        return Float32(MAX_FLOAT32)
+    else
+        return Float32(exp(log_perm))
+    end
+end
+
+@inline function collect_cleavages(
+    b_mask::NTuple{4, UInt64},
+    y_mask::NTuple{4, UInt64},
+    seq_length::Int,
+)
+    cleavages = collect_cleavage_positions(b_mask, seq_length, :b)
+    append!(cleavages, collect_cleavage_positions(y_mask, seq_length, :y))
+    if !isempty(cleavages)
+        sort!(cleavages)
+        unique!(cleavages)
+    end
+    return cleavages
+end
+
+function sequence_permutation_count(
+    b_mask::NTuple{4, UInt64},
+    y_mask::NTuple{4, UInt64},
+    sequence::AbstractString,
+)
+    seq_length = length(sequence)
+    if seq_length <= 1
+        return Float32(1)
+    end
+
+    cleavages = collect_cleavages(b_mask, y_mask, seq_length)
+    log_perm_total = 0.0
+    prev = 0
+
+    for cleavage in cleavages
+        if cleavage <= prev || cleavage >= seq_length
+            continue
+        end
+        log_perm_total += log_segment_permutations(sequence, prev + 1, cleavage)
+        prev = cleavage
+    end
+
+    if prev < seq_length
+        log_perm_total += log_segment_permutations(sequence, prev + 1, seq_length)
+    end
+
+    return log_to_float32(log_perm_total)
 end
 
 function growScoredPSMs!(scored_psms::Vector{SimpleScoredPSM{H,L}}, block_size::Int64) where {L,H<:AbstractFloat}
@@ -214,17 +333,18 @@ function Score!(scored_psms::Vector{SimpleScoredPSM{H, L}},
     return last_val
 end
 
-function Score!(scored_psms::Vector{ComplexScoredPSM{H, L}}, 
-                unscored_PSMs::Vector{ComplexUnscoredPSM{H}}, 
+function Score!(scored_psms::Vector{ComplexScoredPSM{H, L}},
+                unscored_PSMs::Vector{ComplexUnscoredPSM{H}},
                 spectral_scores::Vector{SpectralScoresComplex{L}},
-                weight::Vector{H}, 
+                weight::Vector{H},
                 IDtoCOL::ArrayDict{UInt32, UInt16},
                 cycle_idx::Int64,
                 expected_matches::Float64,
                 last_val::Int64,
                 n_vals::Int64,
                 spectrum_intensity::H,
-                scan_idx::Int64;
+                scan_idx::Int64,
+                precursor_sequences::AbstractVector{<:AbstractString};
                 min_spectral_contrast::H = 0f0,
                 min_log2_matched_ratio::H = -1f0,
                 min_y_count::Int64,
@@ -286,6 +406,12 @@ function Score!(scored_psms::Vector{ComplexScoredPSM{H, L}},
 
         precursor_idx = UInt32(unscored_PSMs[i].precursor_idx)
         scores_idx = IDtoCOL[precursor_idx]
+        sequence = precursor_sequences[Int(precursor_idx)]
+        seq_perm = sequence_permutation_count(
+            unscored_PSMs[i].b_series_mask,
+            unscored_PSMs[i].y_series_mask,
+            sequence,
+        )
         scored_psms[start_idx + i - skipped] = ComplexScoredPSM(
             unscored_PSMs[i].best_rank,
             unscored_PSMs[i].best_rank_iso,
@@ -314,9 +440,10 @@ function Score!(scored_psms::Vector{ComplexScoredPSM{H, L}},
             spectral_scores[scores_idx].scribe,
             #spectral_scores[scores_idx].entropy_score,
             weight[scores_idx],
+            seq_perm,
 
-            
-            UInt32(unscored_PSMs[i].precursor_idx),
+
+            precursor_idx,
             #UInt32(unscored_PSMs[i].ms_file_idx),
             UInt32(cycle_idx),
             UInt32(scan_idx)

--- a/src/Routines/SearchDIA/PSMs/UnscoredPSMs.jl
+++ b/src/Routines/SearchDIA/PSMs/UnscoredPSMs.jl
@@ -36,7 +36,7 @@ SimpleUnscoredPSM{Float32}() = SimpleUnscoredPSM(UInt8(255), zero(UInt8), zero(U
 struct ComplexUnscoredPSM{T<:AbstractFloat} <: UnscoredPSM{T}
     best_rank::UInt8 #Highest ranking predicted framgent that was observed
     best_rank_iso::UInt8
-    topn::UInt8 #How many of the topN predicted fragments were observed. 
+    topn::UInt8 #How many of the topN predicted fragments were observed.
     topn_iso::UInt8
     longest_y::UInt8
     longest_b::UInt8
@@ -50,9 +50,32 @@ struct ComplexUnscoredPSM{T<:AbstractFloat} <: UnscoredPSM{T}
     error::T
     precursor_idx::UInt32
     ms_file_idx::UInt32
+    b_series_mask::NTuple{4, UInt64}
+    y_series_mask::NTuple{4, UInt64}
 end
 
-ComplexUnscoredPSM{Float32}() = ComplexUnscoredPSM(UInt8(255), UInt8(255), zero(UInt8), zero(UInt8), zero(UInt8), zero(UInt8), zero(UInt8), zero(UInt8), Float32(0), zero(UInt8), Float32(0), zero(UInt8), zero(UInt8), Float32(0), UInt32(0), UInt32(0))
+const EMPTY_CLEAVAGE_MASK = (UInt64(0), UInt64(0), UInt64(0), UInt64(0))
+
+ComplexUnscoredPSM{Float32}() = ComplexUnscoredPSM(
+    UInt8(255),
+    UInt8(255),
+    zero(UInt8),
+    zero(UInt8),
+    zero(UInt8),
+    zero(UInt8),
+    zero(UInt8),
+    zero(UInt8),
+    Float32(0),
+    zero(UInt8),
+    Float32(0),
+    zero(UInt8),
+    zero(UInt8),
+    Float32(0),
+    UInt32(0),
+    UInt32(0),
+    EMPTY_CLEAVAGE_MASK,
+    EMPTY_CLEAVAGE_MASK,
+)
 
 struct Ms1UnscoredPSM{T<:AbstractFloat} <: UnscoredPSM{T}
     m0::Bool #Highest ranking predicted framgent that was observed
@@ -138,8 +161,17 @@ function ModifyFeatures!(score::SimpleUnscoredPSM{T}, prec_id::UInt32, match::Fr
     )
 end
 
+@inline function set_cleavage_mask(mask::NTuple{4, UInt64}, index::UInt8)
+    index == 0 && return mask
+    idx = Int(index)
+    block = (idx - 1) ÷ 64 + 1
+    block > 4 && return mask
+    bit = UInt64(1) << ((idx - 1) % 64)
+    return Base.setindex(mask, mask[block] | bit, block)
+end
+
 function ModifyFeatures!(score::ComplexUnscoredPSM{T},  prec_id::UInt32, match::FragmentMatch{T}, errdist::MassErrorModel, m_rank::Int64) where {T<:Real}
-    
+
     best_rank = score.best_rank
     best_rank_iso = score.best_rank_iso
     topn = score.topn
@@ -155,6 +187,8 @@ function ModifyFeatures!(score::ComplexUnscoredPSM{T},  prec_id::UInt32, match::
     non_cannonical_count = score.non_cannonical_count
     error = score.error
     precursor_idx = prec_id
+    b_series_mask = score.b_series_mask
+    y_series_mask = score.y_series_mask
 
     if isIsotope(match)
         isotope_count += 1
@@ -179,12 +213,14 @@ function ModifyFeatures!(score::ComplexUnscoredPSM{T},  prec_id::UInt32, match::
             if getFragInd(match) > longest_b
                 longest_b = getFragInd(match)
             end
+            b_series_mask = set_cleavage_mask(b_series_mask, getFragInd(match))
         elseif getIonType(match) == UInt8(2)
             y_count += 1
             y_int +=  getIntensity(match)
             if getFragInd(match) > longest_y
                 longest_y = getFragInd(match)
             end
+            y_series_mask = set_cleavage_mask(y_series_mask, getFragInd(match))
         elseif getIonType(match) == UInt8(3)
             p_count += 1
         else
@@ -213,7 +249,10 @@ function ModifyFeatures!(score::ComplexUnscoredPSM{T},  prec_id::UInt32, match::
         non_cannonical_count,
         error,
         precursor_idx,
-        score.ms_file_idx)
+        score.ms_file_idx,
+        b_series_mask,
+        y_series_mask,
+    )
 end
 
 function ModifyFeatures!(score::Ms1UnscoredPSM{T},  prec_id::UInt32, match::PrecursorMatch{T}, errdist::MassErrorModel, m_rank::Int64) where {T<:Real}

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
@@ -46,6 +46,8 @@ const ADVANCED_FEATURE_SET = [
     :Mox,
     :prec_mz,
     :sequence_length,
+    :sequence_permutation_count,
+    :min_sequence_permutation_count,
     :charge,
     :irt_pred,
     :irt_error,
@@ -98,6 +100,7 @@ const ADVANCED_FEATURE_SET = [
 const REDUCED_FEATURE_SET = [
     # Core peptide properties
     :missed_cleavage, :Mox, :prec_mz, :sequence_length, :charge,
+    :sequence_permutation_count, :min_sequence_permutation_count,
     # RT features
     :irt_pred, :irt_error, :irt_diff, :rt_diff, :ms1_irt_diff,
     # Spectral features

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -18,6 +18,13 @@
 #==========================================================
 Core Search Funtions
 ==========================================================#
+
+const MODIFICATION_PATTERN = r"\(.*?\)"
+
+@inline function strip_modifications(sequence::AbstractString)
+    return replace(String(sequence), MODIFICATION_PATTERN => "")
+end
+
 """
     perform_second_pass_search(spectra::MassSpecData, rt_index::retentionTimeIndex,
                              search_context::SearchContext, params::SecondPassSearchParameters,
@@ -136,6 +143,10 @@ function process_scans!(
     weights = getTempWeights(search_data)
     precursor_weights = getPrecursorWeights(search_data)
     residuals = getResiduals(search_data)
+    precursor_sequences = map(
+        strip_modifications,
+        getSequence(getPrecursors(getSpecLib(search_context))),
+    )
     last_val = 0
     
 
@@ -275,7 +286,8 @@ function process_scans!(
             last_val,
             Hs.n,
             Float32(sum(getIntensityArray(spectra, scan_idx))),
-            scan_idx;
+            scan_idx,
+            precursor_sequences;
             min_spectral_contrast = params.min_spectral_contrast,
             min_log2_matched_ratio = params.min_log2_matched_ratio,
             min_y_count = params.min_y_count,
@@ -931,6 +943,7 @@ function init_summary_columns!(
         (:max_matched_ratio,        Float16)
         (:num_scans,        UInt16)
         (:smoothness,        Float32)
+        (:min_sequence_permutation_count, Float32)
         (:weights,        Vector{Float32})
         (:irts,         Vector{Float32})
         ];
@@ -980,6 +993,7 @@ function get_summary_scores!(
     y_ions_sum = 0
     max_y_ions = 0
     smoothness = 0.0f0
+    min_sequence_permutation = minimum(psms.sequence_permutation_count)
 
     apex_scan = argmax(psms[!,:weight])
     #Need to make sure there is not a big gap. 
@@ -1047,6 +1061,7 @@ function get_summary_scores!(
     psms.max_y_ions[apex_scan] = max_y_ions
     psms.num_scans[apex_scan] = length(weight)
     psms.smoothness[apex_scan] = smoothness
+    psms.min_sequence_permutation_count[apex_scan] = min_sequence_permutation
     psms.weights[apex_scan] = weight
     psms.irts[apex_scan] = irts
     psms.best_scan[apex_scan] = true


### PR DESCRIPTION
## Summary
- track observed fragment cleavages in ComplexUnscoredPSM and compute per-spectrum permutation counts
- add sequence permutation metrics to second-pass summaries and include them in XGBoost feature sets

## Testing
- julia --project -e 'using Pkg; Pkg.test()' *(fails: GitError(Code:ERROR, Class:HTTP, proxy returned unexpected status: 403))*

------
https://chatgpt.com/codex/tasks/task_e_68c9a358d7fc8325b45d4523ae7cdd21