### PR TITLE
perf: speed up decoy fragment duplication

### DIFF
--- a/src/Routines/BuildSpecLib/chronologer/chronologer_parse.jl
+++ b/src/Routines/BuildSpecLib/chronologer/chronologer_parse.jl
@@ -138,6 +138,13 @@ function parse_chronologer_output(
     end
     sort!(@view(precursors_df[start_idx:end,:]),:mz)
     
+    # Ensure each precursor has a stable identifier for downstream pairing
+    if :precursor_idx ∈ names(precursors_df)
+        precursors_df[!, :precursor_idx] = UInt32.(precursors_df[!, :precursor_idx])
+    else
+        precursors_df[!, :precursor_idx] = UInt32.(1:nrow(precursors_df))
+    end
+
     # Write processed precursors to Arrow file
     precursors_arrow_path = joinpath(pion_lib_dir, "precursors.arrow")
     Arrow.write(precursors_arrow_path, precursors_df)

--- a/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
+++ b/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
@@ -49,8 +49,6 @@ function predict_fragments(
     # Load data and split targets/decoys
     peptides_df = DataFrame(Arrow.Table(peptide_table_path))
 
-    println(names(peptides_df), "\n")
-
     target_idxs = findall(.!peptides_df.decoy)
     decoy_idxs = findall(peptides_df.decoy)
 
@@ -119,11 +117,10 @@ function duplicate_decoy_fragments(
     for idx in target_indices
         pair_val = peptides_df.pair_id[idx]
         charge_val = peptides_df.precursor_charge[idx]
-        precursor_val = peptides_df.precursor_idx[idx]
-        if ismissing(pair_val) || ismissing(charge_val) || ismissing(precursor_val)
+        if ismissing(pair_val) || ismissing(charge_val)
             continue
         end
-        partner_lookup[(UInt32(pair_val), UInt8(charge_val))] = UInt32(precursor_val)
+        partner_lookup[(UInt32(pair_val), UInt8(charge_val))] = UInt32(idx)
     end
 
     decoy_fragments = DataFrame[]
@@ -147,14 +144,8 @@ function duplicate_decoy_fragments(
             continue
         end
 
-        precursor_val = peptides_df.precursor_idx[decoy_idx]
-        if ismissing(precursor_val)
-            @warn "Decoy precursor $decoy_idx missing precursor_idx identifier"
-            continue
-        end
-
         decoy_df = copy(target_lookup[target_precursor])
-        decoy_df[!, :precursor_idx] .= UInt32(precursor_val)
+        decoy_df[!, :precursor_idx] .= UInt32(decoy_idx)
         push!(decoy_fragments, decoy_df)
     end
 

--- a/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
+++ b/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
@@ -49,6 +49,16 @@ function predict_fragments(
     # Load data and split targets/decoys
     peptides_df = DataFrame(Arrow.Table(peptide_table_path))
 
+    if :precursor_idx ∉ names(peptides_df)
+        error("Peptide table $(peptide_table_path) is missing required :precursor_idx column")
+    end
+
+    if any(ismissing, peptides_df[!, :precursor_idx])
+        error("Peptide table $(peptide_table_path) contains missing precursor_idx values")
+    end
+
+    peptides_df[!, :precursor_idx] = UInt32.(peptides_df[!, :precursor_idx])
+
     target_idxs = findall(.!peptides_df.decoy)
     decoy_idxs = findall(peptides_df.decoy)
 
@@ -72,7 +82,7 @@ function predict_fragments(
                 instrument_type,
                 batch_size,
                 max_koina_batches,
-                UInt32.(batch_indices),
+                UInt32.(peptides_df[batch_indices, :precursor_idx]),
             )
 
             push!(target_batches, frags_out)
@@ -93,8 +103,8 @@ function predict_fragments(
         target_fragments_df,
         target_lookup,
         peptides_df,
-        UInt32.(target_idxs),
-        UInt32.(decoy_idxs),
+        target_idxs,
+        decoy_idxs,
     )
 
     Arrow.write(frags_out_path, all_fragments_df)
@@ -104,31 +114,43 @@ function duplicate_decoy_fragments(
     target_fragments_df::DataFrame,
     target_lookup::Dict{UInt32, SubDataFrame},
     peptides_df::DataFrame,
-    target_indices::Vector{UInt32},
-    decoy_indices::Vector{UInt32},
+    target_indices::AbstractVector{<:Integer},
+    decoy_indices::AbstractVector{<:Integer},
 )
     # Fast path: no decoys or no targets
     if isempty(decoy_indices) || isempty(target_fragments_df)
         return target_fragments_df
     end
 
+    if :precursor_idx ∉ names(peptides_df)
+        error("Peptide metadata missing required :precursor_idx column")
+    end
+
     # Build lookup from (pair_id, charge) -> precursor index for targets
     partner_lookup = Dict{Tuple{UInt32, UInt8}, UInt32}()
     for idx in target_indices
-        pair_val = peptides_df.pair_id[idx]
-        charge_val = peptides_df.precursor_charge[idx]
-        if ismissing(pair_val) || ismissing(charge_val)
+        row_idx = Int(idx)
+        pair_val = peptides_df.pair_id[row_idx]
+        charge_val = peptides_df.precursor_charge[row_idx]
+        precursor_val = peptides_df.precursor_idx[row_idx]
+        if ismissing(pair_val) || ismissing(charge_val) || ismissing(precursor_val)
             continue
         end
-        partner_lookup[(UInt32(pair_val), UInt8(charge_val))] = UInt32(idx)
+        partner_lookup[(UInt32(pair_val), UInt8(charge_val))] = UInt32(precursor_val)
     end
 
     decoy_fragments = DataFrame[]
     for decoy_idx in ProgressBar(decoy_indices)
-        pair_val = peptides_df.pair_id[decoy_idx]
-        charge_val = peptides_df.precursor_charge[decoy_idx]
+        row_idx = Int(decoy_idx)
+        pair_val = peptides_df.pair_id[row_idx]
+        charge_val = peptides_df.precursor_charge[row_idx]
+        precursor_val = peptides_df.precursor_idx[row_idx]
         if ismissing(pair_val) || ismissing(charge_val)
             @warn "Decoy precursor $decoy_idx missing pair_id or precursor_charge metadata"
+            continue
+        end
+        if ismissing(precursor_val)
+            @warn "Decoy precursor $decoy_idx missing precursor_idx metadata"
             continue
         end
         partner_key = (UInt32(pair_val), UInt8(charge_val))
@@ -139,13 +161,14 @@ function duplicate_decoy_fragments(
         end
 
         target_precursor = partner_lookup[partner_key]
-        if !haskey(target_lookup, target_precursor)
+        subdf = get(target_lookup, target_precursor, nothing)
+        if subdf === nothing
             @warn "No fragment predictions found for target precursor $target_precursor when duplicating decoy $decoy_idx"
             continue
         end
 
-        decoy_df = copy(target_lookup[target_precursor])
-        decoy_df[!, :precursor_idx] .= UInt32(decoy_idx)
+        decoy_df = copy(subdf)
+        decoy_df[!, :precursor_idx] .= UInt32(precursor_val)
         push!(decoy_fragments, decoy_df)
     end
 

--- a/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
+++ b/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
@@ -83,8 +83,12 @@ function predict_fragments(
 
     target_fragments_df = isempty(target_batches) ? DataFrame() : vcat(target_batches...)
 
-    target_groups = :precursor_idx ∈ names(target_fragments_df) ? groupby(target_fragments_df, :precursor_idx) : nothing
-    target_lookup = target_groups === nothing ? Dict{UInt32, SubDataFrame}() : Dict(UInt32(first(group.precursor_idx)) => group for group in target_groups)
+    target_lookup = Dict{UInt32, SubDataFrame}()
+    if :precursor_idx ∈ names(target_fragments_df)
+        for group in groupby(target_fragments_df, :precursor_idx)
+            target_lookup[UInt32(first(group.precursor_idx))] = group
+        end
+    end
 
     # Duplicate target predictions for decoys using partner mapping
     all_fragments_df = duplicate_decoy_fragments(
@@ -126,21 +130,23 @@ function duplicate_decoy_fragments(
         pair_val = peptides_df.pair_id[decoy_idx]
         charge_val = peptides_df.precursor_charge[decoy_idx]
         if ismissing(pair_val) || ismissing(charge_val)
-            @warn "Decoy precursor $decoy_idx missing pair_id or precursor_charge metadata" continue
+            @warn "Decoy precursor $decoy_idx missing pair_id or precursor_charge metadata"
+            continue
         end
         partner_key = (UInt32(pair_val), UInt8(charge_val))
 
         if !haskey(partner_lookup, partner_key)
-            @warn "No target partner found for decoy precursor $decoy_idx (pair_id=$(pair_val), charge=$(charge_val))" continue
+            @warn "No target partner found for decoy precursor $decoy_idx (pair_id=$(pair_val), charge=$(charge_val))"
+            continue
         end
 
         target_idx = partner_lookup[partner_key]
-        subdf = get(target_lookup, target_idx, nothing)
-        if subdf === nothing
-            @warn "No fragment predictions found for target precursor $target_idx when duplicating decoy $decoy_idx" continue
+        if !haskey(target_lookup, target_idx)
+            @warn "No fragment predictions found for target precursor $target_idx when duplicating decoy $decoy_idx"
+            continue
         end
 
-        decoy_df = copy(subdf)
+        decoy_df = copy(target_lookup[target_idx])
         decoy_df[!, :precursor_idx] .= decoy_idx
         push!(decoy_fragments, decoy_df)
     end

--- a/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
+++ b/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
@@ -119,10 +119,11 @@ function duplicate_decoy_fragments(
     for idx in target_indices
         pair_val = peptides_df.pair_id[idx]
         charge_val = peptides_df.precursor_charge[idx]
-        if ismissing(pair_val) || ismissing(charge_val)
+        precursor_val = peptides_df.precursor_idx[idx]
+        if ismissing(pair_val) || ismissing(charge_val) || ismissing(precursor_val)
             continue
         end
-        partner_lookup[(UInt32(pair_val), UInt8(charge_val))] = idx
+        partner_lookup[(UInt32(pair_val), UInt8(charge_val))] = UInt32(precursor_val)
     end
 
     decoy_fragments = DataFrame[]
@@ -140,14 +141,20 @@ function duplicate_decoy_fragments(
             continue
         end
 
-        target_idx = partner_lookup[partner_key]
-        if !haskey(target_lookup, target_idx)
-            @warn "No fragment predictions found for target precursor $target_idx when duplicating decoy $decoy_idx"
+        target_precursor = partner_lookup[partner_key]
+        if !haskey(target_lookup, target_precursor)
+            @warn "No fragment predictions found for target precursor $target_precursor when duplicating decoy $decoy_idx"
             continue
         end
 
-        decoy_df = copy(target_lookup[target_idx])
-        decoy_df[!, :precursor_idx] .= decoy_idx
+        precursor_val = peptides_df.precursor_idx[decoy_idx]
+        if ismissing(precursor_val)
+            @warn "Decoy precursor $decoy_idx missing precursor_idx identifier"
+            continue
+        end
+
+        decoy_df = copy(target_lookup[target_precursor])
+        decoy_df[!, :precursor_idx] .= UInt32(precursor_val)
         push!(decoy_fragments, decoy_df)
     end
 

--- a/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
+++ b/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
@@ -83,9 +83,13 @@ function predict_fragments(
 
     target_fragments_df = isempty(target_batches) ? DataFrame() : vcat(target_batches...)
 
+    target_groups = :precursor_idx ∈ names(target_fragments_df) ? groupby(target_fragments_df, :precursor_idx) : nothing
+    target_lookup = target_groups === nothing ? Dict{UInt32, SubDataFrame}() : Dict(UInt32(first(group.precursor_idx)) => group for group in target_groups)
+
     # Duplicate target predictions for decoys using partner mapping
     all_fragments_df = duplicate_decoy_fragments(
         target_fragments_df,
+        target_lookup,
         peptides_df,
         UInt32.(target_idxs),
         UInt32.(decoy_idxs),
@@ -96,6 +100,7 @@ end
 
 function duplicate_decoy_fragments(
     target_fragments_df::DataFrame,
+    target_lookup::Dict{UInt32, SubDataFrame},
     peptides_df::DataFrame,
     target_indices::Vector{UInt32},
     decoy_indices::Vector{UInt32},
@@ -117,7 +122,7 @@ function duplicate_decoy_fragments(
     end
 
     decoy_fragments = DataFrame[]
-    for decoy_idx in decoy_indices
+    for decoy_idx in ProgressBar(decoy_indices)
         pair_val = peptides_df.pair_id[decoy_idx]
         charge_val = peptides_df.precursor_charge[decoy_idx]
         if ismissing(pair_val) || ismissing(charge_val)
@@ -130,12 +135,12 @@ function duplicate_decoy_fragments(
         end
 
         target_idx = partner_lookup[partner_key]
-        target_rows = findall(target_fragments_df.precursor_idx .== target_idx)
-        if isempty(target_rows)
+        subdf = get(target_lookup, target_idx, nothing)
+        if subdf === nothing
             @warn "No fragment predictions found for target precursor $target_idx when duplicating decoy $decoy_idx" continue
         end
 
-        decoy_df = deepcopy(target_fragments_df[target_rows, :])
+        decoy_df = copy(subdf)
         decoy_df[!, :precursor_idx] .= decoy_idx
         push!(decoy_fragments, decoy_df)
     end


### PR DESCRIPTION
## Summary
- build a lookup table for target fragment groups keyed by precursor index
- reuse the lookup to copy fragment predictions for decoys without scanning the table each time
- add a progress bar to surface the status of decoy fragment duplication

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910dff062c88325b8443d011ccb6d48)