### PR TITLE
feat: enforce pair-wise precursor competition

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
@@ -402,7 +402,11 @@ function summarize_results!(
                 filter_by_multiple_thresholds([
                     (:global_qval, params.q_value_threshold),
                     (:qval, params.q_value_threshold)
-                ])
+                ]) |>
+                keep_best_by_group([
+                    :ms_file_idx,
+                    :pair_id
+                ], :prec_prob; desc="keep_best_precursor_per_pair")
                 
             
             passing_refs = apply_pipeline_batch(

--- a/src/utils/FileOperations/pipeline/PipelineOperations.jl
+++ b/src/utils/FileOperations/pipeline/PipelineOperations.jl
@@ -111,6 +111,96 @@ function filter_rows(predicate::Function; desc::String="filter")
 end
 
 """
+    keep_best_by_group(group_cols::Vector{Symbol}, score_col::Symbol;
+                       prefer_target::Bool = true, desc::String = "keep_best_by_group")
+
+Retain only the highest-scoring row within each group defined by `group_cols`.
+
+* `group_cols` – Columns used to define grouping (e.g., `[:ms_file_idx, :pair_id]`).
+* `score_col`  – Column containing the score used for comparison (e.g., `:prec_prob`).
+* `prefer_target` – When `true`, ties are broken by preferring rows with `target == true`.
+
+Groups that are missing the specified columns or have `missing` `pair_id` values are
+left unchanged to avoid discarding unpaired precursors.
+"""
+function keep_best_by_group(
+    group_cols::Vector{Symbol},
+    score_col::Symbol;
+    prefer_target::Bool = true,
+    desc::String = "keep_best_by_group"
+)
+    op = function(df)
+        n_rows = nrow(df)
+        if n_rows == 0
+            return df
+        end
+
+        # Ensure all required columns exist
+        available_cols = propertynames(df)
+        if !(score_col in available_cols) || any(col -> col ∉ available_cols, group_cols)
+            return df
+        end
+
+        keep_mask = falses(n_rows)
+        grouped = groupby(df, group_cols, sort=false)
+        target_available = prefer_target && (:target in available_cols)
+        pair_id_in_groups = :pair_id in group_cols
+
+        for subdf in grouped
+            rows = parentindices(subdf)[1]
+            isempty(rows) && continue
+
+            # Preserve all rows when pair_id is missing
+            if pair_id_in_groups && ismissing(df[rows[1], :pair_id])
+                keep_mask[rows] .= true
+                continue
+            end
+
+            best_row = rows[1]
+            best_score = -Inf
+            best_target = -1
+            found_valid_score = false
+
+            for row_idx in rows
+                score_val = df[row_idx, score_col]
+                if ismissing(score_val)
+                    continue
+                end
+
+                found_valid_score = true
+                score = Float64(score_val)
+                target_rank = if target_available
+                    val = df[row_idx, :target]
+                    (val === missing || val == false) ? 0 : 1
+                else
+                    0
+                end
+
+                if (score > best_score) || (score == best_score && target_rank > best_target)
+                    best_score = score
+                    best_target = target_rank
+                    best_row = row_idx
+                end
+            end
+
+            if !found_valid_score
+                # When all scores are missing, keep the first row to avoid dropping data
+                keep_mask[rows[1]] = true
+            else
+                keep_mask[best_row] = true
+            end
+        end
+
+        df_filtered = df[keep_mask, :]
+        empty!(df)
+        append!(df, df_filtered)
+        return df
+    end
+
+    return desc => op
+end
+
+"""
     sort_by(cols::Vector{Symbol}; rev::Vector{Bool}=fill(false, length(cols)))
 
 Sort DataFrame by specified columns. Includes post-action to update FileReference sort state.

--- a/test/Routines/SearchDIA/SearchMethods/ScoringSearch/test_scoring_interface.jl
+++ b/test/Routines/SearchDIA/SearchMethods/ScoringSearch/test_scoring_interface.jl
@@ -279,7 +279,50 @@ using Pioneer: ProbitRegression, ModelPredict!
         result_lightgbm = train_and_evaluate(lightgbm_method, df_no_cv, labels_no_cv, params)
         @test result_lightgbm === nothing
     end
-    
+
+    @testset "Target-Decoy Pair Competition" begin
+        df = DataFrame(
+            ms_file_idx = Int64[1, 1, 1, 1, 2, 2, 3, 3],
+            pair_id = Union{Missing, UInt32}[
+                UInt32(1), UInt32(1), UInt32(1), UInt32(2),
+                missing, missing, UInt32(4), UInt32(4)
+            ],
+            prec_prob = Union{Missing, Float32}[
+                0.75f0, 0.90f0, 0.90f0, 0.40f0,
+                0.70f0, 0.60f0, missing, missing
+            ],
+            target = Union{Missing, Bool}[
+                true, false, true, false,
+                true, false, true, false
+            ]
+        )
+
+        desc, operation = keep_best_by_group([
+            :ms_file_idx,
+            :pair_id
+        ], :prec_prob)
+
+        @test desc == "keep_best_by_group"
+
+        result_df = copy(df)
+        operation(result_df)
+
+        pair_one_rows = result_df[(result_df.ms_file_idx .== 1) .& (result_df.pair_id .== UInt32(1)), :]
+        @test nrow(pair_one_rows) == 1
+        @test pair_one_rows[1, :target] === true
+        @test pair_one_rows[1, :prec_prob] ≈ 0.90f0
+
+        pair_two_rows = result_df[(result_df.ms_file_idx .== 1) .& (result_df.pair_id .== UInt32(2)), :]
+        @test nrow(pair_two_rows) == 1
+
+        missing_pairs = result_df[ismissing.(result_df.pair_id), :]
+        @test nrow(missing_pairs) == 2
+
+        pair_four_rows = result_df[(result_df.ms_file_idx .== 3) .& (result_df.pair_id .== UInt32(4)), :]
+        @test nrow(pair_four_rows) == 1
+        @test pair_four_rows[1, :target] === true
+    end
+
     @testset "Integration Test Components" begin
         # Test individual components work together
         n_samples = 20

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,7 +54,7 @@ using Pioneer: get_proteome, get_sequence, get_structural_mods  # For FastaDiges
 using Pioneer: get_isotopic_mods, get_description, get_id  # For FastaDigestTests.jl
 using Pioneer: get_entrapment_pair_id  # For FastaDigestTests.jl
 using Pioneer: get_gene, get_protein, get_organism  # For FastaEntryConstructorsTests.jl
-using Pioneer: filter_by_threshold, filter_by_multiple_thresholds  # For file operations tests
+using Pioneer: filter_by_threshold, filter_by_multiple_thresholds, keep_best_by_group  # For file operations tests
 using Pioneer: getDetailedFrags, getSeqSet, getSimpleFrags, getMZ  # For BuildPionLibTest.jl
 using Pioneer: getIRT, getPrecCharge, getPrecID, getPrecMZ, getScore  # For BuildPionLibTest.jl
 using Pioneer: is_decoy, SplineDetailedFrag  # For FastaDigestTests.jl and BuildPionLibTest.jl


### PR DESCRIPTION
## Summary
- add a reusable pipeline operation to keep the best scoring row in each target/decoy pair
- apply the new operation during ScoringSearch precursor filtering to enforce pair-wise competition
- cover the behaviour with unit tests for the scoring interface utilities

## Testing
- julia --project -e 'using Pkg; Pkg.test(; test_args=["Routines/SearchDIA/SearchMethods/ScoringSearch/test_scoring_interface.jl"])' *(fails: julia executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68daf0459824832598cf36c82ea1e524