### PR TITLE
feat: skip low-transmission precursors during deconvolution

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/IntegrateChromatogramsSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/IntegrateChromatogramsSearch.jl
@@ -240,11 +240,8 @@ function process_file!(
             getIsolationWidthMzs(spectra)
         )
 
-        # Assuming scans that isolated too little of the precursor are not reliable to quantify
-        filter!(row -> row.precursor_fraction_transmitted >= params.min_fraction_transmitted, chromatograms)
-        
         # Integrate chromatographic peaks for each precursor
-        # Updates peak_area and new_best_scan in passing_psms   
+        # Updates peak_area and new_best_scan in passing_psms
         integrate_precursors(
             chromatograms,
             params.isotope_tracetype,

--- a/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/utils.jl
@@ -284,7 +284,8 @@ function build_chromatograms(
                 (getLowMz(spectra, scan_idx), getHighMz(spectra, scan_idx));
                 precursors_passing = precursors_passing,
                 isotope_err_bounds = params.isotope_err_bounds,
-                block_size = 10000
+                block_size = 10000,
+                min_fraction_transmitted = params.min_fraction_transmitted
             )
         end
 

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -195,7 +195,8 @@ function process_scans!(
                 irt_start,
                 irt_stop,
                 (getLowMz(spectra, scan_idx), getHighMz(spectra, scan_idx));
-                block_size = 10000
+                block_size = 10000,
+                min_fraction_transmitted = params.min_fraction_transmitted
             )
         end
 


### PR DESCRIPTION
## Summary
- filter RT-indexed transition selection so low-transmission precursors are dropped before deconvolution
- reuse precomputed precursor transmission data when populating transition lists to support the new filtering
- remove the redundant chromatogram-level filter that no longer screens any rows

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: `julia` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d157ca68908325a1483c149cf82b0d