### PR TITLE
feat: skip low-transmission precursors during deconvolution

### DIFF
--- a/src/Routines/SearchDIA/CommonSearchUtils/selectTransitions/standardTransitionSelection.jl
+++ b/src/Routines/SearchDIA/CommonSearchUtils/selectTransitions/standardTransitionSelection.jl
@@ -37,31 +37,52 @@ function _select_transitions_impl!(
     iRT_tol::Float32,
     frag_mz_bounds::Tuple{Float32, Float32};
     isotope_err_bounds::Tuple{I, I} = (3, 1),
-    block_size::Int64 = 10000
-    ) where {I<:Integer}
+    block_size::Int64 = 10000,
+    min_fraction_transmitted::Float32 = 0.0f0,
+) where {I<:Integer}
+
+    mz_low_offset = Float32(NEUTRON * first(isotope_err_bounds))
+    mz_high_offset = Float32(NEUTRON * last(isotope_err_bounds))
+    processed_precursors = 0
 
     for i in scan_to_prec_idx
         # Get precursor properties
         prec_idx = precursors_passed_scoring[i]
         prec_charge = prec_charges[prec_idx]
         prec_mz = prec_mzs[prec_idx]
-        
+
         # Check retention time tolerance
         if abs(prec_irts[prec_idx] - iRT) > iRT_tol
             continue
         end
-        
+
         # Handle isotope errors
-        mz_low = getPrecMinBound(quad_transmission_func) - NEUTRON*first(isotope_err_bounds)/prec_charge
-        mz_high = getPrecMaxBound(quad_transmission_func) + NEUTRON*last(isotope_err_bounds)/prec_charge
-        
+        mz_low = getPrecMinBound(quad_transmission_func) - mz_low_offset / prec_charge
+        mz_high = getPrecMaxBound(quad_transmission_func) + mz_high_offset / prec_charge
+
         if (prec_mz < mz_low) | (prec_mz > mz_high)
             continue
         end
-        
+
         prec_sulfur_count = prec_sulfur_counts[prec_idx]
-        # Fill transition list using spline-specific implementation
-        transition_idx = @inline fillTransitionList!(
+        prec_isotope_set = getPrecursorIsotopeSet(prec_mz, prec_charge, quad_transmission_func)
+        last(prec_isotope_set) < 0 && continue
+
+        fraction_transmitted = getPrecursorFractionTransmitted!(
+            precursor_transmission,
+            iso_splines,
+            prec_isotope_set,
+            quad_transmission_func,
+            prec_mz,
+            prec_charge,
+            prec_sulfur_count,
+        )
+
+        fraction_transmitted < min_fraction_transmitted && continue
+
+        processed_precursors += 1
+
+        transition_idx = @inline fillTransitionListPrecomputed!(
             transitions,
             prec_estimation_type,
             getPrecFragRange(lookup, prec_idx),
@@ -71,16 +92,16 @@ function _select_transitions_impl!(
             prec_charge,
             prec_sulfur_count,
             transition_idx,
-            quad_transmission_func,
             precursor_transmission,
+            prec_isotope_set,
             isotopes,
             n_frag_isotopes,
             max_frag_rank,
             iso_splines,
             frag_mz_bounds,
-            block_size
+            block_size,
         )
     end
-    
-    return transition_idx, 0
+
+    return transition_idx, processed_precursors
 end

--- a/src/Routines/SearchDIA/LibrarySearch.jl
+++ b/src/Routines/SearchDIA/LibrarySearch.jl
@@ -152,12 +152,12 @@ function getPSMS(
 
         # Ion Template Selection
         ion_idx, _ = selectTransitions!(
-            getIonTemplates(search_data), 
-            StandardTransitionSelection(), 
+            getIonTemplates(search_data),
+            StandardTransitionSelection(),
             getPrecEstimation(params),
             ion_list,
             scan_to_prec_idx[scan_idx], precursors_passed_scoring,
-            getMz(precursors), 
+            getMz(precursors),
             getCharge(precursors),
             getSulfurCount(precursors),
             getIrt(precursors),
@@ -166,9 +166,10 @@ function getPSMS(
             precursor_transmission, isotopes, getNFragIsotopes(params),
             getMaxFragRank(params),
             Float32(rt_to_irt_spline(getRetentionTime(spectra, scan_idx))),
-            Float32(irt_tol), 
+            Float32(irt_tol),
             (getLowMz(spectra, scan_idx), getHighMz(spectra, scan_idx));
-            isotope_err_bounds = getIsotopeErrBounds(params)
+            isotope_err_bounds = getIsotopeErrBounds(params),
+            min_fraction_transmitted = getMinFractionTransmitted(params),
         )
 
         ion_idx < 2 && continue

--- a/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/IntegrateChromatogramsSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/IntegrateChromatogramsSearch.jl
@@ -240,11 +240,8 @@ function process_file!(
             getIsolationWidthMzs(spectra)
         )
 
-        # Assuming scans that isolated too little of the precursor are not reliable to quantify
-        filter!(row -> row.precursor_fraction_transmitted >= params.min_fraction_transmitted, chromatograms)
-        
         # Integrate chromatographic peaks for each precursor
-        # Updates peak_area and new_best_scan in passing_psms   
+        # Updates peak_area and new_best_scan in passing_psms
         integrate_precursors(
             chromatograms,
             params.isotope_tracetype,

--- a/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/utils.jl
@@ -284,7 +284,8 @@ function build_chromatograms(
                 (getLowMz(spectra, scan_idx), getHighMz(spectra, scan_idx));
                 precursors_passing = precursors_passing,
                 isotope_err_bounds = params.isotope_err_bounds,
-                block_size = 10000
+                block_size = 10000,
+                min_fraction_transmitted = params.min_fraction_transmitted
             )
         end
 

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -195,7 +195,8 @@ function process_scans!(
                 irt_start,
                 irt_stop,
                 (getLowMz(spectra, scan_idx), getHighMz(spectra, scan_idx));
-                block_size = 10000
+                block_size = 10000,
+                min_fraction_transmitted = params.min_fraction_transmitted
             )
         end
 


### PR DESCRIPTION
## Summary
- filter RT-indexed transition selection so low-transmission precursors are dropped before deconvolution
- reuse precomputed precursor transmission data when populating transition lists to support the new filtering
- remove the redundant chromatogram-level filter that no longer screens any rows
- rework the standard (first-pass) transition selector to share the transmission gating and precomputed helper

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: `julia` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d157ca68908325a1483c149cf82b0d