### PR TITLE
Use forked LightGBM in CI and silence discovery log

### DIFF
--- a/.github/workflows/build_app_linux.yml
+++ b/.github/workflows/build_app_linux.yml
@@ -71,7 +71,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          julia --project=. -e 'using Pkg; Pkg.add("PackageCompiler"); Pkg.instantiate()'
+          julia --project=. -e '
+            using Pkg;
+            Pkg.add("PackageCompiler");
+            Pkg.develop(PackageSpec(url="https://github.com/DennisGoldfarb/LightGBM.jl", rev="codex/add-log_library_discovery-constant"));
+            Pkg.resolve();
+            Pkg.instantiate();
+          '
 
       - name: Precompile data (cache & download)
         uses: ./.github/actions/precompile-data

--- a/.github/workflows/build_app_macos.yml
+++ b/.github/workflows/build_app_macos.yml
@@ -135,7 +135,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          julia --project=. -e 'using Pkg; Pkg.add("PackageCompiler"); Pkg.instantiate()'
+          julia --project=. -e '
+            using Pkg;
+            Pkg.add("PackageCompiler");
+            Pkg.develop(PackageSpec(url="https://github.com/DennisGoldfarb/LightGBM.jl", rev="codex/add-log_library_discovery-constant"));
+            Pkg.resolve();
+            Pkg.instantiate();
+          '
 
       - name: Precompile data (cache & download)
         uses: ./.github/actions/precompile-data

--- a/.github/workflows/build_app_windows.yml
+++ b/.github/workflows/build_app_windows.yml
@@ -73,7 +73,13 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          julia --project=. -e 'using Pkg; Pkg.add("PackageCompiler"); Pkg.instantiate()'
+          julia --project=. -e '
+            using Pkg;
+            Pkg.add("PackageCompiler");
+            Pkg.develop(PackageSpec(url="https://github.com/DennisGoldfarb/LightGBM.jl", rev="codex/add-log_library_discovery-constant"));
+            Pkg.resolve();
+            Pkg.instantiate();
+          '
 
       - name: Precompile data (cache & download)
         uses: ./.github/actions/precompile-data

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,8 @@ jobs:
         run: |
           using Pkg
           Pkg.develop(path=pwd())
+          Pkg.develop(PackageSpec(url="https://github.com/DennisGoldfarb/LightGBM.jl", rev="codex/add-log_library_discovery-constant"))
+          Pkg.resolve()
           Pkg.instantiate()
 
       - name: Build docs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,14 @@ jobs:
           restore-keys: |
             julia-${{ matrix.version }}-${{ runner.os }}-
 
+      - name: Override LightGBM dependency
+        run: |
+          julia --project=. -e '
+            using Pkg;
+            Pkg.develop(PackageSpec(url="https://github.com/DennisGoldfarb/LightGBM.jl", rev="codex/add-log_library_discovery-constant"));
+            Pkg.resolve();
+          '
+
       - name: Instantiate & build
         run: |
           julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.build()'

--- a/src/Pioneer.jl
+++ b/src/Pioneer.jl
@@ -40,6 +40,8 @@ using Random
 import RobustModels: rlm, TauEstimator, TukeyLoss
 import StatsModels: @formula
 using StaticArrays, StatsBase, SpecialFunctions, Statistics, SparseArrays
+# Silence LightGBM's library discovery info log (honored by forked LightGBM).
+ENV["LIGHTGBM_LOG_LIBRARY_DISCOVERY"] = "false"
 using LightGBM
 import MLJModelInterface: fit, predict
 using KernelDensity


### PR DESCRIPTION
## Summary
- set `LIGHTGBM_LOG_LIBRARY_DISCOVERY` before importing LightGBM so the forked package suppresses its discovery log
- update test, docs, and app build workflows to develop the forked LightGBM repository and resolve the manifest before instantiating dependencies

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_690cb8cb2c5c8325af140448523da6fa