### PR TITLE
feat: include predicted retention times in precursor exports

### DIFF
--- a/src/Routines/BuildSpecLib.jl
+++ b/src/Routines/BuildSpecLib.jl
@@ -312,6 +312,9 @@ function BuildSpecLib(params_path::String)
                 precursors_table[!, :prec_charge] = UInt8.(precursors_table[!, :prec_charge])
                 precursors_table[!, :mz] = Float32.(precursors_table[!, :mz])
                 precursors_table[!, :irt] = Float32.(precursors_table[!, :irt])
+                if hasproperty(precursors_table, :predicted_rt)
+                    precursors_table[!, :predicted_rt] = Float32.(precursors_table[!, :predicted_rt])
+                end
                 precursors_table[!, :start_idx] = UInt32.(precursors_table[!, :start_idx])
 
                 # Save processed precursor table

--- a/src/Routines/BuildSpecLib/chronologer/chronologer_parse.jl
+++ b/src/Routines/BuildSpecLib/chronologer/chronologer_parse.jl
@@ -78,6 +78,19 @@ function parse_chronologer_output(
     end
     # Read chronologer output
     precursors_df = DataFrame(Tables.columntable(Arrow.Table(path_to_precursors)))
+
+    # Preserve the raw Chronologer predictions before renaming columns.
+    # Chronologer currently returns a single `rt` column with the predicted
+    # retention time in iRT space.  Downstream consumers have historically
+    # expected this information under the `:irt` column, so we keep that
+    # behaviour while also exposing the raw prediction explicitly via a new
+    # `:predicted_rt` column.
+    if hasproperty(precursors_df, :rt)
+        precursors_df[!, :predicted_rt] = Float32.(precursors_df[!, :rt])
+    else
+        precursors_df[!, :predicted_rt] = fill(Float32(NaN), nrow(precursors_df))
+    end
+
     # Rename columns to match Pioneer format
     rename!(precursors_df, Dict(
         :rt => :irt,

--- a/src/structs/LibraryIon.jl
+++ b/src/structs/LibraryIon.jl
@@ -757,6 +757,12 @@ getMz(lp::LibraryPrecursors)::Arrow.Primitive{Float32, Vector{Float32}}  = lp.da
 getLength(lp::LibraryPrecursors)::Arrow.Primitive{UInt8, Vector{UInt8}}  = lp.data[:length]
 getMissedCleavages(lp::LibraryPrecursors)::Arrow.Primitive{UInt8, Vector{UInt8}} = lp.data[:missed_cleavages]
 getIrt(lp::LibraryPrecursors)::Arrow.Primitive{Float32, Vector{Float32}} = lp.data[:irt]
+function getPredictedRt(lp::LibraryPrecursors)
+    if :predicted_rt in propertynames(lp.data)
+        return lp.data[:predicted_rt]
+    end
+    return lp.data[:irt]
+end
 getSulfurCount(lp::LibraryPrecursors)::Arrow.Primitive{UInt8, Vector{UInt8}} = lp.data[:sulfur_count]
 getIsotopicMods(lp::LibraryPrecursors)::Arrow.List{Union{Missing, String}, Int32, Vector{UInt8}} = lp.data[:isotopic_mods]
 getPartnerPrecursorIdx(lp::LibraryPrecursors)::Arrow.Primitive{Union{Missing, I}, Vector{I}} where {I<:Integer} = lp.data[:partner_precursor_idx]

--- a/test/Routines/BuildSpecLib/test_build_spec_lib.jl
+++ b/test/Routines/BuildSpecLib/test_build_spec_lib.jl
@@ -284,7 +284,9 @@ function verify_library_structure(lib_dir::String)
     # Check for essential files
     precursors_file = joinpath(lib_dir, "precursors_table.arrow")
     @test isfile(precursors_file)
-    
+    precursors_table = Arrow.Table(precursors_file)
+    @test :predicted_rt in propertynames(precursors_table)
+
     config_file = joinpath(lib_dir, "config.json")
     @test isfile(config_file)
     


### PR DESCRIPTION
## Summary
- persist Chronologer predicted retention times when parsing precursor data
- carry the predicted_rt column into the processed precursor table and expose it via LibraryPrecursors
- extend the BuildSpecLib integration test to assert the new column is present

## Testing
- not run (Julia binary unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69120414bfa48325911a2ce05d162653)