### PR TITLE
Add signing identity checks to macOS workflow

### DIFF
--- a/.github/workflows/build_app_macos.yml
+++ b/.github/workflows/build_app_macos.yml
@@ -203,6 +203,18 @@ jobs:
         run: |
           set -o pipefail
 
+          if [[ -z "${CODESIGN_IDENTITY}" ]]; then
+            echo "Error: CODESIGN_IDENTITY is not set or empty."
+            exit 1
+          fi
+
+          if [[ -z "${PKG_SIGN_IDENTITY}" ]]; then
+            echo "Error: PKG_SIGN_IDENTITY is not set or empty."
+            exit 1
+          fi
+
+          security find-identity -v -p installer || true
+
           # Helper function: retry codesign with exponential backoff
           codesign_with_retry() {
             local target="$1"


### PR DESCRIPTION
## Summary
- ensure the macOS packaging step fails early when required signing identities are missing
- log available installer identities to aid diagnosing certificate issues

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e81fd4c2d0832599b84fc3f3a4ae3b