### PR TITLE
Scale FTR counts by target/decoy coverage

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
@@ -36,6 +36,34 @@ struct FilterResult
     n_passing::Int
 end
 
+function compute_ftr_scale_factor(df::AbstractDataFrame)
+    if !hasproperty(df, :precursor_idx)
+        return 1.0
+    end
+
+    target_mask = hasproperty(df, :target) ? coalesce.(df.target, false) : falses(nrow(df))
+    decoy_mask = if hasproperty(df, :decoy)
+        coalesce.(df.decoy, false)
+    else
+        .!target_mask
+    end
+
+    precursor_idx_col = df.precursor_idx
+    valid_target_mask = target_mask .& .!ismissing.(precursor_idx_col)
+    valid_decoy_mask = decoy_mask .& .!ismissing.(precursor_idx_col)
+
+    unique_target_count = length(unique(precursor_idx_col[valid_target_mask]))
+    unique_decoy_count = length(unique(precursor_idx_col[valid_decoy_mask]))
+
+    if unique_decoy_count == 0
+        return 1.0
+    end
+
+    scale = unique_target_count / unique_decoy_count
+    @debug "Computed FTR scale factor" scale unique_target_count unique_decoy_count
+    return scale
+end
+
 #==========================================================
 Main MBR Filtering Interface
 ==========================================================#
@@ -84,6 +112,7 @@ function apply_mbr_filter!(
     # Extract candidate data once
     candidate_data = merged_df[candidate_mask, :]
     candidate_labels = is_bad_transfer[candidate_mask]
+    ftr_scale_factor = compute_ftr_scale_factor(merged_df)
 
     n_candidates = length(candidate_labels)
     
@@ -98,7 +127,7 @@ function apply_mbr_filter!(
     results = FilterResult[]
     
     for method in methods
-        result = train_and_evaluate(method, candidate_data, candidate_labels, params)
+        result = train_and_evaluate(method, candidate_data, candidate_labels, params, ftr_scale_factor)
         if result !== nothing
             push!(results, result)
         end
@@ -125,7 +154,7 @@ function apply_mbr_filter!(
         # Use is_bad_transfer as numerator flag; denominator counts all candidates at threshold
         candidate_qvals = Vector{Float32}(undef, length(scores))
         # get_ftr! expects placeholders for targets; it accumulates total candidates internally
-        get_ftr!(scores, trues(length(scores)), candidate_labels, candidate_qvals)
+        get_ftr!(scores, trues(length(scores)), candidate_labels, candidate_qvals; scale_factor=ftr_scale_factor)
 
         # Map back to full dataframe rows (only when candidates exist)
         full_qvals = Vector{Union{Missing, Float32}}(missing, nrow(merged_df))
@@ -154,7 +183,7 @@ Method-Specific Training and Evaluation
 
 Train a filtering method and evaluate performance. Returns FilterResult with scores and threshold.
 """
-function train_and_evaluate(method::ThresholdFilter, candidate_data::DataFrame, candidate_labels::AbstractVector{Bool}, params)
+function train_and_evaluate(method::ThresholdFilter, candidate_data::DataFrame, candidate_labels::AbstractVector{Bool}, params, ftr_scale_factor)
     # Handle empty candidate data
     if isempty(candidate_data) || !hasproperty(candidate_data, :prob)
         return nothing
@@ -164,7 +193,8 @@ function train_and_evaluate(method::ThresholdFilter, candidate_data::DataFrame, 
     τ = get_ftr_threshold(
         candidate_data.prob,
         candidate_labels,
-        params.max_MBR_false_transfer_rate
+        params.max_MBR_false_transfer_rate;
+        scale_factor=ftr_scale_factor
     )
 
     # Handle edge case where threshold is infinite (no valid threshold found)
@@ -177,7 +207,7 @@ function train_and_evaluate(method::ThresholdFilter, candidate_data::DataFrame, 
     return FilterResult("Threshold", candidate_data.prob, τ, n_passing)
 end
 
-function train_and_evaluate(method::ProbitFilter, candidate_data::DataFrame, candidate_labels::AbstractVector{Bool}, params)
+function train_and_evaluate(method::ProbitFilter, candidate_data::DataFrame, candidate_labels::AbstractVector{Bool}, params, ftr_scale_factor)
     try
         # Handle empty candidate data
         if isempty(candidate_data)
@@ -203,7 +233,7 @@ function train_and_evaluate(method::ProbitFilter, candidate_data::DataFrame, can
         scores = run_cv_training(method, feature_data, candidate_labels, candidate_data.cv_fold, params)
         
         # Calibrate threshold
-        τ = calibrate_ml_threshold(scores, candidate_labels, Float64(params.max_MBR_false_transfer_rate))
+        τ = calibrate_ml_threshold(scores, candidate_labels, Float64(params.max_MBR_false_transfer_rate), ftr_scale_factor)
         n_passing = sum(scores .>= τ)  # Higher score = better for probit
         
         
@@ -215,7 +245,7 @@ function train_and_evaluate(method::ProbitFilter, candidate_data::DataFrame, can
     end
 end
 
-function train_and_evaluate(method::LightGBMFilter, candidate_data::DataFrame, candidate_labels::AbstractVector{Bool}, params)
+function train_and_evaluate(method::LightGBMFilter, candidate_data::DataFrame, candidate_labels::AbstractVector{Bool}, params, ftr_scale_factor)
     try
         # Handle empty candidate data
         if isempty(candidate_data)
@@ -241,7 +271,7 @@ function train_and_evaluate(method::LightGBMFilter, candidate_data::DataFrame, c
         scores = run_cv_training(method, feature_data, candidate_labels, candidate_data.cv_fold, params)
 
         # Calibrate threshold
-        τ = calibrate_ml_threshold(scores, candidate_labels, Float64(params.max_MBR_false_transfer_rate))
+        τ = calibrate_ml_threshold(scores, candidate_labels, Float64(params.max_MBR_false_transfer_rate), ftr_scale_factor)
         n_passing = sum(scores .>= τ)  # Higher score = better for LightGBM
 
 
@@ -460,9 +490,9 @@ function prepare_mbr_features(df::DataFrame)
     return X, feature_names
 end
 
-function calibrate_ml_threshold(scores::AbstractVector, is_bad_transfer::AbstractVector{Bool}, target_ftr::Float64)
+function calibrate_ml_threshold(scores::AbstractVector, is_bad_transfer::AbstractVector{Bool}, target_ftr::Float64, scale_factor::Real=1.0)
     """Find score threshold that achieves target FTR."""
-    return get_ftr_threshold(scores, is_bad_transfer, target_ftr)
+    return get_ftr_threshold(scores, is_bad_transfer, target_ftr; scale_factor=scale_factor)
 end
 
 

--- a/src/utils/ML/ftrUtilities.jl
+++ b/src/utils/ML/ftrUtilities.jl
@@ -15,7 +15,7 @@ match-between-runs workflows using transfer decoys.
 Return the minimum score threshold `τ` such that
 
 ```
-FTR(τ) = (# of transfer decoys with score ≥ τ) / (# of targets with score ≥ τ)
+FTR(τ) = scale_factor × (# of transfer decoys with score ≥ τ) / (# of targets with score ≥ τ)
 ```
 
 is less than or equal to `alpha`.  The input vectors must be of equal
@@ -24,7 +24,8 @@ length and correspond element-wise to candidate precursor–run pairs.
 function get_ftr_threshold(scores::AbstractVector{U},
                            is_bad_transfer::AbstractVector{Bool},
                            alpha::Real; doSort::Bool = true,
-                           mask::Union{Nothing,AbstractVector{Bool}} = nothing) where {U<:Real}
+                           mask::Union{Nothing,AbstractVector{Bool}} = nothing,
+                           scale_factor::Real = 1) where {U<:Real}
     @assert length(scores) == length(is_bad_transfer)
 
     if mask === nothing
@@ -40,13 +41,14 @@ function get_ftr_threshold(scores::AbstractVector{U},
     end
 
     num_transfers = 0
-    num_bad_transfers = 0
+    num_bad_transfers = 0.0
+    scale = Float64(scale_factor)
     τ = maximum(scores)
     best_count = 0
     for idx in order
         num_transfers += 1
-        num_bad_transfers += is_bad_transfer[idx] ? 1 : 0
-        
+        num_bad_transfers += is_bad_transfer[idx] ? scale : 0.0
+
         if (num_transfers > 0) && ((num_bad_transfers / num_transfers) <= alpha)
             τ = scores[idx]
             best_count = num_transfers
@@ -63,14 +65,15 @@ end
              ftrs::AbstractVector{T}; doSort::Bool = true,
              mask::Union{Nothing,AbstractVector{Bool}} = nothing) where {U<:Real,T<:Real}
 
-Compute the empirical FTR curve.  `ftrs[i]` contains the FTR for the
-candidate at `scores[i]`.
+Compute the empirical FTR curve using the scaled transfer counts.
+`ftrs[i]` contains the FTR for the candidate at `scores[i]`.
 """
 function get_ftr!(scores::AbstractVector{U},
                   is_target::AbstractVector{Bool},
                   is_transfer_decoy::AbstractVector{Bool},
                   ftrs::AbstractVector{T}; doSort::Bool = true,
-                  mask::Union{Nothing,AbstractVector{Bool}} = nothing) where {U<:Real,T<:Real}
+                  mask::Union{Nothing,AbstractVector{Bool}} = nothing,
+                  scale_factor::Real = 1) where {U<:Real,T<:Real}
     @assert length(scores) == length(is_target) == length(is_transfer_decoy) == length(ftrs)
 
     if mask === nothing
@@ -81,10 +84,11 @@ function get_ftr!(scores::AbstractVector{U},
     end
 
     target_cum = 0
-    transfer_cum = 0
+    transfer_cum = 0.0
+    scale = Float64(scale_factor)
     for idx in order
         target_cum += 1  # Count ALL candidates at this threshold level
-        transfer_cum += is_transfer_decoy[idx] ? 1 : 0
+        transfer_cum += is_transfer_decoy[idx] ? scale : 0.0
         ftrs[idx] = target_cum > 0 ? (transfer_cum / target_cum) : Inf
     end
     return ftrs

--- a/src/utils/ML/percolatorSortOf.jl
+++ b/src/utils/ML/percolatorSortOf.jl
@@ -100,6 +100,8 @@ function assign_random_target_decoy_pairs!(psms::DataFrame)
     for (irt_bin_idx, sub_psms) in pairs(irt_bin_groups)
         last_pair_id = assignPairIds!(sub_psms, last_pair_id)
     end
+
+    print_pairing_summary(psms)
 end
 
 
@@ -108,6 +110,52 @@ function assignPairIds!(psms::AbstractDataFrame, last_pair_id::UInt32)
         psms.target, psms.decoy, psms.precursor_idx, psms.irt_bin_idx, last_pair_id
     )
     return last_pair_id
+end
+
+function print_pairing_summary(psms::AbstractDataFrame)
+    if nrow(psms) == 0
+        println("Pairing summary: targets=0, decoys=0, target-target pairs=0, target-decoy pairs=0, decoy-decoy pairs=0, unpaired targets=0, unpaired decoys=0")
+        println()
+        return
+    end
+
+    target_mask = coalesce.(psms.target, false)
+    decoy_mask = coalesce.(psms.decoy, false)
+    total_targets = length(unique(psms.precursor_idx[target_mask]))
+    total_decoys = length(unique(psms.precursor_idx[decoy_mask]))
+
+    pair_groups = groupby(psms, :pair_id)
+    target_target_pairs = 0
+    target_decoy_pairs = 0
+    decoy_decoy_pairs = 0
+    unpaired_targets = 0
+    unpaired_decoys = 0
+
+    for group in pair_groups
+        group_target_mask = coalesce.(collect(group.target), false)
+        group_decoy_mask = coalesce.(collect(group.decoy), false)
+
+        unique_target_precursors = unique(group.precursor_idx[group_target_mask])
+        unique_decoy_precursors = unique(group.precursor_idx[group_decoy_mask])
+
+        n_targets = length(unique_target_precursors)
+        n_decoys = length(unique_decoy_precursors)
+
+        paired = min(n_targets, n_decoys)
+        target_decoy_pairs += paired
+
+        remaining_targets = n_targets - paired
+        remaining_decoys = n_decoys - paired
+
+        target_target_pairs += remaining_targets ÷ 2
+        unpaired_targets += remaining_targets % 2
+
+        decoy_decoy_pairs += remaining_decoys ÷ 2
+        unpaired_decoys += remaining_decoys % 2
+    end
+
+    println("Pairing summary: targets=$(total_targets), decoys=$(total_decoys), target-target pairs=$(target_target_pairs), target-decoy pairs=$(target_decoy_pairs), decoy-decoy pairs=$(decoy_decoy_pairs), unpaired targets=$(unpaired_targets), unpaired decoys=$(unpaired_decoys)")
+    println()
 end
 
 function assign_pair_ids(


### PR DESCRIPTION
## Summary
- add an FTR scale-factor helper that counts unique targets and decoys at the percolator stage
- pass the scale factor into all MBR filtering paths so transfer counts are weighted consistently
- update FTR utilities to apply the scale factor when building thresholds and q-values

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eaa4e5d8248325b13e4fcbac0de1ff