### PR TITLE
fix: add intensity tie-break for parameter tuning PSM ranking

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/utils.jl
@@ -146,7 +146,26 @@ function filter_and_score_psms!(
     end
     filter!(x -> x.best_psms::Bool, psms)
     =#
-    filter!(x->x.target::Bool, psms) #Otherwise fitting rt/irt and mass tolerance partly on decoys. 
+    filter!(x->x.target::Bool, psms) #Otherwise fitting rt/irt and mass tolerance partly on decoys.
+
+    # Ensure consistent ordering when downstream routines keep the top-N matches per scan.
+    # Sort primarily by preliminary probability score and secondarily by matched fragment
+    # intensity to break ties deterministically when the preliminary score is identical.
+    if :prob ∈ names(psms)
+        if :log2_summed_intensity ∈ names(psms)
+            sort!(
+                psms,
+                [:scan_idx, :prob, :log2_summed_intensity];
+                order=(Base.Order.Forward, Base.Order.Reverse, Base.Order.Reverse),
+            )
+        else
+            sort!(
+                psms,
+                [:scan_idx, :prob];
+                order=(Base.Order.Forward, Base.Order.Reverse),
+            )
+        end
+    end
 
     n_passing_psms = size(psms, 1)
     


### PR DESCRIPTION
## Summary
- sort parameter tuning PSMs by probability and matched fragment intensity to break score ties when taking the top hits

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6903cff205888325b0db1300b7a840a9