### PR TITLE
Only predict target fragments with Koina and reuse decoy masses

### DIFF
--- a/src/Routines/BuildSpecLib.jl
+++ b/src/Routines/BuildSpecLib.jl
@@ -207,6 +207,21 @@ function BuildSpecLib(params_path::String)
             # Parse results and prepare for fragment prediction
             parse_timing = @timed begin
                 iso_mod_to_mass = Dict{String, Float32}()
+                structural_mod_to_mass = Dict{String, Float32}()
+                if haskey(params, "variable_mods")
+                    names = params["variable_mods"]["name"]
+                    masses = params["variable_mods"]["mass"]
+                    for (name, mass) in zip(names, masses)
+                        structural_mod_to_mass[name] = Float32(mass)
+                    end
+                end
+                if haskey(params, "fixed_mods")
+                    names = params["fixed_mods"]["name"]
+                    masses = params["fixed_mods"]["mass"]
+                    for (name, mass) in zip(names, masses)
+                        structural_mod_to_mass[name] = Float32(mass)
+                    end
+                end
                 precursors_arrow_path = parse_chronologer_output(
                     chronologer_out_path,
                     lib_dir,
@@ -266,6 +281,7 @@ function BuildSpecLib(params_path::String)
                         asset_path("immonium.txt"),
                         lib_dir,
                         Dict{String, Int8}(),
+                        structural_mod_to_mass,
                         iso_mod_to_mass,
                         koina_model_type
                     )
@@ -287,6 +303,7 @@ function BuildSpecLib(params_path::String)
                         asset_path("immonium.txt"),
                         lib_dir,
                         Dict{String, Int8}(),
+                        structural_mod_to_mass,
                         iso_mod_to_mass,
                         koina_model_type
                     )

--- a/src/Routines/BuildSpecLib/fragments/fragment_parse.jl
+++ b/src/Routines/BuildSpecLib/fragments/fragment_parse.jl
@@ -331,9 +331,10 @@ end
         immonium_data_path::String,
         out_dir::String,
         mods_to_sulfur_diff::Dict{String, Int8},
+        structural_mod_to_mass::Dict{String, Float32},
         iso_mod_to_mass::Dict{String, Float32},
         model_type::KoinaModelType
-    )
+)
 
 Process Koina prediction outputs into Pioneer's fragment format.
 """
@@ -347,6 +348,7 @@ function parse_koina_fragments(
     immonium_data_path::String,
     out_dir::String,
     mods_to_sulfur_diff::Dict{String, Int8},
+    structural_mod_to_mass::Dict{String, Float32},
     iso_mod_to_mass::Dict{String, Float32},
     model_type::KoinaModelType
 )
@@ -390,6 +392,7 @@ function parse_koina_fragments(
             ion_annotation_to_features_dict,
             frag_name_to_idx,
             mods_to_sulfur_diff,
+            structural_mod_to_mass,
             iso_mod_to_mass,
             model_type
         )
@@ -439,6 +442,7 @@ function process_fragments_batched(
             ion_annotation_to_features_dict,
             frag_name_to_idx,
             mods_to_sulfur_diff,
+            structural_mod_to_mass,
             iso_mod_to_mass,
             model_type
         )
@@ -466,6 +470,7 @@ function append_pioneer_lib_batch(
     ion_annotation_to_data_dict::Dict{String, PioneerFragAnnotation},
     frag_name_to_idx::Dict{String, UInt16},
     mods_to_sulfur_diff::Dict{String, Int8},
+    structural_mod_to_mass::Dict{String, Float32},
     iso_mod_to_mass::Dict{String, Float32},
     ::Union{InstrumentSpecificModel, InstrumentAgnosticModel}
 )
@@ -507,6 +512,7 @@ function append_pioneer_lib_batch(
         ion_annotation_to_data_dict,
         frag_name_to_idx,
         mods_to_sulfur_diff,
+        structural_mod_to_mass,
         iso_mod_to_mass
     )
     
@@ -530,6 +536,7 @@ function append_pioneer_lib_batch(
     fragment_table::Arrow.Table,
     ion_annotation_to_data_dict::Dict{Int32, PioneerFragAnnotation},
     mods_to_sulfur_diff::Dict{String, Int8},
+    structural_mod_to_mass::Dict{String, Float32},
     iso_mod_to_mass::Dict{String, Float32},
     ::SplineCoefficientModel
 )
@@ -574,6 +581,7 @@ function append_pioneer_lib_batch(
         fragment_table,
         ion_annotation_to_data_dict,
         mods_to_sulfur_diff,
+        structural_mod_to_mass,
         iso_mod_to_mass
     )
     
@@ -601,15 +609,20 @@ function process_batch!(
     ion_annotation_to_data_dict::Dict{String, PioneerFragAnnotation},
     frag_name_to_idx::Dict{String, UInt16},
     mods_to_sulfur_diff::Dict{String, Int8},
+    structural_mod_to_mass::Dict{String, Float32},
     iso_mod_to_mass::Dict{String, Float32}
 )
     # Track working variables
     seq_idx_to_sulfur = zeros(UInt8, 255)
     seq_idx_to_iso_mod = zeros(Float32, 255)
+    aa_masses = zeros(Float32, 255)
+    structural_mod_masses = zeros(Float32, 255)
+    zero_iso_mods = zeros(Float32, 255)
     last_pid = zero(UInt32)
     precursor_sulfur_count = zero(UInt8)
     precursor_length = zero(UInt8)
     batch_pid = 0
+    current_is_decoy = false
     
     for frag_idx in 1:length(prec_frags)
         # Get fragment info
@@ -621,11 +634,13 @@ function process_batch!(
         if pid != last_pid
             batch_pid += 1
             last_pid = pid
-            
+
             # Reset and update sulfur tracking
             fill!(seq_idx_to_sulfur, zero(UInt8))
             fill!(seq_idx_to_iso_mod, zero(Float32))
-            
+            fill!(aa_masses, 0f0)
+            fill!(structural_mod_masses, 0f0)
+
             # Calculate sulfur count for new precursor
             prec_sulfur_count[batch_pid] = count_sulfurs!(
                 seq_idx_to_sulfur,
@@ -633,7 +648,7 @@ function process_batch!(
                 parseMods(precursor_table[:mods][pid]),
                 mods_to_sulfur_diff
             )
-            
+
             # Handle isotope modifications
             iso_mods_iterator = parseMods(precursor_table[:isotope_mods][pid])
             fill_isotope_mods!(
@@ -641,10 +656,17 @@ function process_batch!(
                 iso_mods_iterator,
                 iso_mod_to_mass
             )
-            
+
+            sequence = precursor_table[:sequence][pid]
+            mods_value = precursor_table[:mods][pid]
+            mods_string = mods_value === missing ? "" : mods_value
+            get_aa_masses!(aa_masses, sequence)
+            get_structural_mod_masses!(structural_mod_masses, mods_string, structural_mod_to_mass)
+
             precursor_sulfur_count = prec_sulfur_count[batch_pid]
-            precursor_length = UInt8(length(precursor_table[:sequence][pid]))
+            precursor_length = UInt8(length(sequence))
             pid_to_frag_idxs[batch_pid] = actual_frag_idx
+            current_is_decoy = hasproperty(precursor_table, :decoy) ? precursor_table[:decoy][pid] : false
         end
 
         # Get fragment data and parse annotation
@@ -692,6 +714,18 @@ function process_batch!(
 
         # Add any sulfur difference from modifications
         sulfur_count += frag_data.sulfur_diff
+
+        if current_is_decoy && !frag_data.immonium
+            frag_mz = get_fragment_mz(
+                start_idx,
+                stop_idx,
+                frag_data.base_type,
+                frag_data.charge,
+                aa_masses,
+                structural_mod_masses,
+                zero_iso_mods,
+            )
+        end
 
         # Adjust m/z for isotope modifications
         frag_mz += apply_isotope_mod(
@@ -748,17 +782,22 @@ function process_spline_batch!(
     fragment_table::Arrow.Table,
     ion_annotation_to_data_dict::Dict{Int32, PioneerFragAnnotation},
     mods_to_sulfur_diff::Dict{String, Int8},
+    structural_mod_to_mass::Dict{String, Float32},
     iso_mod_to_mass::Dict{String, Float32}
 ) where N
     # Working arrays for tracking modifications and sulfur
     seq_idx_to_sulfur = zeros(UInt8, 255)
     seq_idx_to_iso_mod = zeros(Float32, 255)
-    
+    aa_masses = zeros(Float32, 255)
+    structural_mod_masses = zeros(Float32, 255)
+    zero_iso_mods = zeros(Float32, 255)
+
     # Tracking variables
     last_pid = zero(UInt32)
     precursor_sulfur_count = zero(UInt8)
     precursor_length = zero(UInt8)
     batch_pid = 0
+    current_is_decoy = false
 
     for frag_idx in 1:length(prec_frags)
         actual_frag_idx = first_frag_idx + frag_idx - 1
@@ -776,6 +815,8 @@ function process_spline_batch!(
             # Reset tracking arrays
             fill!(seq_idx_to_sulfur, zero(UInt8))
             fill!(seq_idx_to_iso_mod, zero(Float32))
+            fill!(aa_masses, 0f0)
+            fill!(structural_mod_masses, 0f0)
 
             # Calculate sulfur count for new precursor
             prec_sulfur_count[batch_pid] = count_sulfurs!(
@@ -793,10 +834,17 @@ function process_spline_batch!(
                 iso_mod_to_mass
             )
 
+            sequence = precursor_table[:sequence][pid]
+            mods_value = precursor_table[:mods][pid]
+            mods_string = mods_value === missing ? "" : mods_value
+            get_aa_masses!(aa_masses, sequence)
+            get_structural_mod_masses!(structural_mod_masses, mods_string, structural_mod_to_mass)
+
             # Update precursor tracking
             precursor_sulfur_count = prec_sulfur_count[batch_pid]
-            precursor_length = UInt8(length(precursor_table[:sequence][pid]))
+            precursor_length = UInt8(length(sequence))
             pid_to_frag_idxs[batch_pid] = actual_frag_idx
+            current_is_decoy = hasproperty(precursor_table, :decoy) ? precursor_table[:decoy][pid] : false
         end
 
         # Get fragment data
@@ -837,6 +885,18 @@ function process_spline_batch!(
 
         # Add modification-based sulfur changes
         sulfur_count += frag_data.sulfur_diff
+
+        if current_is_decoy && !frag_data.immonium
+            frag_mz = get_fragment_mz(
+                start_idx,
+                stop_idx,
+                frag_data.base_type,
+                frag_data.charge,
+                aa_masses,
+                structural_mod_masses,
+                zero_iso_mods,
+            )
+        end
 
         # Adjust m/z for isotope modifications
         frag_mz += apply_isotope_mod(
@@ -888,6 +948,7 @@ function parse_altimeter_fragments(
     immonium_data_path::String,
     out_dir::String,
     mods_to_sulfur_diff::Dict{String, Int8},
+    structural_mod_to_mass::Dict{String, Float32},
     iso_mod_to_mass::Dict{String, Float32},
     model_type::KoinaModelType
 )
@@ -930,6 +991,7 @@ function parse_altimeter_fragments(
             fragment_table,
             ion_annotation_to_features_dict,
             mods_to_sulfur_diff,
+            structural_mod_to_mass,
             iso_mod_to_mass,
             model_type
         )

--- a/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
+++ b/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
@@ -48,7 +48,7 @@ function predict_fragments(
 
     # Load data and split targets/decoys
     peptides_df = DataFrame(Arrow.Table(peptide_table_path))
-    if !haskey(peptides_df, :decoy)
+    if :decoy ∉ names(peptides_df)
         error("Expected precursor table to contain a :decoy column")
     end
 
@@ -106,7 +106,7 @@ function duplicate_decoy_fragments(
         return target_fragments_df
     end
 
-    if !haskey(peptides_df, :pair_id) || !haskey(peptides_df, :precursor_charge)
+    if (:pair_id ∉ names(peptides_df)) || (:precursor_charge ∉ names(peptides_df))
         error("Precursor table must contain :pair_id and :precursor_charge columns to duplicate decoys")
     end
 

--- a/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
+++ b/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
@@ -46,42 +46,112 @@ function predict_fragments(
         error("Invalid model name: $model_name. Valid options: $(join(keys(KOINA_URLS), ", "))")
     end
 
-    # Load data
+    # Load data and split targets/decoys
     peptides_df = DataFrame(Arrow.Table(peptide_table_path))
+    if !haskey(peptides_df, :decoy)
+        error("Expected precursor table to contain a :decoy column")
+    end
 
-    # Process in batches
+    target_idxs = findall(!peptides_df.decoy)
+    decoy_idxs = findall(peptides_df.decoy)
+
+    # Process in batches for targets only
     koina_pool_size = max_koina_batches * 5
-    nprecs = nrow(peptides_df)
+    n_targets = length(target_idxs)
     batch_size = min(batch_size, 1000)
-    batch_start_idxs = collect(one(UInt32):UInt32(batch_size*koina_pool_size):UInt32(nprecs))
+    target_batches = DataFrame[]
+    if n_targets > 0
+        batch_start_positions = 1:batch_size*koina_pool_size:n_targets
+        rm(frags_out_path, force=true)
 
-    rm(frags_out_path, force=true)
-    
-    for start_idx in ProgressBar(batch_start_idxs)
-        stop_idx = min(start_idx + batch_size*koina_pool_size - 1, nrow(peptides_df))
-        batch_df = peptides_df[start_idx:stop_idx, :]
-        
-        # Generate predictions for batch
-        frags_out = predict_fragments_batch(
-            batch_df,
-            model_type,
-            instrument_type,
-            batch_size,
-            max_koina_batches,
-            start_idx,
-            
-        )
+        for start_pos in ProgressBar(batch_start_positions)
+            stop_pos = min(start_pos + batch_size*koina_pool_size - 1, n_targets)
+            batch_indices = target_idxs[start_pos:stop_pos]
+            batch_df = peptides_df[batch_indices, :]
 
-        # Write or append results
-        if start_idx == 1
-            # Create file in stream format to support appending
-            open(frags_out_path, "w") do io
-                Arrow.write(io, frags_out; file=false)  # file=false creates stream format
-            end
-        else
-            Arrow.append(frags_out_path, frags_out)
+            frags_out = predict_fragments_batch(
+                batch_df,
+                model_type,
+                instrument_type,
+                batch_size,
+                max_koina_batches,
+                UInt32.(batch_indices),
+            )
+
+            push!(target_batches, frags_out)
         end
     end
+
+    target_fragments_df = isempty(target_batches) ? DataFrame() : vcat(target_batches...)
+
+    # Duplicate target predictions for decoys using partner mapping
+    all_fragments_df = duplicate_decoy_fragments(
+        target_fragments_df,
+        peptides_df,
+        UInt32.(target_idxs),
+        UInt32.(decoy_idxs),
+    )
+
+    Arrow.write(frags_out_path, all_fragments_df)
+end
+
+function duplicate_decoy_fragments(
+    target_fragments_df::DataFrame,
+    peptides_df::DataFrame,
+    target_indices::Vector{UInt32},
+    decoy_indices::Vector{UInt32},
+)
+    # Fast path: no decoys or no targets
+    if isempty(decoy_indices) || isempty(target_fragments_df)
+        return target_fragments_df
+    end
+
+    if !haskey(peptides_df, :pair_id) || !haskey(peptides_df, :precursor_charge)
+        error("Precursor table must contain :pair_id and :precursor_charge columns to duplicate decoys")
+    end
+
+    # Build lookup from (pair_id, charge) -> precursor index for targets
+    partner_lookup = Dict{Tuple{UInt32, UInt8}, UInt32}()
+    for idx in target_indices
+        pair_val = peptides_df.pair_id[idx]
+        charge_val = peptides_df.precursor_charge[idx]
+        if ismissing(pair_val) || ismissing(charge_val)
+            continue
+        end
+        partner_lookup[(UInt32(pair_val), UInt8(charge_val))] = idx
+    end
+
+    decoy_fragments = DataFrame[]
+    for decoy_idx in decoy_indices
+        pair_val = peptides_df.pair_id[decoy_idx]
+        charge_val = peptides_df.precursor_charge[decoy_idx]
+        if ismissing(pair_val) || ismissing(charge_val)
+            @warn "Decoy precursor $decoy_idx missing pair_id or precursor_charge metadata" continue
+        end
+        partner_key = (UInt32(pair_val), UInt8(charge_val))
+
+        if !haskey(partner_lookup, partner_key)
+            @warn "No target partner found for decoy precursor $decoy_idx (pair_id=$(pair_val), charge=$(charge_val))" continue
+        end
+
+        target_idx = partner_lookup[partner_key]
+        target_rows = findall(target_fragments_df.precursor_idx .== target_idx)
+        if isempty(target_rows)
+            @warn "No fragment predictions found for target precursor $target_idx when duplicating decoy $decoy_idx" continue
+        end
+
+        decoy_df = deepcopy(target_fragments_df[target_rows, :])
+        decoy_df[!, :precursor_idx] .= decoy_idx
+        push!(decoy_fragments, decoy_df)
+    end
+
+    if isempty(decoy_fragments)
+        return target_fragments_df
+    end
+
+    combined = vcat(target_fragments_df, decoy_fragments...)
+    sort!(combined, :precursor_idx)
+    return combined
 end
 
 """
@@ -93,7 +163,7 @@ function predict_fragments_batch(
     instrument_type::String,
     batch_size::Int,
     concurrent_koina_requests::Int,
-    first_prec_idx::UInt32
+    precursor_indices::Vector{UInt32}
 )::DataFrame
     # Verify instrument compatibility
     if instrument_type ∉ MODEL_CONFIGS[model.name].instruments
@@ -110,16 +180,16 @@ function predict_fragments_batch(
     # Request predictions
     responses = make_koina_batch_requests(json_batches, KOINA_URLS[model.name]; concurrency=concurrent_koina_requests)
     # Process responses
-    batch_dfs = []
+    batch_dfs = Vector{DataFrame}()
     for (i, response) in enumerate(responses)
         batch_result = parse_koina_batch(model, response)
-        start_idx = (i-1) * batch_size + 1 + first_prec_idx - 1
-        
-        # Add precursor indices
+        batch_start = (i-1) * batch_size + 1
+        batch_stop = min(i * batch_size, length(precursor_indices))
+        current_indices = precursor_indices[batch_start:batch_stop]
+
         batch_df = batch_result.fragments
-        n_precursors_in_batch = UInt32(fld(size( batch_df , 1), batch_result.frags_per_precursor))
-        batch_df[!, :precursor_idx] = repeat(start_idx:(start_idx + n_precursors_in_batch - one(UInt32)), 
-                                                inner=batch_result.frags_per_precursor)
+        n_precursors_in_batch = length(current_indices)
+        batch_df[!, :precursor_idx] = repeat(current_indices, inner=batch_result.frags_per_precursor)
         # Filter and sort fragments
         filter_fragments!(batch_df, model)
         push!(batch_dfs, batch_df)
@@ -142,7 +212,7 @@ function predict_fragments_batch(
     _::String,  # instrument type not used
     batch_size::Int,
     concurrent_koina_requests::Int,
-    first_prec_idx::UInt32
+    precursor_indices::Vector{UInt32}
 )::DataFrame
     # Prepare batches (no instrument type needed)
     json_batches = prepare_koina_batch(
@@ -155,16 +225,16 @@ function predict_fragments_batch(
     responses = make_koina_batch_requests(json_batches, KOINA_URLS[model.name]; concurrency=concurrent_koina_requests)
 
     # Process responses
-    batch_dfs = []
+    batch_dfs = Vector{DataFrame}()
     for (i, response) in enumerate(responses)
         batch_result = parse_koina_batch(model, response)
-        start_idx = (i-1) * batch_size + 1 + first_prec_idx - 1
-        
-        # Add precursor indices
+        batch_start = (i-1) * batch_size + 1
+        batch_stop = min(i * batch_size, length(precursor_indices))
+        current_indices = precursor_indices[batch_start:batch_stop]
+
         batch_df = batch_result.fragments
-        n_precursors_in_batch = UInt32(fld(size( batch_df , 1), batch_result.frags_per_precursor))
-        batch_df[!, :precursor_idx] = repeat(start_idx:(start_idx + n_precursors_in_batch - one(UInt32)), 
-                                                inner=batch_result.frags_per_precursor)
+        n_precursors_in_batch = length(current_indices)
+        batch_df[!, :precursor_idx] = repeat(current_indices, inner=batch_result.frags_per_precursor)
         # Filter and sort fragments
         filter_fragments!(batch_df, model)
         push!(batch_dfs, batch_df)
@@ -185,7 +255,7 @@ function predict_fragments_batch(
     instrument_type::String,
     batch_size::Int,
     concurrent_koina_requests::Int,
-    first_prec_idx::UInt32
+    precursor_indices::Vector{UInt32}
 )::DataFrame
     # Similar to InstrumentSpecificModel but handles spline coefficients
     json_batches = prepare_koina_batch(
@@ -197,17 +267,18 @@ function predict_fragments_batch(
 
     responses = make_koina_batch_requests(json_batches, KOINA_URLS[model.name]; concurrency=concurrent_koina_requests)
 
-    batch_dfs = []
+    batch_dfs = Vector{DataFrame}()
     knot_vectors = []
-    
+
     for (i, response) in enumerate(responses)
         batch_result = parse_koina_batch(model, response)
-        start_idx = (i-1) * batch_size + 1 + first_prec_idx - 1
-        
+        batch_start = (i-1) * batch_size + 1
+        batch_stop = min(i * batch_size, length(precursor_indices))
+        current_indices = precursor_indices[batch_start:batch_stop]
+
         batch_df = batch_result.fragments
-        n_precursors_in_batch = UInt32(fld(size( batch_df , 1), batch_result.frags_per_precursor))
-        batch_df[!, :precursor_idx] = repeat(start_idx:(start_idx + n_precursors_in_batch - one(UInt32)), 
-                                                inner=batch_result.frags_per_precursor)
+        n_precursors_in_batch = length(current_indices)
+        batch_df[!, :precursor_idx] = repeat(current_indices, inner=batch_result.frags_per_precursor)
         filter_fragments!(batch_df, model)
         push!(batch_dfs, batch_df)
         push!(knot_vectors, batch_result.extra_data)  # Store knot vectors


### PR DESCRIPTION
## Summary
- restrict Koina fragment requests to target precursors and duplicate predictions for paired decoys
- recompute decoy fragment m/z values during parsing using structural modification masses
- propagate structural modification mass dictionaries through the BuildSpecLib pipeline to support decoy recalculation

## Testing
- `julia --project -e 'using Pioneer; println("Pioneer loaded")'` *(fails: `julia` not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910c57653f8832596c8e875830c7954)