### PR TITLE
Integrate residual boosting for MBR rescore

### DIFF
--- a/src/utils/ML/lightgbm_utils.jl
+++ b/src/utils/ML/lightgbm_utils.jl
@@ -111,7 +111,9 @@ end
 function fit_lightgbm_model(model::LightGBM.LGBMClassification,
                             feature_data::AbstractDataFrame,
                             labels::AbstractVector;
-                            positive_label = true)
+                            positive_label = true,
+                            init_score = nothing,
+                            sample_weight = nothing)
     features = Symbol.(names(feature_data))
     X = feature_matrix(feature_data, features)
     y_int = _prepare_labels(labels)
@@ -122,7 +124,19 @@ function fit_lightgbm_model(model::LightGBM.LGBMClassification,
         return LightGBMModel(nothing, features, constant_prob)
     end
 
-    LightGBM.fit!(model, X, y_int; verbosity = -1)
+    kwargs = (verbosity = -1,)
+    if init_score !== nothing
+        init_vec = Float64.(collect(init_score))
+        length(init_vec) == size(X, 1) || throw(ArgumentError("init_score length must match number of rows"))
+        kwargs = merge(kwargs, (init_score = init_vec,))
+    end
+    if sample_weight !== nothing
+        weight_vec = Float64.(collect(sample_weight))
+        length(weight_vec) == size(X, 1) || throw(ArgumentError("sample_weight length must match number of rows"))
+        kwargs = merge(kwargs, (weight = weight_vec,))
+    end
+
+    LightGBM.fit!(model, X, y_int; kwargs...)
     return LightGBMModel(model, features, nothing)
 end
 

--- a/src/utils/ML/percolatorSortOf.jl
+++ b/src/utils/ML/percolatorSortOf.jl
@@ -280,24 +280,8 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
             end
 
             init_scores = nothing
-            if match_between_runs && itr == mbr_start_iter
-                if hasproperty(psms_train_itr, :MBR_transfer_candidate)
-                    candidate_mask_itr = psms_train_itr.MBR_transfer_candidate
-                    if any(candidate_mask_itr)
-                        control_idx = findall(.!candidate_mask_itr)
-                        candidate_idx = findall(candidate_mask_itr)
-                        n_control = min(length(control_idx), length(candidate_idx))
-                        selected_controls = n_control > 0 ? begin
-                            Random.shuffle!(control_idx)
-                            control_idx[1:n_control]
-                        end : Int[]
-                        selected_idx = sort!(vcat(candidate_idx, selected_controls))
-                        psms_train_itr = psms_train_itr[selected_idx, :]
-                    end
-                end
-                if nrow(psms_train_itr) > 0
-                    init_scores = logit.(clamp!(copy(psms_train_itr.prob), PROBABILITY_EPS, 1 - PROBABILITY_EPS))
-                end
+            if match_between_runs && itr == mbr_start_iter && nrow(psms_train_itr) > 0
+                init_scores = logit.(clamp!(copy(psms_train_itr.prob), PROBABILITY_EPS, 1 - PROBABILITY_EPS))
             end
 
             bst = train_booster(psms_train_itr, train_feats, num_round;

--- a/src/utils/ML/percolatorSortOf.jl
+++ b/src/utils/ML/percolatorSortOf.jl
@@ -21,6 +21,15 @@
 
 const PAIRING_RANDOM_SEED = 1844  # Fixed seed for reproducible pairing
 const IRT_BIN_SIZE = 1000
+const PROBABILITY_EPS = eps(Float32)
+
+@inline function logit(p::Real)
+    return log(p / (one(p) - p))
+end
+
+@inline function σ(x::Real)
+    return one(x) / (one(x) + exp(-x))
+end
 
 #############################################################################
 # Running Statistics Helper Functions
@@ -201,8 +210,9 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
 
     prob_test   = zeros(Float32, nrow(psms))  # final CV predictions
     prob_train  = zeros(Float32, nrow(psms))  # temporary, used during training
-    MBR_estimates = zeros(Float32, nrow(psms)) # optional MBR layer
     nonMBR_estimates  = zeros(Float32, nrow(psms)) # keep track of last nonMBR test scores
+    logit_base = zeros(Float32, nrow(psms))
+    boost_mask = zeros(Float32, nrow(psms))
 
     unique_cv_folds = unique(psms[!, :cv_fold])
     models = Dict{UInt8, LightGBMModelVector}()
@@ -269,6 +279,27 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
                 end
             end
 
+            init_scores = nothing
+            if match_between_runs && itr == mbr_start_iter
+                if hasproperty(psms_train_itr, :MBR_transfer_candidate)
+                    candidate_mask_itr = psms_train_itr.MBR_transfer_candidate
+                    if any(candidate_mask_itr)
+                        control_idx = findall(.!candidate_mask_itr)
+                        candidate_idx = findall(candidate_mask_itr)
+                        n_control = min(length(control_idx), length(candidate_idx))
+                        selected_controls = n_control > 0 ? begin
+                            Random.shuffle!(control_idx)
+                            control_idx[1:n_control]
+                        end : Int[]
+                        selected_idx = sort!(vcat(candidate_idx, selected_controls))
+                        psms_train_itr = psms_train_itr[selected_idx, :]
+                    end
+                end
+                if nrow(psms_train_itr) > 0
+                    init_scores = logit.(clamp!(copy(psms_train_itr.prob), PROBABILITY_EPS, 1 - PROBABILITY_EPS))
+                end
+            end
+
             bst = train_booster(psms_train_itr, train_feats, num_round;
                                feature_fraction=feature_fraction,
                                learning_rate=learning_rate,
@@ -276,7 +307,8 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
                                bagging_fraction=bagging_fraction,
                                min_gain_to_split=min_gain_to_split,
                                max_depth=max_depth,
-                               num_leaves=num_leaves)
+                               num_leaves=num_leaves,
+                               init_score=init_scores)
                                
             fold_models[itr] = bst
 
@@ -298,22 +330,37 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
 
             #predict_fold!(bst, psms_train, psms_test, train_feats)
             # **temporary predictions for training only**
-            prob_train[train_idx] = predict(bst, psms_train)
-            psms_train[!,:prob] = prob_train[train_idx]
+            train_predictions = predict(bst, psms_train)
+            prob_train[train_idx] = train_predictions
+            psms_train[!,:prob] = train_predictions
             get_qvalues!(psms_train.prob, psms_train.target, psms_train.q_value)
 
             # **predict held-out fold**
-            prob_test[test_idx] = predict(bst, psms_test)
-            psms_test[!,:prob] = prob_test[test_idx]
+            test_predictions = predict(bst, psms_test)
+            prob_test[test_idx] = test_predictions
+            psms_test[!,:prob] = test_predictions
 
             if itr == (mbr_start_iter - 1)
-			    nonMBR_estimates[test_idx] = prob_test[test_idx]
+                nonMBR_estimates[test_idx] = test_predictions
+                clamped_base = clamp!(copy(test_predictions), PROBABILITY_EPS, 1 - PROBABILITY_EPS)
+                logit_base[test_idx] = logit.(clamped_base)
+            elseif match_between_runs && itr == mbr_start_iter
+                candidate_mask_test = hasproperty(psms_test, :MBR_transfer_candidate) ? psms_test.MBR_transfer_candidate : falses(length(test_predictions))
+                if any(candidate_mask_test)
+                    candidate_indices = findall(candidate_mask_test)
+                    clamped_boost = clamp!(copy(test_predictions[candidate_indices]), PROBABILITY_EPS, 1 - PROBABILITY_EPS)
+                    boost_mask[test_idx[candidate_indices]] = logit.(clamped_boost)
+                end
             end
 
             if match_between_runs
                 update_mbr_features!(psms_train, psms_test, prob_test,
                                      test_idx, itr, mbr_start_iter,
                                      max_q_value_lightgbm_rescore)
+                if itr == mbr_start_iter - 1
+                    mark_transfer_candidates!(psms_train, max_q_value_lightgbm_rescore)
+                    mark_transfer_candidates!(psms_test, max_q_value_lightgbm_rescore)
+                end
             end
 
             show_progress && update(pbar)
@@ -323,9 +370,7 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
             end
         end
         # Make predictions on hold out data.
-        if match_between_runs
-            MBR_estimates[test_idx] = psms_test.prob
-        else
+        if !match_between_runs
             prob_test[test_idx] = psms_test.prob
         end
         # Store models for this fold
@@ -333,19 +378,7 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
     end
 
     if match_between_runs
-        # Determine which precursors failed the q-value cutoff prior to MBR
-        qvals_prev = Vector{Float32}(undef, length(nonMBR_estimates))
-        get_qvalues!(nonMBR_estimates, psms.target, qvals_prev)
-        pass_mask = (qvals_prev .<= max_q_value_lightgbm_rescore)
-        has_passing_psms = !isempty(pass_mask) && any(pass_mask)
-        prob_thresh = has_passing_psms ? minimum(nonMBR_estimates[pass_mask]) : typemax(Float32)
-        # Label as transfer candidates only those failing the q-value cutoff but
-        # whose best matched pair surpassed the passing probability threshold.
-        psms[!, :MBR_transfer_candidate] .= .!pass_mask .&
-                                            (psms.MBR_max_pair_prob .>= prob_thresh)
-
-        # Use the final MBR probabilities for all precursors
-        psms[!, :prob] = MBR_estimates
+        apply_mbr_boost!(psms, nonMBR_estimates, logit_base, boost_mask, max_q_value_lightgbm_rescore)
     else
         psms[!, :prob] = prob_test
     end
@@ -698,7 +731,9 @@ function train_booster(psms::AbstractDataFrame, features, num_round;
                        bagging_fraction::Float64,
                        min_gain_to_split::Float64,
                        max_depth::Int,
-                       num_leaves::Int)
+                       num_leaves::Int,
+                       init_score = nothing,
+                       sample_weight = nothing)
 
     classifier = build_lightgbm_classifier(
         num_iterations = num_round,
@@ -712,7 +747,10 @@ function train_booster(psms::AbstractDataFrame, features, num_round;
         min_gain_to_split = min_gain_to_split,
     )
     feature_frame = psms[:, features]
-    return fit_lightgbm_model(classifier, feature_frame, psms.target; positive_label=true)
+    return fit_lightgbm_model(classifier, feature_frame, psms.target;
+                              positive_label=true,
+                              init_score=init_score,
+                              sample_weight=sample_weight)
 end
 
 function predict_fold!(bst, psms_train::AbstractDataFrame,
@@ -853,6 +891,16 @@ function initialize_prob_group_features!(
     return psms
 end
 
+function mark_transfer_candidates!(psms::AbstractDataFrame, qval_thresh::Float32)
+    qvals_prev = similar(psms.prob)
+    get_qvalues!(psms.prob, psms.target, qvals_prev)
+    pass_mask = (qvals_prev .<= qval_thresh) .& psms.target
+    prob_thresh = any(pass_mask) ? minimum(psms.prob[pass_mask]) : typemax(Float32)
+    psms[!, :MBR_transfer_candidate] = (qvals_prev .> qval_thresh) .&
+                                       (psms.MBR_max_pair_prob .>= prob_thresh)
+    return psms
+end
+
 function get_training_data_for_iteration!(
     psms_train::AbstractDataFrame,
     itr::Int,
@@ -973,6 +1021,32 @@ function update_mbr_probs!(
                                      (df.MBR_max_pair_prob .>= prob_thresh)
     df[!, :prob] = probs
     return df
+end
+
+function apply_mbr_boost!(
+    psms::AbstractDataFrame,
+    nonMBR_estimates::AbstractVector{Float32},
+    logit_base::AbstractVector{Float32},
+    boost_mask::AbstractVector{Float32},
+    qval_thresh::Float32,
+)
+    qvals_prev = similar(nonMBR_estimates)
+    get_qvalues!(nonMBR_estimates, psms.target, qvals_prev)
+    pass_mask = (qvals_prev .<= qval_thresh) .& psms.target
+    prob_thresh = any(pass_mask) ? minimum(nonMBR_estimates[pass_mask]) : typemax(Float32)
+    candidate_mask = (qvals_prev .> qval_thresh) .&
+                     (psms.MBR_max_pair_prob .>= prob_thresh)
+    psms[!, :MBR_transfer_candidate] = candidate_mask
+
+    boost_effect = boost_mask .* Float32.(candidate_mask)
+    logit_final = logit_base .+ boost_effect
+    final_probs = σ.(logit_final)
+    if any(.!candidate_mask)
+        final_probs[.!candidate_mask] .= nonMBR_estimates[.!candidate_mask]
+    end
+
+    psms[!, :prob] = final_probs
+    return final_probs
 end
 
 """

--- a/test/Routines/SearchDIA/SearchMethods/ScoringSearch/test_scoring_interface.jl
+++ b/test/Routines/SearchDIA/SearchMethods/ScoringSearch/test_scoring_interface.jl
@@ -26,6 +26,7 @@ using Pioneer: FilterResult, train_and_evaluate, apply_filtering
 using Pioneer: select_mbr_features, prepare_mbr_features, logodds
 using Pioneer: ProbitRegression, ModelPredict!
 using Pioneer: summarize_precursors!
+using Pioneer: apply_mbr_boost!
 
 
 @testset "Scoring Interface Tests" begin
@@ -239,7 +240,27 @@ using Pioneer: summarize_precursors!
         @test filtered_probs_ml[5] == 0.5f0  # Score 0.9 >= 0.5, not filtered (good transfer)
         @test filtered_probs_ml[6] == 0.4f0  # Not a candidate, not filtered
     end
-    
+
+    @testset "MBR Probability Combination" begin
+        psms = DataFrame(
+            target = Bool[true, false, true, false],
+            MBR_max_pair_prob = Float32[0.95, 0.3, 0.92, 0.2]
+        )
+
+        nonMBR = Float32[0.9, 0.6, 0.4, 0.3]
+        logit_base = Float32.(log.(nonMBR ./ (1 .- nonMBR)))
+        boost_mask = zeros(Float32, length(nonMBR))
+        boost_mask[3] = 0.5f0
+        max_q = 0.4f0
+
+        final_probs = apply_mbr_boost!(psms, nonMBR, logit_base, boost_mask, max_q)
+        expected_boosted = Float32(1 / (1 + exp(-(logit_base[3] + boost_mask[3]))))
+
+        @test final_probs[3] ≈ expected_boosted atol=1e-6
+        @test all(final_probs[[1, 2, 4]] .≈ nonMBR[[1, 2, 4]])
+        @test psms.MBR_transfer_candidate == [false, false, true, false]
+    end
+
     @testset "Logodds Function" begin
         # Test single probability
         @test logodds([0.8], 1) == 0.8


### PR DESCRIPTION
## Summary
- capture non-MBR logits and candidate masks before the final LightGBM iteration and restrict boosting data to transfer candidates with balanced controls
- feed optional init scores into LightGBM so the final model learns residual boosts and combine them via `apply_mbr_boost!`
- cover the new probability combination logic with a dedicated unit test

## Testing
- Not run (Julia executable unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f5ae2a3c088325a7777e91dea215fa