### PR TITLE
Use fit! when training EvoTrees boosters

### DIFF
--- a/src/Pioneer.jl
+++ b/src/Pioneer.jl
@@ -39,7 +39,7 @@ using StatsPlots, SentinelArrays
 using Random
 using StaticArrays, StatsBase, SpecialFunctions, Statistics, SparseArrays
 using EvoTrees
-using MLJModelInterface: fit, predict
+using MLJModelInterface: fit, fit!, predict
 using KernelDensity
 using FastGaussQuadrature
 using LaTeXStrings, Printf

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
@@ -368,9 +368,16 @@ function train_xgboost_model_df(feature_data::DataFrame, y::AbstractVector{Bool}
     )
 
     # Train model directly with DataFrame (no Matrix conversion)
-    model = EvoTrees.fit(config, training_df; target_name=:target)
-
-    return model
+    kwargs = (; target_name = :target)
+    try
+        return EvoTrees.fit!(config, training_df; kwargs...)
+    catch e
+        if e isa MethodError
+            return EvoTrees.fit(config, training_df; kwargs...)
+        else
+            rethrow()
+        end
+    end
 end
 
 #==========================================================

--- a/src/utils/ML/percolatorSortOf.jl
+++ b/src/utils/ML/percolatorSortOf.jl
@@ -640,8 +640,18 @@ function train_booster(psms::AbstractDataFrame, features, num_round;
         eta = eta,
         gamma = gamma
     )
-    model = fit(config, psms; target_name = :target, feature_names = features, verbosity = 0)
-    return model
+
+    fit_kwargs = (; target_name = :target, feature_names = features, verbosity = 0)
+
+    try
+        return fit!(config, psms; fit_kwargs...)
+    catch e
+        if e isa MethodError
+            return fit(config, psms; fit_kwargs...)
+        else
+            rethrow()
+        end
+    end
 end
 
 function predict_fold!(bst, psms_train::AbstractDataFrame,


### PR DESCRIPTION
## Summary
- import `fit!` from MLJModelInterface so the Pioneer module can call it directly
- update EvoTrees booster training helpers to try `fit!` before falling back to the non-mutating `fit`
- apply the same strategy in the ScoringSearch DataFrame training path to avoid manual dataset creation

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: `julia` executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1e4e2c10c8325bac1cd42d40adb7a