### PR TITLE
Disable hot start during Huber tuning fits

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/HuberTuningSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/HuberTuningSearch/utils.jl
@@ -402,6 +402,13 @@ function process_delta_values!(
         getIdToCol(search_data)
     )
     
+    zero_weight = zero(eltype(weights))
+
+    # Reset precursor weights to avoid reusing previous solutions as hot starts
+    for i in 1:getIdToCol(search_data).size
+        precursor_weights[getIdToCol(search_data).keys[i]] = zero_weight
+    end
+
     # Process each delta value
     for δ in delta_grid
         # Resize arrays if needed
@@ -411,11 +418,11 @@ function process_delta_values!(
             resize!(getSpectralScores(search_data), length(getSpectralScores(search_data)) + new_entries)
             append!(getUnscoredPsms(search_data), [eltype(getUnscoredPsms(search_data))() for _ in 1:new_entries])
         end
-        
+
         # Initialize weights
         for i in 1:getIdToCol(search_data).size
-            weights[getIdToCol(search_data)[getIdToCol(search_data).keys[i]]] = 
-                precursor_weights[getIdToCol(search_data).keys[i]]
+            col_idx = getIdToCol(search_data)[getIdToCol(search_data).keys[i]]
+            weights[col_idx] = zero_weight
         end
         
         # Solve deconvolution problem
@@ -439,9 +446,6 @@ function process_delta_values!(
         for i in 1:getIdToCol(search_data).size
             id = getIdToCol(search_data).keys[i]
             colid = getIdToCol(search_data)[id]
-            
-            # Update precursor weights
-            precursor_weights[id] = weights[colid]
             
             # Record if this is a target PSM
             if id ∈ scan_to_prec[scan_idx]


### PR DESCRIPTION
## Summary
- reset precursor weights before evaluating the Huber delta grid so each solve starts from a neutral state
- initialize weights to zero for every delta fit to avoid reusing solutions as hot starts

## Testing
- julia --project -e 'using Pkg; Pkg.test()' *(fails: command not found: julia)*

------
https://chatgpt.com/codex/tasks/task_e_68f14c5c99308325b2cfe56a22631cef