### PR TITLE
fix: silence LightGBM logging during import

### DIFF
--- a/src/Pioneer.jl
+++ b/src/Pioneer.jl
@@ -54,7 +54,7 @@ using HTTP
 # logger that would intercept every log message.
 const LightGBM = begin
     Logging.with_logger(NullLogger()) do
-        Base.require(:LightGBM)
+        Base.require(Pioneer, :LightGBM)
     end
 end
 

--- a/src/Pioneer.jl
+++ b/src/Pioneer.jl
@@ -40,7 +40,6 @@ using Random
 import RobustModels: rlm, TauEstimator, TukeyLoss
 import StatsModels: @formula
 using StaticArrays, StatsBase, SpecialFunctions, Statistics, SparseArrays
-using LightGBM
 import MLJModelInterface: fit, predict
 using KernelDensity
 using FastGaussQuadrature
@@ -48,6 +47,12 @@ using LaTeXStrings, Printf
 using Dates
 using InlineStrings
 using HTTP
+
+
+# Silence LightGBM initialization logging so the module loads cleanly.
+Logging.with_logger(NullLogger()) do
+    @eval using LightGBM
+end
 
 
 # Simple console logger - detailed logging handled by custom logging system

--- a/src/Pioneer.jl
+++ b/src/Pioneer.jl
@@ -52,9 +52,11 @@ using HTTP
 # Load LightGBM once under a `NullLogger` so its startup banner does not reach
 # the console. Keeping a direct module reference avoids introducing a custom
 # logger that would intercept every log message.
-const LightGBM = begin
-    Logging.with_logger(NullLogger()) do
+const LightGBM = let previous_logger = Logging.global_logger(NullLogger())
+    try
         Base.require(Pioneer, :LightGBM)
+    finally
+        Logging.global_logger(previous_logger)
     end
 end
 

--- a/src/Pioneer.jl
+++ b/src/Pioneer.jl
@@ -49,45 +49,13 @@ using InlineStrings
 using HTTP
 
 
-# Dedicated logger that suppresses LightGBM's startup banner while delegating
-# all other messages to the standard console logger. This ensures Pioneer loads
-# quietly even if LightGBM emits informational messages about library discovery.
-const LIGHTGBM_INFO_BANNER = "lib_lightgbm found in system dirs!"
-
-struct PioneerConsoleLogger{L<:AbstractLogger} <: AbstractLogger
-    logger::L
-end
-
-PioneerConsoleLogger() = PioneerConsoleLogger(ConsoleLogger())
-
-Logging.min_enabled_level(logger::PioneerConsoleLogger) =
-    Logging.min_enabled_level(logger.logger)
-
-Logging.shouldlog(logger::PioneerConsoleLogger, level, _module, group, id, file, line) =
-    Logging.shouldlog(logger.logger, level, _module, group, id, file, line)
-
-Logging.catch_exceptions(logger::PioneerConsoleLogger) =
-    Logging.catch_exceptions(logger.logger)
-
-Logging.isdisabled(logger::PioneerConsoleLogger) =
-    Logging.isdisabled(logger.logger)
-
-Logging.handle_message(logger::PioneerConsoleLogger, level, message, _module, group, id, file, line; kwargs...) =
-    if level == Logging.Info && occursin(LIGHTGBM_INFO_BANNER, string(message))
-        return
+# Load LightGBM once under a `NullLogger` so its startup banner does not reach
+# the console. Keeping a direct module reference avoids introducing a custom
+# logger that would intercept every log message.
+const LightGBM = begin
+    Logging.with_logger(NullLogger()) do
+        Base.require(:LightGBM)
     end
-    Logging.handle_message(logger.logger, level, message, _module, group, id, file, line; kwargs...)
-
-
-# Install the filtered console logger before loading LightGBM so its
-# initialization output is also filtered when the package is imported.
-const PIONEER_LOGGER = PioneerConsoleLogger()
-global_logger(PIONEER_LOGGER)
-
-
-# Silence LightGBM initialization logging entirely while importing the module.
-Logging.with_logger(NullLogger()) do
-    @eval using LightGBM
 end
 
 

--- a/src/Pioneer.jl
+++ b/src/Pioneer.jl
@@ -49,14 +49,46 @@ using InlineStrings
 using HTTP
 
 
-# Silence LightGBM initialization logging so the module loads cleanly.
+# Dedicated logger that suppresses LightGBM's startup banner while delegating
+# all other messages to the standard console logger. This ensures Pioneer loads
+# quietly even if LightGBM emits informational messages about library discovery.
+const LIGHTGBM_INFO_BANNER = "lib_lightgbm found in system dirs!"
+
+struct PioneerConsoleLogger{L<:AbstractLogger} <: AbstractLogger
+    logger::L
+end
+
+PioneerConsoleLogger() = PioneerConsoleLogger(ConsoleLogger())
+
+Logging.min_enabled_level(logger::PioneerConsoleLogger) =
+    Logging.min_enabled_level(logger.logger)
+
+Logging.shouldlog(logger::PioneerConsoleLogger, level, _module, group, id, file, line) =
+    Logging.shouldlog(logger.logger, level, _module, group, id, file, line)
+
+Logging.catch_exceptions(logger::PioneerConsoleLogger) =
+    Logging.catch_exceptions(logger.logger)
+
+Logging.isdisabled(logger::PioneerConsoleLogger) =
+    Logging.isdisabled(logger.logger)
+
+Logging.handle_message(logger::PioneerConsoleLogger, level, message, _module, group, id, file, line; kwargs...) =
+    if level == Logging.Info && occursin(LIGHTGBM_INFO_BANNER, string(message))
+        return
+    end
+    Logging.handle_message(logger.logger, level, message, _module, group, id, file, line; kwargs...)
+
+
+# Install the filtered console logger before loading LightGBM so its
+# initialization output is also filtered when the package is imported.
+const PIONEER_LOGGER = PioneerConsoleLogger()
+global_logger(PIONEER_LOGGER)
+
+
+# Silence LightGBM initialization logging entirely while importing the module.
 Logging.with_logger(NullLogger()) do
     @eval using LightGBM
 end
-
-
-# Simple console logger - detailed logging handled by custom logging system
-global_logger(ConsoleLogger())
 
 
 """


### PR DESCRIPTION
## Summary
- load LightGBM within a temporary `NullLogger` so its initialization output is suppressed

## Testing
- not run (Julia executable unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_690a2d0965e48325b01dd50de4706526