### PR TITLE
Add predicted RT column to precursor outputs

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
@@ -692,6 +692,45 @@ function summarize_results!(
         end
         #@debug_l1 "Step 11 completed in $(round(step11_time, digits=2)) seconds"
 
+        # Convert calibrated predicted iRT values into RT space for downstream outputs
+        irt_to_rt_models = getIrtRtMap(search_context)
+        identity_model = IdentityModel()
+        predicted_rt_fn = function (df::DataFrame)
+            n = nrow(df)
+            result = Vector{Union{Missing, Float32}}(undef, n)
+
+            if !(hasproperty(df, :ms_file_idx) && hasproperty(df, :irt_pred))
+                fill!(result, missing)
+                return result
+            end
+
+            ms_idx_col = df.ms_file_idx
+            irt_pred_col = df.irt_pred
+
+            @inbounds for i in 1:n
+                irt_val = irt_pred_col[i]
+                if ismissing(irt_val)
+                    result[i] = missing
+                    continue
+                end
+
+                ms_idx = ms_idx_col[i]
+                if ismissing(ms_idx)
+                    result[i] = missing
+                    continue
+                end
+
+                model = get(irt_to_rt_models, Int(ms_idx), identity_model)
+                result[i] = Float32(model(Float32(irt_val)))
+            end
+
+            return result
+        end
+
+        for ref in passing_refs
+            add_column_to_file!(ref, :predicted_rt, predicted_rt_fn)
+        end
+
         # Update search context with passing PSM paths
         for (file_idx, ref) in zip(valid_file_indices, passing_refs)
             setPassingPsms!(getMSData(search_context), file_idx, file_path(ref))

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
@@ -699,11 +699,6 @@ function summarize_results!(
             n = nrow(df)
             result = Vector{Union{Missing, Float32}}(undef, n)
 
-            if !(hasproperty(df, :ms_file_idx) && hasproperty(df, :irt_pred))
-                fill!(result, missing)
-                return result
-            end
-
             ms_idx_col = df.ms_file_idx
             irt_pred_col = df.irt_pred
 

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
@@ -695,6 +695,21 @@ function summarize_results!(
         # Convert calibrated predicted iRT values into RT space for downstream outputs
         irt_to_rt_models = getIrtRtMap(search_context)
         identity_model = IdentityModel()
+
+        convert_to_union_float32 = function (column::AbstractVector)
+            n = length(column)
+            result = Vector{Union{Missing, Float32}}(undef, n)
+            @inbounds for i in 1:n
+                value = column[i]
+                if ismissing(value)
+                    result[i] = missing
+                else
+                    result[i] = Float32(value)
+                end
+            end
+            return result
+        end
+
         predicted_rt_fn = function (df::DataFrame)
             n = nrow(df)
             result = Vector{Union{Missing, Float32}}(undef, n)
@@ -722,7 +737,12 @@ function summarize_results!(
             return result
         end
 
+        observed_irt_fn = df -> convert_to_union_float32(df.irt_obs)
+        predicted_irt_fn = df -> convert_to_union_float32(df.irt_pred)
+
         for ref in passing_refs
+            add_column_to_file!(ref, :observed_irt, observed_irt_fn)
+            add_column_to_file!(ref, :predicted_irt, predicted_irt_fn)
             add_column_to_file!(ref, :predicted_rt, predicted_rt_fn)
         end
 

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
@@ -508,6 +508,7 @@ function get_quant_necessary_columns(match_between_runs::Bool)
         :weight,
         :target,
         :rt,
+        :irt_pred,
         :irt_obs,
         :missed_cleavage,
         :Mox,

--- a/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
+++ b/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
@@ -260,6 +260,8 @@ function writePrecursorCSV(
         :precursor_fraction_transmitted,
         :isotopes_captured,
         :rt,
+        :observed_irt,
+        :predicted_irt,
         :predicted_rt,
         :apex_scan,
         :global_pg_score,

--- a/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
+++ b/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
@@ -260,6 +260,7 @@ function writePrecursorCSV(
         :precursor_fraction_transmitted,
         :isotopes_captured,
         :rt,
+        :predicted_rt,
         :apex_scan,
         :global_pg_score,
         :pg_score,


### PR DESCRIPTION
## Summary
- convert calibrated predicted iRT values into RTs for each passing PSM file
- include the predicted RT column in the precursor long-form exports

## Testing
- `julia --project -e 'using Pioneer; println("Pioneer loaded")'` *(fails: `julia` command not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69120a8ac860832591417669fd769f7f)