### PR TITLE
Add progress bar while duplicating decoy fragments

### DIFF
--- a/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
+++ b/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
@@ -117,7 +117,7 @@ function duplicate_decoy_fragments(
     end
 
     decoy_fragments = DataFrame[]
-    for decoy_idx in decoy_indices
+    for decoy_idx in ProgressBar(decoy_indices)
         pair_val = peptides_df.pair_id[decoy_idx]
         charge_val = peptides_df.precursor_charge[decoy_idx]
         if ismissing(pair_val) || ismissing(charge_val)


### PR DESCRIPTION
## Summary
- add a progress bar to the decoy fragment duplication step so users can track progress during library building

## Testing
- not run (Julia is unavailable in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910db0b4bfc8325a3289023fe369e25)