### PR TITLE
Separate MS1/MS2 Huber iteration diagnostics

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/IntegrateChromatogramsSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/IntegrateChromatogramsSearch.jl
@@ -37,6 +37,8 @@ Results container for chromatogram integration search.
 """
 struct IntegrateChromatogramSearchResults <: SearchResults
     psms::Base.Ref{DataFrame}  # Chromatogram data per file
+    huber_iterations_ms2::Base.Ref{HuberIterationHistogram}
+    huber_iterations_ms1::Base.Ref{HuberIterationHistogram}
 end
 
 """
@@ -164,7 +166,9 @@ get_parameters(::IntegrateChromatogramSearch, params::Any) = IntegrateChromatogr
 
 function init_search_results(::IntegrateChromatogramSearchParameters, search_context::SearchContext)
     return IntegrateChromatogramSearchResults(
-        Ref(DataFrame())
+        Ref(DataFrame()),
+        Ref(HuberIterationHistogram()),
+        Ref(HuberIterationHistogram())
     )
 end
 
@@ -233,6 +237,9 @@ function process_file!(
             passing_psms[!, :ms1_best_scan] = zeros(UInt32, nrow(passing_psms))
             passing_psms[!, :ms1_points_integrated] = zeros(UInt32, nrow(passing_psms))
         end
+        ms2_iteration_hist = HuberIterationHistogram()
+        ms1_iteration_hist = HuberIterationHistogram()
+
         # Extract chromatograms for all passing PSMs
         # Builds chromatograms using parallel processing across scan ranges
         chromatograms = extract_chromatograms(
@@ -242,6 +249,7 @@ function process_file!(
             search_context,
             params,
             ms_file_idx,
+            ms2_iteration_hist,
             MS2CHROM(),
         )
         #sort!(chromatograms, :rt)
@@ -256,6 +264,7 @@ function process_file!(
                 search_context,
                 params,
                 ms_file_idx,
+                ms1_iteration_hist,
                 MS1CHROM(),
             )
             sort!(ms1_chromatograms, :rt)
@@ -322,6 +331,8 @@ function process_file!(
 
         # Store processed PSMs in results
         results.psms[] = passing_psms
+        results.huber_iterations_ms2[] = ms2_iteration_hist
+        results.huber_iterations_ms1[] = ms1_iteration_hist
     catch e
         # Handle failures gracefully using helper function
         handle_search_error!(search_context, ms_file_idx, "IntegrateChromatogramSearch", e, createFallbackResults!, results)
@@ -350,6 +361,8 @@ function createFallbackResults!(results::IntegrateChromatogramSearchResults, ms_
     
     # Set empty results (don't append since this file failed)
     results.psms[] = empty_psms
+    results.huber_iterations_ms2[] = HuberIterationHistogram()
+    results.huber_iterations_ms1[] = HuberIterationHistogram()
 end
 
 function process_search_results!(
@@ -367,6 +380,12 @@ function process_search_results!(
 
     try
         passing_psms = results.psms[]
+        parsed_fname = getFileIdToName(getMSData(search_context), ms_file_idx)
+        hist_dir = joinpath(getDataOutDir(search_context), "temp_data", "chromatogram_integration_huber_iterations")
+        ms2_hist_counts = snapshot(results.huber_iterations_ms2[])
+        write_huber_histogram(joinpath(hist_dir, parsed_fname * "_ms2.tsv"), ms2_hist_counts)
+        ms1_hist_counts = snapshot(results.huber_iterations_ms1[])
+        write_huber_histogram(joinpath(hist_dir, parsed_fname * "_ms1.tsv"), ms1_hist_counts)
 
         # Skip processing if no PSMs (empty DataFrame from failed search)
         if nrow(passing_psms) == 0 || ncol(passing_psms) == 0
@@ -374,7 +393,6 @@ function process_search_results!(
             return nothing
         end
 
-        parsed_fname = getFileIdToName(getMSData(search_context), ms_file_idx)
         # Process final PSMs
         process_final_psms!(
             passing_psms,
@@ -393,6 +411,8 @@ end
 
 function reset_results!(results::IntegrateChromatogramSearchResults)
     results.psms[] = DataFrame()
+    results.huber_iterations_ms2[] = HuberIterationHistogram()
+    results.huber_iterations_ms1[] = HuberIterationHistogram()
     GC.gc()
     return nothing
 end

--- a/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/utils.jl
@@ -163,6 +163,7 @@ function extract_chromatograms(
     search_context::SearchContext,
     params::IntegrateChromatogramSearchParameters,
     ms_file_idx::Int64,
+    iteration_hist::HuberIterationHistogram,
     chrom_type::CHROMATOGRAM
 )
     if typeof(chrom_type)==typeof(MS2CHROM())
@@ -187,6 +188,7 @@ function extract_chromatograms(
                 search_data,
                 params,
                 ms_file_idx,
+                iteration_hist,
                 chrom_type
             )
         end
@@ -218,6 +220,7 @@ function build_chromatograms(
     search_data::SearchDataStructures,
     params::IntegrateChromatogramSearchParameters,
     ms_file_idx::Int64,
+    iteration_hist::HuberIterationHistogram,
     ::MS2CHROM
 )
     # Initialize working arrays
@@ -335,7 +338,7 @@ function build_chromatograms(
             # Solve deconvolution
             initResiduals!(residuals, Hs, weights)
 
-            solveHuber!(
+            huber_iters = solveHuber!(
                 Hs,
                 residuals,
                 weights,
@@ -349,6 +352,7 @@ function build_chromatograms(
                 params.max_diff,
                 params.reg_type
             )
+            record_huber_iterations!(iteration_hist, huber_iters)
 
             # Record chromatogram points with weights
             for j in 1:prec_temp_size
@@ -432,6 +436,7 @@ function build_chromatograms(
     search_data::SearchDataStructures,
     params::IntegrateChromatogramSearchParameters,
     ms_file_idx::Int64,
+    iteration_hist::HuberIterationHistogram,
     ::MS1CHROM
 )
     # Initialize working arrays
@@ -569,7 +574,7 @@ function build_chromatograms(
 
             # Solve deconvolution
             initResiduals!(residuals, Hs, weights)
-            solveHuber!(
+            huber_iters = solveHuber!(
                 Hs,
                 residuals,
                 weights,
@@ -583,6 +588,7 @@ function build_chromatograms(
                 params.max_diff,
                 params.ms1_reg_type
             )
+            record_huber_iterations!(iteration_hist, huber_iters)
 
             # NEW: Distribute grouped coefficients back to individual precursors
             distribute_ms1_coefficients!(

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/SecondPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/SecondPassSearch.jl
@@ -353,9 +353,9 @@ function process_file!(
                     search_context,
                     params,
                     ms_file_idx,
-                    ms1_iteration_hist,
                     precursors_passing,
                     isotopes_dict,
+                    ms1_iteration_hist,
                     MS1CHROM()
                 )
                 pair_idx = getPairIdx(precursors);

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/SecondPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/SecondPassSearch.jl
@@ -144,6 +144,8 @@ Results container for second pass search.
 struct SecondPassSearchResults <: SearchResults
     psms::Base.Ref{DataFrame}          # PSMs for each file
     ms1_psms::Base.Ref{DataFrame}
+    huber_iterations_ms2::Base.Ref{HuberIterationHistogram}
+    huber_iterations_ms1::Base.Ref{HuberIterationHistogram}
 end
 
 """
@@ -281,8 +283,10 @@ function init_search_results(::P, search_context::SearchContext) where {P<:Secon
     second_pass_psms = joinpath(getDataOutDir(search_context), "temp_data", "second_pass_psms")
     !isdir(second_pass_psms) && mkdir(second_pass_psms)
     return SecondPassSearchResults(
-        DataFrame(),
-        DataFrame()
+        Ref(DataFrame()),
+        Ref(DataFrame()),
+        Ref(HuberIterationHistogram()),
+        Ref(HuberIterationHistogram())
     )
 end
 
@@ -317,6 +321,9 @@ function process_file!(
             DataFrame(Arrow.Table(getRtIndex(getMSData(search_context), ms_file_idx))),
             bin_rt_size = 0.1)
 
+        ms2_iteration_hist = HuberIterationHistogram()
+        ms1_iteration_hist = HuberIterationHistogram()
+
         # Perform second pass search
         psms = perform_second_pass_search(
             spectra,
@@ -324,6 +331,7 @@ function process_file!(
             search_context,
             params,
             ms_file_idx,
+            ms2_iteration_hist,
             MS2CHROM()
         )
         if params.ms1_scoring
@@ -345,6 +353,7 @@ function process_file!(
                     search_context,
                     params,
                     ms_file_idx,
+                    ms1_iteration_hist,
                     precursors_passing,
                     isotopes_dict,
                     MS1CHROM()
@@ -396,6 +405,8 @@ function process_file!(
 
         results.psms[] = psms
         results.ms1_psms[] = ms1_psms
+        results.huber_iterations_ms2[] = ms2_iteration_hist
+        results.huber_iterations_ms1[] = ms1_iteration_hist
 
     catch e
         # Handle failures gracefully using helper function (logs full stacktrace)
@@ -434,6 +445,8 @@ function createFallbackResults!(results::SecondPassSearchResults, ms_file_idx::I
     # Set empty results (don't append since this file failed)
     results.psms[] = empty_psms
     results.ms1_psms[] = empty_ms1_psms
+    results.huber_iterations_ms2[] = HuberIterationHistogram()
+    results.huber_iterations_ms1[] = HuberIterationHistogram()
 end
 
 function process_search_results!(
@@ -453,6 +466,7 @@ function process_search_results!(
         # Get PSMs from results container
         psms = results.psms[]
         ms1_psms = results.ms1_psms[]
+        parsed_fname = getParsedFileName(search_context, ms_file_idx)
         # Add basic search columns (RT, charge, target/decoy status)
         add_second_search_columns!(psms, 
             getRetentionTimes(spectra),
@@ -584,7 +598,7 @@ function process_search_results!(
             temp_path = joinpath(
                 getDataOutDir(search_context), "temp_data",
                 "second_pass_psms",
-                getParsedFileName(search_context, ms_file_idx) * ".arrow"
+                parsed_fname * ".arrow"
             )
             writeArrow(temp_path, psms)
             setSecondPassPsms!(getMSData(search_context), ms_file_idx, temp_path)
@@ -593,6 +607,12 @@ function process_search_results!(
             @debug_l2 "No PSMs found for file $ms_file_idx in SecondPassSearch, setting empty path"
             setSecondPassPsms!(getMSData(search_context), ms_file_idx, "")
         end
+
+        hist_dir = joinpath(getDataOutDir(search_context), "temp_data", "second_pass_huber_iterations")
+        ms2_hist_counts = snapshot(results.huber_iterations_ms2[])
+        write_huber_histogram(joinpath(hist_dir, parsed_fname * "_ms2.tsv"), ms2_hist_counts)
+        ms1_hist_counts = snapshot(results.huber_iterations_ms1[])
+        write_huber_histogram(joinpath(hist_dir, parsed_fname * "_ms1.tsv"), ms1_hist_counts)
     catch e
         # Mark file as failed and handle gracefully
         file_name = try
@@ -622,6 +642,9 @@ Reset results containers.
 """
 function reset_results!(results::SecondPassSearchResults)
     results.psms[] = DataFrame()
+    results.ms1_psms[] = DataFrame()
+    results.huber_iterations_ms2[] = HuberIterationHistogram()
+    results.huber_iterations_ms1[] = HuberIterationHistogram()
 end
 
 function summarize_results!(

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -43,6 +43,7 @@ function perform_second_pass_search(
     search_context::SearchContext,
     params::SecondPassSearchParameters,
     ms_file_idx::Int64,
+    iteration_hist::HuberIterationHistogram,
     ::MS2CHROM
 )
     thread_tasks = partition_scans(spectra, Threads.nthreads())
@@ -60,6 +61,7 @@ function perform_second_pass_search(
                 search_data,
                 params,
                 ms_file_idx,
+                iteration_hist,
                 MS2CHROM()
             )
         end
@@ -88,6 +90,7 @@ function perform_second_pass_search(
     ms_file_idx::Int64,
     precursors_passing::Set{UInt32},
     isotopes_dict::UnorderedDictionary{UInt32, Vector{Isotope{T}}},
+    iteration_hist::HuberIterationHistogram,
     ::MS1CHROM
 ) where {T<:AbstractFloat}
     thread_tasks = partition_scans(spectra, Threads.nthreads(), ms_order_select = 1)
@@ -106,6 +109,7 @@ function perform_second_pass_search(
                 ms_file_idx,
                 precursors_passing,
                 isotopes_dict,
+                iteration_hist,
                 MS1CHROM()
             )
         end
@@ -150,6 +154,7 @@ function process_scans!(
     search_data::SearchDataStructures,
     params::SecondPassSearchParameters,
     ms_file_idx::Int64,
+    iteration_hist::HuberIterationHistogram,
     ::MS2CHROM
 )
     # Get working arrays
@@ -256,7 +261,7 @@ function process_scans!(
         
         # Solve deconvolution problem
         initResiduals!(residuals, Hs, weights)
-        solveHuber!(
+        huber_iters = solveHuber!(
             Hs,
             residuals,
             weights,
@@ -270,6 +275,7 @@ function process_scans!(
             params.max_diff,
             params.reg_type
         )
+        record_huber_iterations!(iteration_hist, huber_iters)
 
         # Update precursor weights
         update_precursor_weights!(search_data, weights, precursor_weights)
@@ -338,6 +344,7 @@ function process_scans!(
     ms_file_idx::Int64,
     precursors_passing::Set{UInt32},
     isotopes_dict::UnorderedDictionary{UInt32, Vector{Isotope{T}}},
+    iteration_hist::HuberIterationHistogram,
     ::MS1CHROM
 ) where {T<:AbstractFloat}
     #######
@@ -518,7 +525,7 @@ function process_scans!(
 
             # Solve deconvolution
             initResiduals!(residuals, Hs, weights)
-            solveHuber!(
+            huber_iters = solveHuber!(
                 Hs,
                 residuals,
                 weights,
@@ -532,6 +539,7 @@ function process_scans!(
                 params.max_diff,
                 params.ms1_reg_type
             )
+            record_huber_iterations!(iteration_hist, huber_iters)
 
             # NEW: Distribute grouped coefficients back to individual precursors
             distribute_ms1_coefficients!(

--- a/src/utils/ML/spectralLinearRegression.jl
+++ b/src/utils/ML/spectralLinearRegression.jl
@@ -20,6 +20,77 @@ struct L1Norm <: RegularizationType end
 struct L2Norm <: RegularizationType end
 struct NoNorm <: RegularizationType end
 
+
+"""
+    HuberIterationHistogram
+
+Thread-safe accumulator that tracks how many outer iterations the
+`solveHuber!` solver performed for each invocation. The histogram is stored
+as a dictionary keyed by iteration count with the number of observations as
+the value.
+"""
+mutable struct HuberIterationHistogram
+    counts::Dict{Int, Int}
+    lock::ReentrantLock
+end
+
+HuberIterationHistogram() = HuberIterationHistogram(Dict{Int, Int}(), ReentrantLock())
+
+"""
+    record_huber_iterations!(hist::HuberIterationHistogram, iterations::Integer)
+
+Add a single observation to the histogram. The operation is protected by a
+`ReentrantLock` so that multiple threads can safely update the accumulator.
+"""
+function record_huber_iterations!(hist::HuberIterationHistogram, iterations::Integer)
+    lock(hist.lock) do
+        iter_key = Int(iterations)
+        hist.counts[iter_key] = get(hist.counts, iter_key, 0) + 1
+    end
+    return nothing
+end
+
+"""
+    snapshot(hist::HuberIterationHistogram) -> Dict{Int, Int}
+
+Return a copy of the histogram counts for reporting without mutating the
+original accumulator.
+"""
+function snapshot(hist::HuberIterationHistogram)
+    lock(hist.lock) do
+        return copy(hist.counts)
+    end
+end
+
+"""
+    reset!(hist::HuberIterationHistogram)
+
+Clear all accumulated counts.
+"""
+function reset!(hist::HuberIterationHistogram)
+    lock(hist.lock) do
+        empty!(hist.counts)
+    end
+    return nothing
+end
+
+"""
+    write_huber_histogram(path::AbstractString, counts::AbstractDict)
+
+Write the histogram data to `path` as a TSV file with `iterations` and
+`count` columns. The parent directory is created automatically.
+"""
+function write_huber_histogram(path::AbstractString, counts::AbstractDict)
+    mkpath(dirname(path))
+    open(path, "w") do io
+        println(io, "iterations\tcount")
+        for iter in sort!(collect(keys(counts)))
+            println(io, "$(iter)\t$(counts[iter])")
+        end
+    end
+    return nothing
+end
+
 function getRegL1(λ::T, xk::T, ::NoNorm) where T<:AbstractFloat
     return zero(Float32)
 end
@@ -258,10 +329,12 @@ function solveHuber!(Hs::SparseArray{Ti, T},
     
     # Initialize iteration counter
     i = 0
+    iterations = 0
     while i < max_iter_outer
+        iterations += 1
         _diff = T(0)
         for col in range(1, Hs.n)
-            
+
             # Update coefficient
             δx = abs(newton_bisection!(Hs, r, X₁, col, δ, λ,
                                         max_iter_newton, 
@@ -283,9 +356,9 @@ function solveHuber!(Hs::SparseArray{Ti, T},
         # Check convergence
         if _diff < relative_convergence_threshold
             break
-        end  
+        end
         i += 1
     end
-    
-    return nothing
+
+    return iterations
 end


### PR DESCRIPTION
## Summary
- add a thread-safe histogram accumulator for solveHuber! that records outer iteration counts
- capture iteration histograms during second-pass and chromatogram-integration searches and emit MS1/MS2-specific TSV diagnostics per MS file

## Testing
- `julia --project -e 'using Pioneer; println("Pioneer loaded")'` *(fails: julia not installed in runner)*

------
https://chatgpt.com/codex/tasks/task_e_69079e12daac83259b211059f605cbe5