### PR TITLE
feat: reuse target fragment predictions for decoys

### DIFF
--- a/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
+++ b/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
@@ -123,9 +123,7 @@ function clone_decoy_fragments(
 
     pair_to_target = Dict{UInt32, UInt32}()
     for (idx, row) in enumerate(eachrow(peptides_df))
-        if hasproperty(row, :pair_id) && !ismissing(row.pair_id) && hasproperty(row, :decoy) && !row.decoy
-            pair_to_target[row.pair_id] = UInt32(idx)
-        end
+        pair_to_target[row.pair_id] = UInt32(idx)
     end
 
     target_groups = Dict{UInt32, DataFrame}()
@@ -159,20 +157,7 @@ function clone_decoy_fragments(
 
     decoy_tables = DataFrame[]
     for (idx, row) in enumerate(eachrow(peptides_df))
-        if !(hasproperty(row, :decoy) && row.decoy)
-            continue
-        end
-
-        if !hasproperty(row, :pair_id) || ismissing(row.pair_id) || !haskey(pair_to_target, row.pair_id)
-            @warn "Skipping decoy without paired target" pair_id=row.pair_id
-            continue
-        end
-
         target_idx = pair_to_target[row.pair_id]
-        if !haskey(target_groups, target_idx)
-            @warn "No fragments available for paired target" pair_id=row.pair_id target_idx=target_idx
-            continue
-        end
 
         frag_df = copy(target_groups[target_idx])
         frag_df[!, :precursor_idx] .= UInt32(idx)
@@ -180,12 +165,12 @@ function clone_decoy_fragments(
         filter_fragments!(frag_df, model_type)
 
         sequence = row.sequence
-        struct_mods = if hasproperty(row, mods_column) && row[mods_column] !== missing
+        struct_mods = if row[mods_column] !== missing
             String(row[mods_column])
         else
             ""
         end
-        iso_mods = if hasproperty(row, iso_column) && row[iso_column] !== missing
+        iso_mods = if row[iso_column] !== missing
             String(row[iso_column])
         else
             ""

--- a/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
+++ b/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
@@ -17,12 +17,188 @@
 
 # src/fragments/fragment_predict.jl
 
+using JSON
+
+"""
+    load_fragment_mod_dictionaries(config_path::String)
+
+Load structural and isotope modification dictionaries from a configuration JSON file.
+"""
+function load_fragment_mod_dictionaries(config_path::String)
+    params = JSON.parsefile(config_path)
+
+    structural_mod_to_mass = Dict{String, Float32}()
+    for (mass, name) in zip(
+        get(params["fixed_mods"], "mass", Float64[]),
+        get(params["fixed_mods"], "name", String[])
+    )
+        structural_mod_to_mass[name] = Float32(mass)
+    end
+
+    if haskey(params, "variable_mods")
+        for (mass, name) in zip(
+            get(params["variable_mods"], "mass", Float64[]),
+            get(params["variable_mods"], "name", String[])
+        )
+            structural_mod_to_mass[name] = Float32(mass)
+        end
+    end
+
+    iso_mods_dict = Dict{String, Dict{String, Float32}}()
+    for mod_group in get(params, "isotope_mod_groups", Any[])
+        name = mod_group["name"]
+        iso_mods_dict[name] = Dict{String, Float32}()
+        for channel in get(mod_group, "channels", Any[])
+            iso_mods_dict[name][channel["channel"]] = Float32(channel["mass"])
+        end
+    end
+
+    if get(params, "channel_decoys", false)
+        for mod_group in get(params, "decoy_isotope_mod_groups", Any[])
+            name = mod_group["name"]
+            dict = get!(iso_mods_dict, name, Dict{String, Float32}())
+            for channel in get(mod_group, "channels", Any[])
+                dict[channel["channel"]] = Float32(channel["mass"])
+            end
+        end
+    end
+
+    mods_to_sulfur_diff = Dict{String, Int8}()
+    for mod_group in get(params, "sulfur_mod_groups", Any[])
+        mods_to_sulfur_diff[mod_group["name"]] = Int8(mod_group["sulfur_count"])
+    end
+
+    return structural_mod_to_mass, iso_mods_dict, mods_to_sulfur_diff
+end
+
+function get_fragment_annotation_info(
+    annotation,
+    model::KoinaModelType,
+    ion_dictionary::Union{Nothing, Dict{Int32, String}},
+    cache::Dict{Any, PioneerFragAnnotation}
+)
+    if haskey(cache, annotation)
+        return cache[annotation]
+    end
+
+    frag_annotation = if model isa SplineCoefficientModel
+        if ion_dictionary === nothing
+            error("Ion dictionary required for spline coefficient models")
+        end
+        ion_name = ion_dictionary[Int32(annotation)]
+        UniSpecFragAnnotation(ion_name)
+    elseif model isa InstrumentSpecificModel
+        UniSpecFragAnnotation(String(annotation))
+    else
+        GenericFragAnnotation(String(annotation))
+    end
+
+    info = parse_fragment_annotation(frag_annotation)
+    cache[annotation] = info
+    return info
+end
+
+function clone_decoy_fragments(
+    peptides_df::DataFrame,
+    target_fragments::DataFrame,
+    model_type::KoinaModelType,
+    config_path::String
+)
+    isempty(target_fragments) && return DataFrame()
+
+    pair_to_target = Dict{UInt32, UInt32}()
+    for (idx, row) in enumerate(eachrow(peptides_df))
+        if hasproperty(row, :pair_id) && !ismissing(row.pair_id) && hasproperty(row, :decoy) && !row.decoy
+            pair_to_target[row.pair_id] = UInt32(idx)
+        end
+    end
+
+    target_groups = Dict{UInt32, DataFrame}()
+    if !isempty(target_fragments)
+        for subdf in groupby(target_fragments, :precursor_idx)
+            pid = first(subdf.precursor_idx)
+            target_groups[pid] = DataFrame(subdf)
+        end
+    end
+
+    structural_mod_to_mass, iso_mods_dict, _ = load_fragment_mod_dictionaries(config_path)
+
+    ion_dictionary = nothing
+    if model_type isa SplineCoefficientModel
+        ion_dictionary = get_altimeter_ion_dict(joinpath(@__DIR__, "..", "..", "..", "..", "assets", "ion_dictionary.txt"))
+    end
+
+    aa_masses = zeros(Float32, 255)
+    structural_mod_masses = zeros(Float32, 255)
+    iso_mod_masses = zeros(Float32, 255)
+    annotation_cache = Dict{Any, PioneerFragAnnotation}()
+
+    mods_column = hasproperty(peptides_df, :mods) ? :mods : :structural_mods
+    iso_column = hasproperty(peptides_df, :isotope_mods) ? :isotope_mods : :isotopic_mods
+
+    decoy_tables = DataFrame[]
+    for (idx, row) in enumerate(eachrow(peptides_df))
+        if !(hasproperty(row, :decoy) && row.decoy)
+            continue
+        end
+
+        if !hasproperty(row, :pair_id) || ismissing(row.pair_id) || !haskey(pair_to_target, row.pair_id)
+            @warn "Skipping decoy without paired target" pair_id=row.pair_id
+            continue
+        end
+
+        target_idx = pair_to_target[row.pair_id]
+        if !haskey(target_groups, target_idx)
+            @warn "No fragments available for paired target" pair_id=row.pair_id target_idx=target_idx
+            continue
+        end
+
+        frag_df = copy(target_groups[target_idx])
+        frag_df[!, :precursor_idx] .= UInt32(idx)
+
+        sequence = row.sequence
+        struct_mods = if hasproperty(row, mods_column) && row[mods_column] !== missing
+            String(row[mods_column])
+        else
+            ""
+        end
+        iso_mods = if hasproperty(row, iso_column) && row[iso_column] !== missing
+            String(row[iso_column])
+        else
+            ""
+        end
+
+        get_aa_masses!(aa_masses, sequence)
+        get_structural_mod_masses!(structural_mod_masses, struct_mods, structural_mod_to_mass)
+        getIsoModMasses!(iso_mod_masses, struct_mods, iso_mods, iso_mods_dict)
+        seq_length = UInt8(length(sequence))
+
+        for frag_row in eachrow(frag_df)
+            info = get_fragment_annotation_info(frag_row.annotation, model_type, ion_dictionary, annotation_cache)
+            start_idx, stop_idx = get_fragment_indices(info.base_type, info.frag_index, seq_length)
+            frag_row.mz = get_fragment_mz(
+                start_idx,
+                stop_idx,
+                info.base_type,
+                info.charge,
+                aa_masses,
+                structural_mod_masses,
+                iso_mod_masses
+            )
+        end
+
+        push!(decoy_tables, frag_df)
+    end
+
+    return isempty(decoy_tables) ? DataFrame() : vcat(decoy_tables...)
+end
+
 """
     predict_fragments(
         peptide_table_path::String,
         frags_out_path::String,
         model_type::KoinaModelType,
-        instrument_type::String, 
+        instrument_type::String,
         max_koina_batches::Int,
         batch_size::Int,
         model_name::String;
@@ -41,47 +217,57 @@ function predict_fragments(
     model_name::String;
     intensity_threshold::Float32 = 0.001f0
 )
-    # Verify model configuration
     if !haskey(KOINA_URLS, model_name)
         error("Invalid model name: $model_name. Valid options: $(join(keys(KOINA_URLS), ", "))")
     end
 
-    # Load data
     peptides_df = DataFrame(Arrow.Table(peptide_table_path))
+    decoy_mask = hasproperty(peptides_df, :decoy) ? peptides_df.decoy : falses(nrow(peptides_df))
+    target_rows = findall(!, decoy_mask)
 
-    # Process in batches
+    if isempty(target_rows)
+        @warn "No target precursors available for fragment prediction."
+        Arrow.write(frags_out_path, DataFrame())
+        return
+    end
+
+    target_df = peptides_df[target_rows, :]
+    target_precursor_indices = UInt32.(target_rows)
+
     koina_pool_size = max_koina_batches * 5
-    nprecs = nrow(peptides_df)
     batch_size = min(batch_size, 1000)
-    batch_start_idxs = collect(one(UInt32):UInt32(batch_size*koina_pool_size):UInt32(nprecs))
+    n_targets = length(target_rows)
+    batch_start_idxs = collect(1:batch_size*koina_pool_size:n_targets)
 
     rm(frags_out_path, force=true)
-    
+
+    target_batches = DataFrame[]
     for start_idx in ProgressBar(batch_start_idxs)
-        stop_idx = min(start_idx + batch_size*koina_pool_size - 1, nrow(peptides_df))
-        batch_df = peptides_df[start_idx:stop_idx, :]
-        
-        # Generate predictions for batch
+        stop_idx = min(start_idx + batch_size*koina_pool_size - 1, n_targets)
+        batch_df = target_df[start_idx:stop_idx, :]
+        batch_indices = target_precursor_indices[start_idx:stop_idx]
+
         frags_out = predict_fragments_batch(
             batch_df,
             model_type,
             instrument_type,
             batch_size,
             max_koina_batches,
-            start_idx,
-            
+            batch_indices,
         )
 
-        # Write or append results
-        if start_idx == 1
-            # Create file in stream format to support appending
-            open(frags_out_path, "w") do io
-                Arrow.write(io, frags_out; file=false)  # file=false creates stream format
-            end
-        else
-            Arrow.append(frags_out_path, frags_out)
-        end
+        push!(target_batches, frags_out)
     end
+
+    target_fragments = isempty(target_batches) ? DataFrame() : vcat(target_batches...)
+
+    config_path = joinpath(dirname(frags_out_path), "config.json")
+    decoy_fragments = clone_decoy_fragments(peptides_df, target_fragments, model_type, config_path)
+
+    fragments_df = isempty(decoy_fragments) ? target_fragments : vcat(target_fragments, decoy_fragments)
+    sort_fragments!(fragments_df)
+
+    Arrow.write(frags_out_path, fragments_df; file=false)
 end
 
 """
@@ -93,7 +279,7 @@ function predict_fragments_batch(
     instrument_type::String,
     batch_size::Int,
     concurrent_koina_requests::Int,
-    first_prec_idx::UInt32
+    precursor_indices::AbstractVector{UInt32}
 )::DataFrame
     # Verify instrument compatibility
     if instrument_type ∉ MODEL_CONFIGS[model.name].instruments
@@ -113,13 +299,12 @@ function predict_fragments_batch(
     batch_dfs = []
     for (i, response) in enumerate(responses)
         batch_result = parse_koina_batch(model, response)
-        start_idx = (i-1) * batch_size + 1 + first_prec_idx - 1
-        
-        # Add precursor indices
+        start_idx = (i-1) * batch_size + 1
+        stop_idx = min(i * batch_size, length(precursor_indices))
+        batch_precursor_idxs = precursor_indices[start_idx:stop_idx]
+
         batch_df = batch_result.fragments
-        n_precursors_in_batch = UInt32(fld(size( batch_df , 1), batch_result.frags_per_precursor))
-        batch_df[!, :precursor_idx] = repeat(start_idx:(start_idx + n_precursors_in_batch - one(UInt32)), 
-                                                inner=batch_result.frags_per_precursor)
+        batch_df[!, :precursor_idx] = repeat(batch_precursor_idxs, inner=batch_result.frags_per_precursor)
         # Filter and sort fragments
         filter_fragments!(batch_df, model)
         push!(batch_dfs, batch_df)
@@ -142,7 +327,7 @@ function predict_fragments_batch(
     _::String,  # instrument type not used
     batch_size::Int,
     concurrent_koina_requests::Int,
-    first_prec_idx::UInt32
+    precursor_indices::AbstractVector{UInt32}
 )::DataFrame
     # Prepare batches (no instrument type needed)
     json_batches = prepare_koina_batch(
@@ -158,13 +343,12 @@ function predict_fragments_batch(
     batch_dfs = []
     for (i, response) in enumerate(responses)
         batch_result = parse_koina_batch(model, response)
-        start_idx = (i-1) * batch_size + 1 + first_prec_idx - 1
-        
-        # Add precursor indices
+        start_idx = (i-1) * batch_size + 1
+        stop_idx = min(i * batch_size, length(precursor_indices))
+        batch_precursor_idxs = precursor_indices[start_idx:stop_idx]
+
         batch_df = batch_result.fragments
-        n_precursors_in_batch = UInt32(fld(size( batch_df , 1), batch_result.frags_per_precursor))
-        batch_df[!, :precursor_idx] = repeat(start_idx:(start_idx + n_precursors_in_batch - one(UInt32)), 
-                                                inner=batch_result.frags_per_precursor)
+        batch_df[!, :precursor_idx] = repeat(batch_precursor_idxs, inner=batch_result.frags_per_precursor)
         # Filter and sort fragments
         filter_fragments!(batch_df, model)
         push!(batch_dfs, batch_df)
@@ -185,7 +369,7 @@ function predict_fragments_batch(
     instrument_type::String,
     batch_size::Int,
     concurrent_koina_requests::Int,
-    first_prec_idx::UInt32
+    precursor_indices::AbstractVector{UInt32}
 )::DataFrame
     # Similar to InstrumentSpecificModel but handles spline coefficients
     json_batches = prepare_koina_batch(
@@ -202,12 +386,12 @@ function predict_fragments_batch(
     
     for (i, response) in enumerate(responses)
         batch_result = parse_koina_batch(model, response)
-        start_idx = (i-1) * batch_size + 1 + first_prec_idx - 1
-        
+        start_idx = (i-1) * batch_size + 1
+        stop_idx = min(i * batch_size, length(precursor_indices))
+        batch_precursor_idxs = precursor_indices[start_idx:stop_idx]
+
         batch_df = batch_result.fragments
-        n_precursors_in_batch = UInt32(fld(size( batch_df , 1), batch_result.frags_per_precursor))
-        batch_df[!, :precursor_idx] = repeat(start_idx:(start_idx + n_precursors_in_batch - one(UInt32)), 
-                                                inner=batch_result.frags_per_precursor)
+        batch_df[!, :precursor_idx] = repeat(batch_precursor_idxs, inner=batch_result.frags_per_precursor)
         filter_fragments!(batch_df, model)
         push!(batch_dfs, batch_df)
         push!(knot_vectors, batch_result.extra_data)  # Store knot vectors

--- a/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
+++ b/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
@@ -227,10 +227,14 @@ function clone_decoy_fragments(
         end
 
         if nrow(frag_df) > max_allowed
-            if hasproperty(frag_df, :intensities)
-                order = sortperm(frag_df.intensities; rev=true)
+            order = if hasproperty(frag_df, :intensities)
+                sortperm(frag_df.intensities; rev=true)
+            elseif hasproperty(frag_df, :ranking)
+                sortperm(frag_df.ranking)
+            elseif hasproperty(frag_df, :rank)
+                sortperm(frag_df.rank)
             else
-                order = collect(1:nrow(frag_df))
+                collect(1:nrow(frag_df))
             end
             order = order[1:max_allowed]
             frag_df = frag_df[order, :]
@@ -508,6 +512,23 @@ end
 Sort fragments by intensity within each precursor group.
 """
 function sort_fragments!(df::DataFrame)
-    sort!(df, [:precursor_idx, order(:intensities, rev=true)])
+    nrow(df) <= 1 && return df
+
+    if hasproperty(df, :intensities)
+        sort!(df, [:precursor_idx, order(:intensities, rev=true)])
+        return df
+    elseif hasproperty(df, :ranking)
+        sort!(df, [:precursor_idx, :ranking])
+        return df
+    elseif hasproperty(df, :rank)
+        sort!(df, [:precursor_idx, :rank])
+        return df
+    end
+
+    tmp_col = gensym(:frag_order)
+    df[!, tmp_col] = collect(1:nrow(df))
+    sort!(df, [:precursor_idx, tmp_col])
+    select!(df, filter(col -> col != tmp_col, names(df)))
+    return df
 end
 

--- a/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
+++ b/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
@@ -22,7 +22,8 @@ using JSON
 """
     load_fragment_mod_dictionaries(config_path::String)
 
-Load structural and isotope modification dictionaries from a configuration JSON file.
+Load structural and isotope modification dictionaries from a configuration JSON file and
+return the fragment filtering parameters required for decoy cloning.
 """
 function load_fragment_mod_dictionaries(config_path::String)
     params = JSON.parsefile(config_path)
@@ -68,7 +69,17 @@ function load_fragment_mod_dictionaries(config_path::String)
         mods_to_sulfur_diff[mod_group["name"]] = Int8(mod_group["sulfur_count"])
     end
 
-    return structural_mod_to_mass, iso_mods_dict, mods_to_sulfur_diff
+    library_params = get(params, "library_params", Dict{String, Any}())
+    include_immonium = get(library_params, "include_immonium", true)
+    max_frag_rank = Int(get(library_params, "max_frag_rank", 255))
+    length_to_frag_count_multiple = Float32(get(library_params, "length_to_frag_count_multiple", 255))
+
+    return structural_mod_to_mass,
+           iso_mods_dict,
+           mods_to_sulfur_diff,
+           include_immonium,
+           max_frag_rank,
+           length_to_frag_count_multiple
 end
 
 function get_fragment_annotation_info(
@@ -125,7 +136,12 @@ function clone_decoy_fragments(
         end
     end
 
-    structural_mod_to_mass, iso_mods_dict, _ = load_fragment_mod_dictionaries(config_path)
+    structural_mod_to_mass,
+    iso_mods_dict,
+    _,
+    include_immonium,
+    max_frag_rank,
+    length_to_frag_count_multiple = load_fragment_mod_dictionaries(config_path)
     immonium_to_sulfur_count = get_immonium_sulfur_dict(asset_path("immonium.txt"))
 
     ion_dictionary = nothing
@@ -161,6 +177,8 @@ function clone_decoy_fragments(
         frag_df = copy(target_groups[target_idx])
         frag_df[!, :precursor_idx] .= UInt32(idx)
 
+        filter_fragments!(frag_df, model_type)
+
         sequence = row.sequence
         struct_mods = if hasproperty(row, mods_column) && row[mods_column] !== missing
             String(row[mods_column])
@@ -178,7 +196,9 @@ function clone_decoy_fragments(
         getIsoModMasses!(iso_mod_masses, struct_mods, iso_mods, iso_mods_dict)
         seq_length = UInt8(length(sequence))
 
-        for frag_row in eachrow(frag_df)
+        keep_rows = Int[]
+        frag_infos = PioneerFragAnnotation[]
+        for (row_idx, frag_row) in enumerate(eachrow(frag_df))
             info = get_fragment_annotation_info(
                 frag_row.annotation,
                 model_type,
@@ -186,6 +206,38 @@ function clone_decoy_fragments(
                 annotation_cache,
                 immonium_to_sulfur_count,
             )
+            if info.immonium && !include_immonium
+                continue
+            end
+            push!(keep_rows, row_idx)
+            push!(frag_infos, info)
+        end
+
+        isempty(keep_rows) && continue
+
+        frag_df = frag_df[keep_rows, :]
+
+        max_allowed = min(
+            max_frag_rank,
+            round(Int, seq_length * length_to_frag_count_multiple) + 1,
+        )
+
+        if max_allowed <= 0
+            continue
+        end
+
+        if nrow(frag_df) > max_allowed
+            if hasproperty(frag_df, :intensities)
+                order = sortperm(frag_df.intensities; rev=true)
+            else
+                order = collect(1:nrow(frag_df))
+            end
+            order = order[1:max_allowed]
+            frag_df = frag_df[order, :]
+            frag_infos = frag_infos[order]
+        end
+
+        for (frag_row, info) in zip(eachrow(frag_df), frag_infos)
             start_idx, stop_idx = get_fragment_indices(info.base_type, info.frag_index, seq_length)
             frag_row.mz = get_fragment_mz(
                 start_idx,

--- a/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
+++ b/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
@@ -75,7 +75,8 @@ function get_fragment_annotation_info(
     annotation,
     model::KoinaModelType,
     ion_dictionary::Union{Nothing, Dict{Int32, String}},
-    cache::Dict{Any, PioneerFragAnnotation}
+    cache::Dict{Any, PioneerFragAnnotation},
+    immonium_to_sulfur_count::Dict{String, Int8} = Dict{String, Int8}()
 )
     if haskey(cache, annotation)
         return cache[annotation]
@@ -93,7 +94,10 @@ function get_fragment_annotation_info(
         GenericFragAnnotation(String(annotation))
     end
 
-    info = parse_fragment_annotation(frag_annotation)
+    info = parse_fragment_annotation(
+        frag_annotation;
+        immonium_to_sulfur_count=immonium_to_sulfur_count,
+    )
     cache[annotation] = info
     return info
 end
@@ -122,6 +126,7 @@ function clone_decoy_fragments(
     end
 
     structural_mod_to_mass, iso_mods_dict, _ = load_fragment_mod_dictionaries(config_path)
+    immonium_to_sulfur_count = get_immonium_sulfur_dict(asset_path("immonium.txt"))
 
     ion_dictionary = nothing
     if model_type isa SplineCoefficientModel
@@ -174,7 +179,13 @@ function clone_decoy_fragments(
         seq_length = UInt8(length(sequence))
 
         for frag_row in eachrow(frag_df)
-            info = get_fragment_annotation_info(frag_row.annotation, model_type, ion_dictionary, annotation_cache)
+            info = get_fragment_annotation_info(
+                frag_row.annotation,
+                model_type,
+                ion_dictionary,
+                annotation_cache,
+                immonium_to_sulfur_count,
+            )
             start_idx, stop_idx = get_fragment_indices(info.base_type, info.frag_index, seq_length)
             frag_row.mz = get_fragment_mz(
                 start_idx,

--- a/test/Routines/BuildSpecLib/fragments/test_fragment_predict.jl
+++ b/test/Routines/BuildSpecLib/fragments/test_fragment_predict.jl
@@ -1,4 +1,6 @@
 
+using JSON
+
 @testset "Fragment Predict Tests" begin
     
     @testset "Model Type Validation" begin
@@ -98,7 +100,7 @@
             intensities = Float32[0.5, 0.9, 0.7, 0.3, 0.8, 0.6],
             mz = Float32[300.1, 400.2, 500.3, 200.1, 350.2, 450.3]
         )
-        
+
         sort_fragments!(df)
         
         # Check that within each precursor, fragments are sorted by intensity (descending)
@@ -176,7 +178,67 @@
         
         rm(temp_dir, recursive=true)
     end
-    
+
+    @testset "clone_decoy_fragments" begin
+        temp_dir = mktempdir()
+        config_path = joinpath(temp_dir, "config.json")
+        config = Dict(
+            "fixed_mods" => Dict("mass" => Float64[], "name" => String[]),
+            "variable_mods" => Dict("mass" => Float64[], "name" => String[]),
+            "isotope_mod_groups" => Any[],
+            "channel_decoys" => false,
+            "sulfur_mod_groups" => Any[]
+        )
+        open(config_path, "w") do io
+            write(io, JSON.json(config))
+        end
+
+        peptides_df = DataFrame(
+            sequence = ["PEPTIDE", "PEPTIDA"],
+            mods = ["", ""],
+            isotope_mods = ["", ""],
+            decoy = [false, true],
+            pair_id = UInt32[1, 1]
+        )
+
+        target_fragments = DataFrame(
+            annotation = ["y2"],
+            mz = Float32[400.0],
+            intensities = Float32[0.8],
+            precursor_idx = UInt32[1]
+        )
+
+        model = InstrumentSpecificModel("unispec")
+        decoy_frags = clone_decoy_fragments(peptides_df, target_fragments, model, config_path)
+
+        @test nrow(decoy_frags) == 1
+        @test decoy_frags.precursor_idx == [UInt32(2)]
+        @test decoy_frags.intensities == target_fragments.intensities
+
+        aa_masses = zeros(Float32, 255)
+        structural_mod_masses = zeros(Float32, 255)
+        iso_mod_masses = zeros(Float32, 255)
+        sequence = peptides_df.sequence[2]
+        get_aa_masses!(aa_masses, sequence)
+        get_structural_mod_masses!(structural_mod_masses, "", Dict{String, Float32}())
+        getIsoModMasses!(iso_mod_masses, "", "", Dict{String, Dict{String, Float32}}())
+        info = parse_fragment_annotation(UniSpecFragAnnotation("y2"))
+        start_idx, stop_idx = get_fragment_indices(info.base_type, info.frag_index, UInt8(length(sequence)))
+        expected_mz = get_fragment_mz(
+            start_idx,
+            stop_idx,
+            info.base_type,
+            info.charge,
+            aa_masses,
+            structural_mod_masses,
+            iso_mod_masses
+        )
+
+        @test isapprox(decoy_frags.mz[1], expected_mz; atol=1e-5)
+
+        rm(temp_dir, recursive=true)
+    end
+
     @testset "predict_fragments - main dispatcher" begin
         temp_dir = mktempdir()
         

--- a/test/Routines/BuildSpecLib/fragments/test_fragment_predict.jl
+++ b/test/Routines/BuildSpecLib/fragments/test_fragment_predict.jl
@@ -182,15 +182,20 @@ using JSON
     @testset "clone_decoy_fragments" begin
         temp_dir = mktempdir()
         config_path = joinpath(temp_dir, "config.json")
-        config = Dict(
+        base_config = Dict(
             "fixed_mods" => Dict("mass" => Float64[], "name" => String[]),
             "variable_mods" => Dict("mass" => Float64[], "name" => String[]),
             "isotope_mod_groups" => Any[],
             "channel_decoys" => false,
-            "sulfur_mod_groups" => Any[]
+            "sulfur_mod_groups" => Any[],
+            "library_params" => Dict(
+                "include_immonium" => false,
+                "max_frag_rank" => 50,
+                "length_to_frag_count_multiple" => 2.0,
+            ),
         )
         open(config_path, "w") do io
-            write(io, JSON.json(config))
+            write(io, JSON.json(base_config))
         end
 
         peptides_df = DataFrame(
@@ -211,10 +216,10 @@ using JSON
         model = InstrumentSpecificModel("unispec")
         decoy_frags = clone_decoy_fragments(peptides_df, target_fragments, model, config_path)
 
-        @test nrow(decoy_frags) == 2
+        @test nrow(decoy_frags) == 1
         @test all(decoy_frags.precursor_idx .== UInt32(2))
-        @test decoy_frags.intensities == target_fragments.intensities
-        @test decoy_frags.annotation == target_fragments.annotation
+        @test decoy_frags.intensities == Float32[0.8]
+        @test decoy_frags.annotation == ["y2"]
 
         aa_masses = zeros(Float32, 255)
         structural_mod_masses = zeros(Float32, 255)
@@ -239,9 +244,36 @@ using JSON
         @test y2_idx !== nothing
         @test isapprox(decoy_frags.mz[y2_idx], expected_mz; atol=1e-5)
 
-        ih_idx = findfirst(==("IH"), decoy_frags.annotation)
-        @test ih_idx !== nothing
-        @test isfinite(decoy_frags.mz[ih_idx])
+        @test all(!=("IH"), decoy_frags.annotation)
+
+        # Re-run with immonium enabled
+        include_config = deepcopy(base_config)
+        include_config["library_params"]["include_immonium"] = true
+        open(config_path, "w") do io
+            write(io, JSON.json(include_config))
+        end
+
+        decoy_frags = clone_decoy_fragments(peptides_df, target_fragments, model, config_path)
+        @test nrow(decoy_frags) == 2
+        @test "IH" in decoy_frags.annotation
+
+        # Limit the requested number of ions
+        rank_limited_config = deepcopy(include_config)
+        rank_limited_config["library_params"]["max_frag_rank"] = 1
+        open(config_path, "w") do io
+            write(io, JSON.json(rank_limited_config))
+        end
+
+        rich_target = DataFrame(
+            annotation = ["y2", "b3", "a1"],
+            mz = Float32[400.0, 320.0, 210.0],
+            intensities = Float32[0.8, 0.5, 0.3],
+            precursor_idx = UInt32[1, 1, 1],
+        )
+
+        limited_frags = clone_decoy_fragments(peptides_df, rich_target, model, config_path)
+        @test nrow(limited_frags) == 1
+        @test limited_frags.annotation == ["y2"]
 
         rm(temp_dir, recursive=true)
     end

--- a/test/Routines/BuildSpecLib/fragments/test_fragment_predict.jl
+++ b/test/Routines/BuildSpecLib/fragments/test_fragment_predict.jl
@@ -102,17 +102,35 @@ using JSON
         )
 
         sort_fragments!(df)
-        
+
         # Check that within each precursor, fragments are sorted by intensity (descending)
         @test df.precursor_idx == [1, 1, 1, 2, 2, 2]
-        
+
         # For precursor 1
         prec1_mask = df.precursor_idx .== 1
         @test issorted(df[prec1_mask, :intensities], rev=true)
-        
+
         # For precursor 2
         prec2_mask = df.precursor_idx .== 2
         @test issorted(df[prec2_mask, :intensities], rev=true)
+
+        coef_df = DataFrame(
+            precursor_idx = UInt32[1, 1, 2, 2],
+            annotation = Int32[10, 11, 20, 21],
+            coefficients = [
+                (0.1f0, 0.2f0),
+                (0.3f0, 0.4f0),
+                (0.5f0, 0.6f0),
+                (0.7f0, 0.8f0),
+            ],
+            ranking = UInt8[2, 1, 2, 1],
+            mz = Float32[100.0, 101.0, 200.0, 201.0],
+        )
+
+        sort_fragments!(coef_df)
+
+        @test coef_df.precursor_idx == UInt32[1, 1, 2, 2]
+        @test coef_df.ranking == UInt8[1, 2, 1, 2]
     end
     
     @testset "predict_fragments_batch" begin

--- a/test/Routines/BuildSpecLib/fragments/test_fragment_predict.jl
+++ b/test/Routines/BuildSpecLib/fragments/test_fragment_predict.jl
@@ -202,18 +202,19 @@ using JSON
         )
 
         target_fragments = DataFrame(
-            annotation = ["y2"],
-            mz = Float32[400.0],
-            intensities = Float32[0.8],
-            precursor_idx = UInt32[1]
+            annotation = ["y2", "IH"],
+            mz = Float32[400.0, 110.0],
+            intensities = Float32[0.8, 0.2],
+            precursor_idx = UInt32[1, 1]
         )
 
         model = InstrumentSpecificModel("unispec")
         decoy_frags = clone_decoy_fragments(peptides_df, target_fragments, model, config_path)
 
-        @test nrow(decoy_frags) == 1
-        @test decoy_frags.precursor_idx == [UInt32(2)]
+        @test nrow(decoy_frags) == 2
+        @test all(decoy_frags.precursor_idx .== UInt32(2))
         @test decoy_frags.intensities == target_fragments.intensities
+        @test decoy_frags.annotation == target_fragments.annotation
 
         aa_masses = zeros(Float32, 255)
         structural_mod_masses = zeros(Float32, 255)
@@ -234,7 +235,13 @@ using JSON
             iso_mod_masses
         )
 
-        @test isapprox(decoy_frags.mz[1], expected_mz; atol=1e-5)
+        y2_idx = findfirst(==("y2"), decoy_frags.annotation)
+        @test y2_idx !== nothing
+        @test isapprox(decoy_frags.mz[y2_idx], expected_mz; atol=1e-5)
+
+        ih_idx = findfirst(==("IH"), decoy_frags.annotation)
+        @test ih_idx !== nothing
+        @test isfinite(decoy_frags.mz[ih_idx])
 
         rm(temp_dir, recursive=true)
     end


### PR DESCRIPTION
## Summary
- reuse target fragment predictions for decoys by cloning target batches and recomputing fragment m/z values with configuration masses
- update fragment batch helpers to carry explicit precursor indices for target-only Koina requests
- add a unit test covering the decoy cloning helper

## Testing
- not run (Julia executable unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69110b585bc08325a85844de17e5f1a2)