### PR TITLE
feat: refine precursor selection for shared library

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -301,9 +301,14 @@ function process_file!(
             search_context::SearchContext
         )
             fdr_scale_factor = getLibraryFdrScaleFactor(search_context)
+            precursors = getPrecursors(getSpecLib(search_context))
+            sequences = getSequence(precursors)
+            structural_mods = getStructuralMods(precursors)
             get_best_psms!(
                 psms,
                 precursor_mzs,
+                sequences,
+                structural_mods,
                 max_PEP=params.max_PEP,
                 fdr_scale_factor=fdr_scale_factor
             )
@@ -640,24 +645,12 @@ function summarize_results!(
             return Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_irt::Float32, mean_irt::Union{Missing, Float32}, var_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32}}()
         end
         
-        precursors = getPrecursors(getSpecLib(search_context))
-        prec_mzs = getMz(precursors)
-        is_decoy = getIsDecoy(precursors)
-        sequences = getSequence(precursors)
-        structural_mods = getStructuralMods(precursors)
-        fdr_scale_factor = getLibraryFdrScaleFactor(search_context)
-
         # Get best precursors from valid files only
         return get_best_precursors_accross_runs(
             valid_psms_paths,
-            prec_mzs,#[:mz],
+            getMz(getPrecursors(getSpecLib(search_context))),
             valid_rt_irt,
-            is_decoy,
-            sequences,
-            structural_mods;
-            max_q_val=params.max_q_val_for_irt,
-            pep_threshold=params.max_PEP,
-            fdr_scale_factor=fdr_scale_factor
+            max_q_val=params.max_q_val_for_irt
         )
     end
     # Map retention times and update iRT observations

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -413,8 +413,13 @@ function process_file!(
 
 
         # Select scoring columns
-        select!(psms, vcat(column_names, [:ms_file_idx, :score, :precursor_idx, :scan_idx,
-            :q_value, :log2_summed_intensity, :irt, :rt, :irt_predicted, :target]))
+        has_isotopes = :isotopes_captured in names(psms)
+        preserved_cols = [:ms_file_idx, :score, :precursor_idx, :scan_idx,
+            :q_value, :log2_summed_intensity, :irt, :rt, :irt_predicted, :target]
+        if has_isotopes
+            push!(preserved_cols, :isotopes_captured)
+        end
+        select!(psms, vcat(column_names, preserved_cols))
         sort!(psms, [:rt, :precursor_idx])
         # Score PSMs
         fdr_scale_factor = getLibraryFdrScaleFactor(search_context)
@@ -443,8 +448,7 @@ function process_file!(
         end
         # Process scores
        
-        select!(psms, [:ms_file_idx, :score, :precursor_idx, :scan_idx,
-            :q_value, :log2_summed_intensity, :irt, :rt, :irt_predicted, :target])
+        select!(psms, preserved_cols)
         get_probs!(psms, psms[!,:score])
     end
 
@@ -574,10 +578,14 @@ function process_search_results!(
     parsed_fname = getParsedFileName(search_context, ms_file_idx)
     temp_path = joinpath(getDataOutDir(search_context), "temp_data", "first_pass_psms", parsed_fname * ".arrow")
     psms[!, :ms_file_idx] .= UInt32(ms_file_idx)
+    write_cols = [:ms_file_idx, :scan_idx, :precursor_idx, :rt,
+        :irt_predicted, :q_value, :score, :prob, :scan_count]
+    if :isotopes_captured in names(psms)
+        insert!(write_cols, findfirst(==(:precursor_idx), write_cols) + 1, :isotopes_captured)
+    end
     Arrow.write(
         temp_path,
-        select!(psms, [:ms_file_idx, :scan_idx, :precursor_idx, :rt,
-            :irt_predicted, :q_value, :score, :prob, :scan_count])
+        select!(psms, write_cols)
     )
     setFirstPassPsms!(getMSData(search_context), ms_file_idx, temp_path)
 
@@ -632,12 +640,24 @@ function summarize_results!(
             return Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_irt::Float32, mean_irt::Union{Missing, Float32}, var_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32}}()
         end
         
+        precursors = getPrecursors(getSpecLib(search_context))
+        prec_mzs = getMz(precursors)
+        is_decoy = getIsDecoy(precursors)
+        sequences = getSequence(precursors)
+        structural_mods = getStructuralMods(precursors)
+        fdr_scale_factor = getLibraryFdrScaleFactor(search_context)
+
         # Get best precursors from valid files only
         return get_best_precursors_accross_runs(
             valid_psms_paths,
-            getMz(getPrecursors(getSpecLib(search_context))),#[:mz],
+            prec_mzs,#[:mz],
             valid_rt_irt,
-            max_q_val=params.max_q_val_for_irt
+            is_decoy,
+            sequences,
+            structural_mods;
+            max_q_val=params.max_q_val_for_irt,
+            pep_threshold=params.max_PEP,
+            fdr_scale_factor=fdr_scale_factor
         )
     end
     # Map retention times and update iRT observations

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
@@ -16,245 +16,341 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 """
-    get_best_precursors_accross_runs(psms_paths::Vector{String}, 
-                                    prec_mzs::AbstractVector{Float32},
-                                    rt_irt::Dict{Int64, RtConversionModel};
-                                    max_q_val::Float32=0.01f0) 
+    get_best_precursors_accross_runs(psms_paths::Vector{String},
+                                    prec_mzs::AbstractVector{<:AbstractFloat},
+                                    rt_irt::Dict{Int64, RtConversionModel},
+                                    is_decoy::AbstractVector{Bool},
+                                    sequences::AbstractVector,
+                                    structural_mods::AbstractVector;
+                                    max_q_val::Float32=0.01f0,
+                                    pep_threshold::Float32=0.9f0,
+                                    fdr_scale_factor::Float32=1.0f0)
     -> Dictionary{UInt32, NamedTuple}
 
-Identify and collect best precursor matches across multiple runs for retention time calibration.
+Identify and collect high-confidence precursors across multiple runs for retention time calibration.
 
 # Arguments
 - `psms_paths`: Paths to PSM files from first pass search
 - `prec_mzs`: Vector of precursor m/z values
 - `rt_irt`: Dictionary mapping file indices to RT-iRT conversion models
-- `max_q_val`: Maximum q-value threshold for considering PSMs
+- `is_decoy`: Indicator vector for decoy precursors
+- `sequences`: Precursor peptide sequences
+- `structural_mods`: Structural modification annotations for each precursor
+- `max_q_val`: Maximum q-value threshold for contributing to RT statistics
+- `pep_threshold`: Posterior error probability threshold applied per run
+- `fdr_scale_factor`: Scale factor correcting target/decoy imbalance when estimating PEP
 
 # Returns
 Dictionary mapping precursor indices to NamedTuple containing:
-- `best_prob`: Highest probability score
+- `best_prob`: Run-level probability after peptide backpropagation
 - `best_ms_file_idx`: File index with best match
 - `best_scan_idx`: Scan index of best match
 - `best_irt`: iRT value of best match
-- `mean_irt`: Mean iRT across qualifying matches
-- `var_irt`: Variance in iRT across qualifying matches
-- `n`: Number of qualifying matches
+- `mean_irt`: Sum of iRT observations below `max_q_val`
+- `var_irt`: Sum of squared deviations for iRT observations
+- `n`: Count of iRT observations contributing to statistics
 - `mz`: Precursor m/z value
 
 # Process
-1. First pass: Collects best matches and calculates mean iRT for each precursor accross the runs 
-2. Filters to top N precursors by probability
-3. Second pass: Calculates iRT variance for remaining precursors
+1. For each run, keep the best score per precursor/isotope combination.
+2. Combine isotope scores into precursor probabilities and group precursors by modified peptide (sequence + structural mods).
+3. Backpropagate peptide confidence to precursors and estimate precursor-level PEP within the run.
+4. Retain precursors passing the PEP threshold, accumulating RT statistics across runs.
+5. Limit retained precursors to the top-N by probability and compute cross-run iRT variance for qualifying precursors.
 """
 function get_best_precursors_accross_runs(
                          psms_paths::Vector{String},
-                         prec_mzs::AbstractVector{Float32},
-                         rt_irt::Dict{Int64, RtConversionModel};
-                         max_q_val::Float32 = 0.01f0
+                         prec_mzs::AbstractVector{<:AbstractFloat},
+                         rt_irt::Dict{Int64, RtConversionModel},
+                         is_decoy::AbstractVector{Bool},
+                         sequences::AbstractVector,
+                         structural_mods::AbstractVector;
+                         max_q_val::Float32 = 0.01f0,
+                         pep_threshold::Float32 = 0.9f0,
+                         fdr_scale_factor::Float32 = 1.0f0
                          )
 
-    function readPSMs!(
-        prec_to_best_prob::Dictionary{UInt32, @NamedTuple{ best_prob::Float32, 
-                                                    best_ms_file_idx::UInt32,
-                                                    best_scan_idx::UInt32,
-                                                    best_irt::Float32, 
-                                                    mean_irt::Union{Missing, Float32}, 
-                                                    var_irt::Union{Missing, Float32}, 
-                                                    n::Union{Missing, UInt16}, 
-                                                    mz::Float32}},
-        precursor_idxs::AbstractVector{UInt32},
-        q_values::AbstractVector{Float16},
-        probs::AbstractVector{Float32},
-        rts::AbstractVector{Float32},
-        scan_idxs::AbstractVector{UInt32},
-        ms_file_idxs::AbstractVector{UInt32},
-        rt_irt::RtConversionModel,
-        max_q_val::Float32)
-
-        for row in eachindex(precursor_idxs)
-            # Extract current PSM information
-            q_value = q_values[row]
-            precursor_idx = precursor_idxs[row]
-            prob = probs[row]
-            irt =  rt_irt(rts[row])
-            scan_idx = UInt32(scan_idxs[row])
-            ms_file_idx = UInt32(ms_file_idxs[row])
-
-            # Initialize running statistics
-            passed_q_val = (q_value <= max_q_val)
-            n = passed_q_val ? one(UInt16) : zero(UInt16)
-            mean_irt = passed_q_val ? irt : zero(Float32)
-            var_irt = zero(Float32)
-            mz = prec_mzs[precursor_idx]
-
-            #Has the precursor been encountered in a previous raw file?
-            #Keep a running mean irt for instances below q-val threshold
-            if haskey(prec_to_best_prob, precursor_idx)
-                # Update existing precursor entry
-                best_prob, best_ms_file_idx, best_scan_idx, best_irt, old_mean_irt, var_irt, old_n, mz = prec_to_best_prob[precursor_idx] 
-                
-                # Update best match if current is better
-                if (best_prob < prob)
-                    best_prob = prob
-                    best_irt = irt
-                    best_scan_idx = scan_idx
-                    best_ms_file_idx = ms_file_idx
-                end
-
-                # Update running statistics
-                mean_irt += old_mean_irt
-                n += old_n 
-                prec_to_best_prob[precursor_idx] = (
-                                                best_prob = prob, 
-                                                best_ms_file_idx = best_ms_file_idx,
-                                                best_scan_idx = best_scan_idx,
-                                                best_irt = irt,
-                                                mean_irt = mean_irt, 
-                                                var_irt = var_irt,
-                                                n = n,
-                                                mz = mz)
-            else
-                # Create new precursor entry
-                val = (best_prob = prob,
-                        best_ms_file_idx = ms_file_idx,
-                        best_scan_idx = scan_idx, 
-                        best_irt = irt,
-                        mean_irt = mean_irt, 
-                        var_irt = var_irt,
-                        n = n,
-                        mz = mz)
-                insert!(prec_to_best_prob, precursor_idx, val)
-            end
-        end
-    end
-    function getVariance!(
-        prec_to_best_prob::Dictionary{UInt32, @NamedTuple{ best_prob::Float32, 
-                                                    best_ms_file_idx::UInt32,
-                                                    best_scan_idx::UInt32,
-                                                    best_irt::Float32, 
-                                                    mean_irt::Union{Missing, Float32}, 
-                                                    var_irt::Union{Missing, Float32}, 
-                                                    n::Union{Missing, UInt16}, 
-                                                    mz::Float32}},
-        precursor_idxs::AbstractVector{UInt32},
-        q_values::AbstractVector{Float16},
-        rts::AbstractVector{Float32},
-        rt_irt::RtConversionModel,
-        max_q_val::Float32)
-        for row in eachindex(precursor_idxs)
-            # Skip PSMs that don't pass q-value threshold
-            q_value = q_values[row]
-
-            # Get precursor info
-            precursor_idx = precursor_idxs[row]
-            irt =  rt_irt(rts[row])
-
-            if q_value > max_q_val
+    combine_probability_evidence(probs::AbstractVector{Float32}) = begin
+        log_prod = 0.0f0
+        has_positive = false
+        @inbounds for prob in probs
+            if prob <= 0f0
                 continue
             end
-            if haskey(prec_to_best_prob, precursor_idx)
-                # Update variance calculation
-                best_prob, best_ms_file_idx, best_scan_idx, best_irt, mean_irt, var_irt, n, mz = prec_to_best_prob[precursor_idx] 
-                var_irt += (irt - mean_irt/n)^2
-                prec_to_best_prob[precursor_idx] = (
-                    best_prob = best_prob, 
-                    best_ms_file_idx= best_ms_file_idx,
-                    best_scan_idx = best_scan_idx,
-                    best_irt = best_irt,
-                    mean_irt = mean_irt, 
-                    var_irt = var_irt,
-                    n = n,
-                    mz = mz)
+            has_positive = true
+            clamped = min(prob, 1.0f0 - 1f-6)
+            log_prod += log1p(-clamped)
+        end
+        if !has_positive
+            return 0.0f0
+        end
+        combined = 1.0f0 - exp(log_prod)
+        return clamp(combined, 0.0f0, 1.0f0 - 1f-6)
+    end
 
-            end
+    normalize_isotopes(value) = begin
+        if value === missing
+            return (Int8(-1), Int8(-1))
+        elseif value isa Tuple
+            return (Int8(first(value)), Int8(last(value)))
+        else
+            return (Int8(-1), Int8(-1))
         end
     end
-    # Initialize dictionary to store best precursor matches
-    prec_to_best_prob = Dictionary{UInt32, @NamedTuple{ best_prob::Float32, 
-                                                        best_ms_file_idx::UInt32,
-                                                        best_scan_idx::UInt32,
-                                                        best_irt::Float32, 
-                                                        mean_irt::Union{Missing, Float32}, 
-                                                        var_irt::Union{Missing, Float32}, 
-                                                        n::Union{Missing, UInt16}, 
-                                                        mz::Float32}}()
 
-    # First pass: collect best matches and mean iRT
+    function peptide_key_for_precursor(prec_idx::UInt32)
+        idx = Int(prec_idx)
+        seq_val = sequences[idx]
+        struct_val = structural_mods[idx]
+        seq_key = seq_val === missing ? "" : String(seq_val)
+        struct_key = struct_val === missing ? "" : String(struct_val)
+        return (is_decoy[idx], seq_key, struct_key)
+    end
+
+    prec_to_best_prob = Dictionary{UInt32, @NamedTuple{
+        best_prob::Float32,
+        best_ms_file_idx::UInt32,
+        best_scan_idx::UInt32,
+        best_irt::Float32,
+        mean_irt::Union{Missing, Float32},
+        var_irt::Union{Missing, Float32},
+        n::Union{Missing, UInt16},
+        mz::Float32
+    }}()
 
     n_precursors_vec = Vector{UInt64}()
-    for psms_path in psms_paths #For each data frame 
+
+    for psms_path in psms_paths
         psms = Arrow.Table(psms_path)
-        
-        # Get the original file index from the PSM data
         if isempty(psms[:ms_file_idx])
-            continue  # Skip empty files
+            continue
         end
-        file_idx = first(psms[:ms_file_idx])  # All PSMs in a file should have the same ms_file_idx
-        
-        # Check if RT model exists for this file
+
+        file_idx = Int(first(psms[:ms_file_idx]))
         if !haskey(rt_irt, file_idx)
             @warn "No RT model found for file index $file_idx, skipping"
             continue
         end
 
-        push!(n_precursors_vec, length(psms[:precursor_idx]))
-        #One row for each precursor 
-        readPSMs!(
-            prec_to_best_prob,
-            psms[:precursor_idx],
-            psms[:q_value],
-            psms[:prob],
-            psms[:rt],
-            psms[:scan_idx],
-            psms[:ms_file_idx],
-            rt_irt[file_idx],
-            max_q_val
-        )
+        precursor_idxs = psms[:precursor_idx]
+        prob_col = psms[:prob]
+        q_values = psms[:q_value]
+        rt_vals = psms[:rt]
+        scan_idxs = psms[:scan_idx]
+        iso_available = hasproperty(psms, :isotopes_captured)
+        iso_vals = iso_available ? psms[:isotopes_captured] : nothing
+
+        push!(n_precursors_vec, UInt64(length(precursor_idxs)))
+
+        trace_best = Dict{Tuple{UInt32, Tuple{Int8, Int8}}, Float32}()
+        best_scan_idx = Dict{UInt32, UInt32}()
+        best_psm_prob = Dict{UInt32, Float32}()
+        best_irt = Dict{UInt32, Float32}()
+        irt_sum = Dict{UInt32, Float32}()
+        irt_count = Dict{UInt32, UInt16}()
+
+        rt_model = rt_irt[file_idx]
+
+        @inbounds for row in eachindex(precursor_idxs)
+            prec_idx = precursor_idxs[row]
+            prob = Float32(prob_col[row])
+            iso_key = iso_available ? normalize_isotopes(iso_vals[row]) : (Int8(-1), Int8(-1))
+            combo_key = (prec_idx, iso_key)
+            if prob > get(trace_best, combo_key, 0f0)
+                trace_best[combo_key] = prob
+            end
+
+            if prob > get(best_psm_prob, prec_idx, -Inf32)
+                best_psm_prob[prec_idx] = prob
+                best_scan_idx[prec_idx] = scan_idxs[row]
+                best_irt[prec_idx] = Float32(rt_model(rt_vals[row]))
+            end
+
+            if q_values[row] <= max_q_val
+                irt_val = Float32(rt_model(rt_vals[row]))
+                irt_sum[prec_idx] = get(irt_sum, prec_idx, 0f0) + irt_val
+                irt_count[prec_idx] = get(irt_count, prec_idx, UInt16(0)) + UInt16(1)
+            end
+        end
+
+        if isempty(trace_best)
+            continue
+        end
+
+        precursor_to_trace_probs = Dict{UInt32, Vector{Float32}}()
+        for ((prec_idx, _), prob) in trace_best
+            push!(get!(precursor_to_trace_probs, prec_idx, Float32[]), prob)
+        end
+
+        precursor_combined = Dict{UInt32, Float32}()
+        for (prec_idx, prob_vec) in precursor_to_trace_probs
+            precursor_combined[prec_idx] = combine_probability_evidence(prob_vec)
+        end
+
+        precursor_to_peptide_key = Dict{UInt32, Tuple{Bool, String, String}}()
+        peptide_to_precursor_probs = Dict{Tuple{Bool, String, String}, Vector{Float32}}()
+        for (prec_idx, prec_prob) in precursor_combined
+            key = peptide_key_for_precursor(prec_idx)
+            precursor_to_peptide_key[prec_idx] = key
+            push!(get!(peptide_to_precursor_probs, key, Float32[]), prec_prob)
+        end
+
+        peptide_probs = Dict{Tuple{Bool, String, String}, Float32}()
+        for (key, prob_vec) in peptide_to_precursor_probs
+            peptide_probs[key] = combine_probability_evidence(prob_vec)
+        end
+
+        final_precursor_probs = Dict{UInt32, Float32}()
+        for (prec_idx, prec_prob) in precursor_combined
+            key = precursor_to_peptide_key[prec_idx]
+            peptide_prob = peptide_probs[key]
+            final_precursor_probs[prec_idx] = min(prec_prob, peptide_prob)
+        end
+
+        prec_ids = collect(keys(final_precursor_probs))
+        if isempty(prec_ids)
+            continue
+        end
+
+        scores = Float32[final_precursor_probs[pid] for pid in prec_ids]
+        labels = Bool[!is_decoy[Int(pid)] for pid in prec_ids]
+        peps = Vector{Float32}(undef, length(prec_ids))
+        get_PEP!(scores, labels, peps; fdr_scale_factor=fdr_scale_factor)
+
+        passing_precursors = Set{UInt32}()
+        for (i, prec_idx) in enumerate(prec_ids)
+            if peps[i] <= pep_threshold
+                push!(passing_precursors, prec_idx)
+            end
+        end
+
+        if isempty(passing_precursors)
+            continue
+        end
+
+        for prec_idx in passing_precursors
+            final_prob = final_precursor_probs[prec_idx]
+            best_scan = get(best_scan_idx, prec_idx, UInt32(0))
+            best_irt_val = get(best_irt, prec_idx, 0f0)
+            sum_irt = get(irt_sum, prec_idx, 0f0)
+            count = get(irt_count, prec_idx, UInt16(0))
+            mz_value = Float32(coalesce(prec_mzs[Int(prec_idx)], 0f0))
+
+            if haskey(prec_to_best_prob, prec_idx)
+                old = prec_to_best_prob[prec_idx]
+                best_prob_old = old.best_prob
+                best_scan_old = old.best_scan_idx
+                best_file_old = old.best_ms_file_idx
+                best_irt_old = old.best_irt
+                if final_prob > best_prob_old
+                    best_prob_old = final_prob
+                    best_scan_old = best_scan
+                    best_file_old = UInt32(file_idx)
+                    best_irt_old = best_irt_val
+                end
+                mean_sum_old = Float32(something(old.mean_irt, 0f0))
+                n_old = UInt16(something(old.n, UInt16(0)))
+                var_old = Float32(something(old.var_irt, 0f0))
+                mean_sum_new = mean_sum_old + sum_irt
+                n_new = n_old + count
+                new_entry = (
+                    best_prob = best_prob_old,
+                    best_ms_file_idx = best_file_old,
+                    best_scan_idx = best_scan_old,
+                    best_irt = best_irt_old,
+                    mean_irt = mean_sum_new,
+                    var_irt = var_old,
+                    n = n_new,
+                    mz = old.mz,
+                )
+                prec_to_best_prob[prec_idx] = new_entry
+            else
+                new_entry = (
+                    best_prob = final_prob,
+                    best_ms_file_idx = UInt32(file_idx),
+                    best_scan_idx = best_scan,
+                    best_irt = best_irt_val,
+                    mean_irt = sum_irt,
+                    var_irt = 0f0,
+                    n = count,
+                    mz = mz_value,
+                )
+                insert!(prec_to_best_prob, prec_idx, new_entry)
+            end
+        end
     end
-    
-    # Handle case where no valid files were processed
+
     if isempty(n_precursors_vec)
         @warn "No valid PSM files found for cross-run analysis"
         return prec_to_best_prob
     end
-    
+
     max_precursors = maximum(n_precursors_vec)
-    # Filter to top N precursors by probability
-    sort!(prec_to_best_prob, by = x->x[:best_prob], alg=PartialQuickSort(1:max_precursors), rev = true);
-    N = 0
-    for key in collect(keys(prec_to_best_prob))
-        N += 1
-        if N > max_precursors
-            delete!(prec_to_best_prob, key)
+    if max_precursors > 0
+        sort!(prec_to_best_prob, by = x -> x[:best_prob], alg = PartialQuickSort(1:max_precursors), rev = true)
+        N = 0
+        for key in collect(keys(prec_to_best_prob))
+            N += 1
+            if N > max_precursors
+                delete!(prec_to_best_prob, key)
+            end
         end
     end
 
-    # Second pass: calculate iRT variance for remaining precursors
-    for psms_path in psms_paths #For each data frame 
-        psms = Arrow.Table(psms_path)
-        
-        # Get the original file index from the PSM data
-        if isempty(psms[:ms_file_idx])
-            continue  # Skip empty files
-        end
-        file_idx = first(psms[:ms_file_idx])  # All PSMs in a file should have the same ms_file_idx
-        
-        # Check if RT model exists for this file
-        if !haskey(rt_irt, file_idx)
-            continue  # Skip files without RT models (already warned in first pass)
-        end
-        
-        #One row for each precursor 
-        getVariance!(
-            prec_to_best_prob,
-            psms[:precursor_idx],
-            psms[:q_value],
-            psms[:rt],
-            rt_irt[file_idx],
-            max_q_val
-        )
-    end 
+    if isempty(prec_to_best_prob)
+        return prec_to_best_prob
+    end
 
-    
-    return prec_to_best_prob #[(prob, idx) for (idx, prob) in sort(collect(top_probs), rev=true)]
+    for psms_path in psms_paths
+        psms = Arrow.Table(psms_path)
+        if isempty(psms[:ms_file_idx])
+            continue
+        end
+
+        file_idx = Int(first(psms[:ms_file_idx]))
+        if !haskey(rt_irt, file_idx)
+            continue
+        end
+
+        precursor_idxs = psms[:precursor_idx]
+        q_values = psms[:q_value]
+        rt_vals = psms[:rt]
+        rt_model = rt_irt[file_idx]
+
+        @inbounds for row in eachindex(precursor_idxs)
+            if q_values[row] > max_q_val
+                continue
+            end
+
+            prec_idx = precursor_idxs[row]
+            if !haskey(prec_to_best_prob, prec_idx)
+                continue
+            end
+
+            entry = prec_to_best_prob[prec_idx]
+            n = UInt16(something(entry.n, UInt16(0)))
+            if n <= 1
+                continue
+            end
+
+            mean_sum = Float32(something(entry.mean_irt, 0f0))
+            mean_val = mean_sum / Float32(n)
+            current_var = Float32(something(entry.var_irt, 0f0))
+            irt_val = Float32(rt_model(rt_vals[row]))
+
+            updated_entry = (
+                best_prob = entry.best_prob,
+                best_ms_file_idx = entry.best_ms_file_idx,
+                best_scan_idx = entry.best_scan_idx,
+                best_irt = entry.best_irt,
+                mean_irt = entry.mean_irt,
+                var_irt = current_var + (irt_val - mean_val)^2,
+                n = entry.n,
+                mz = entry.mz,
+            )
+            prec_to_best_prob[prec_idx] = updated_entry
+        end
+    end
+
+    return prec_to_best_prob
 end

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
@@ -16,341 +16,245 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 """
-    get_best_precursors_accross_runs(psms_paths::Vector{String},
-                                    prec_mzs::AbstractVector{<:AbstractFloat},
-                                    rt_irt::Dict{Int64, RtConversionModel},
-                                    is_decoy::AbstractVector{Bool},
-                                    sequences::AbstractVector,
-                                    structural_mods::AbstractVector;
-                                    max_q_val::Float32=0.01f0,
-                                    pep_threshold::Float32=0.9f0,
-                                    fdr_scale_factor::Float32=1.0f0)
+    get_best_precursors_accross_runs(psms_paths::Vector{String}, 
+                                    prec_mzs::AbstractVector{Float32},
+                                    rt_irt::Dict{Int64, RtConversionModel};
+                                    max_q_val::Float32=0.01f0) 
     -> Dictionary{UInt32, NamedTuple}
 
-Identify and collect high-confidence precursors across multiple runs for retention time calibration.
+Identify and collect best precursor matches across multiple runs for retention time calibration.
 
 # Arguments
 - `psms_paths`: Paths to PSM files from first pass search
 - `prec_mzs`: Vector of precursor m/z values
 - `rt_irt`: Dictionary mapping file indices to RT-iRT conversion models
-- `is_decoy`: Indicator vector for decoy precursors
-- `sequences`: Precursor peptide sequences
-- `structural_mods`: Structural modification annotations for each precursor
-- `max_q_val`: Maximum q-value threshold for contributing to RT statistics
-- `pep_threshold`: Posterior error probability threshold applied per run
-- `fdr_scale_factor`: Scale factor correcting target/decoy imbalance when estimating PEP
+- `max_q_val`: Maximum q-value threshold for considering PSMs
 
 # Returns
 Dictionary mapping precursor indices to NamedTuple containing:
-- `best_prob`: Run-level probability after peptide backpropagation
+- `best_prob`: Highest probability score
 - `best_ms_file_idx`: File index with best match
 - `best_scan_idx`: Scan index of best match
 - `best_irt`: iRT value of best match
-- `mean_irt`: Sum of iRT observations below `max_q_val`
-- `var_irt`: Sum of squared deviations for iRT observations
-- `n`: Count of iRT observations contributing to statistics
+- `mean_irt`: Mean iRT across qualifying matches
+- `var_irt`: Variance in iRT across qualifying matches
+- `n`: Number of qualifying matches
 - `mz`: Precursor m/z value
 
 # Process
-1. For each run, keep the best score per precursor/isotope combination.
-2. Combine isotope scores into precursor probabilities and group precursors by modified peptide (sequence + structural mods).
-3. Backpropagate peptide confidence to precursors and estimate precursor-level PEP within the run.
-4. Retain precursors passing the PEP threshold, accumulating RT statistics across runs.
-5. Limit retained precursors to the top-N by probability and compute cross-run iRT variance for qualifying precursors.
+1. First pass: Collects best matches and calculates mean iRT for each precursor accross the runs 
+2. Filters to top N precursors by probability
+3. Second pass: Calculates iRT variance for remaining precursors
 """
 function get_best_precursors_accross_runs(
                          psms_paths::Vector{String},
-                         prec_mzs::AbstractVector{<:AbstractFloat},
-                         rt_irt::Dict{Int64, RtConversionModel},
-                         is_decoy::AbstractVector{Bool},
-                         sequences::AbstractVector,
-                         structural_mods::AbstractVector;
-                         max_q_val::Float32 = 0.01f0,
-                         pep_threshold::Float32 = 0.9f0,
-                         fdr_scale_factor::Float32 = 1.0f0
+                         prec_mzs::AbstractVector{Float32},
+                         rt_irt::Dict{Int64, RtConversionModel};
+                         max_q_val::Float32 = 0.01f0
                          )
 
-    combine_probability_evidence(probs::AbstractVector{Float32}) = begin
-        log_prod = 0.0f0
-        has_positive = false
-        @inbounds for prob in probs
-            if prob <= 0f0
+    function readPSMs!(
+        prec_to_best_prob::Dictionary{UInt32, @NamedTuple{ best_prob::Float32, 
+                                                    best_ms_file_idx::UInt32,
+                                                    best_scan_idx::UInt32,
+                                                    best_irt::Float32, 
+                                                    mean_irt::Union{Missing, Float32}, 
+                                                    var_irt::Union{Missing, Float32}, 
+                                                    n::Union{Missing, UInt16}, 
+                                                    mz::Float32}},
+        precursor_idxs::AbstractVector{UInt32},
+        q_values::AbstractVector{Float16},
+        probs::AbstractVector{Float32},
+        rts::AbstractVector{Float32},
+        scan_idxs::AbstractVector{UInt32},
+        ms_file_idxs::AbstractVector{UInt32},
+        rt_irt::RtConversionModel,
+        max_q_val::Float32)
+
+        for row in eachindex(precursor_idxs)
+            # Extract current PSM information
+            q_value = q_values[row]
+            precursor_idx = precursor_idxs[row]
+            prob = probs[row]
+            irt =  rt_irt(rts[row])
+            scan_idx = UInt32(scan_idxs[row])
+            ms_file_idx = UInt32(ms_file_idxs[row])
+
+            # Initialize running statistics
+            passed_q_val = (q_value <= max_q_val)
+            n = passed_q_val ? one(UInt16) : zero(UInt16)
+            mean_irt = passed_q_val ? irt : zero(Float32)
+            var_irt = zero(Float32)
+            mz = prec_mzs[precursor_idx]
+
+            #Has the precursor been encountered in a previous raw file?
+            #Keep a running mean irt for instances below q-val threshold
+            if haskey(prec_to_best_prob, precursor_idx)
+                # Update existing precursor entry
+                best_prob, best_ms_file_idx, best_scan_idx, best_irt, old_mean_irt, var_irt, old_n, mz = prec_to_best_prob[precursor_idx] 
+                
+                # Update best match if current is better
+                if (best_prob < prob)
+                    best_prob = prob
+                    best_irt = irt
+                    best_scan_idx = scan_idx
+                    best_ms_file_idx = ms_file_idx
+                end
+
+                # Update running statistics
+                mean_irt += old_mean_irt
+                n += old_n 
+                prec_to_best_prob[precursor_idx] = (
+                                                best_prob = prob, 
+                                                best_ms_file_idx = best_ms_file_idx,
+                                                best_scan_idx = best_scan_idx,
+                                                best_irt = irt,
+                                                mean_irt = mean_irt, 
+                                                var_irt = var_irt,
+                                                n = n,
+                                                mz = mz)
+            else
+                # Create new precursor entry
+                val = (best_prob = prob,
+                        best_ms_file_idx = ms_file_idx,
+                        best_scan_idx = scan_idx, 
+                        best_irt = irt,
+                        mean_irt = mean_irt, 
+                        var_irt = var_irt,
+                        n = n,
+                        mz = mz)
+                insert!(prec_to_best_prob, precursor_idx, val)
+            end
+        end
+    end
+    function getVariance!(
+        prec_to_best_prob::Dictionary{UInt32, @NamedTuple{ best_prob::Float32, 
+                                                    best_ms_file_idx::UInt32,
+                                                    best_scan_idx::UInt32,
+                                                    best_irt::Float32, 
+                                                    mean_irt::Union{Missing, Float32}, 
+                                                    var_irt::Union{Missing, Float32}, 
+                                                    n::Union{Missing, UInt16}, 
+                                                    mz::Float32}},
+        precursor_idxs::AbstractVector{UInt32},
+        q_values::AbstractVector{Float16},
+        rts::AbstractVector{Float32},
+        rt_irt::RtConversionModel,
+        max_q_val::Float32)
+        for row in eachindex(precursor_idxs)
+            # Skip PSMs that don't pass q-value threshold
+            q_value = q_values[row]
+
+            # Get precursor info
+            precursor_idx = precursor_idxs[row]
+            irt =  rt_irt(rts[row])
+
+            if q_value > max_q_val
                 continue
             end
-            has_positive = true
-            clamped = min(prob, 1.0f0 - 1f-6)
-            log_prod += log1p(-clamped)
-        end
-        if !has_positive
-            return 0.0f0
-        end
-        combined = 1.0f0 - exp(log_prod)
-        return clamp(combined, 0.0f0, 1.0f0 - 1f-6)
-    end
+            if haskey(prec_to_best_prob, precursor_idx)
+                # Update variance calculation
+                best_prob, best_ms_file_idx, best_scan_idx, best_irt, mean_irt, var_irt, n, mz = prec_to_best_prob[precursor_idx] 
+                var_irt += (irt - mean_irt/n)^2
+                prec_to_best_prob[precursor_idx] = (
+                    best_prob = best_prob, 
+                    best_ms_file_idx= best_ms_file_idx,
+                    best_scan_idx = best_scan_idx,
+                    best_irt = best_irt,
+                    mean_irt = mean_irt, 
+                    var_irt = var_irt,
+                    n = n,
+                    mz = mz)
 
-    normalize_isotopes(value) = begin
-        if value === missing
-            return (Int8(-1), Int8(-1))
-        elseif value isa Tuple
-            return (Int8(first(value)), Int8(last(value)))
-        else
-            return (Int8(-1), Int8(-1))
+            end
         end
     end
+    # Initialize dictionary to store best precursor matches
+    prec_to_best_prob = Dictionary{UInt32, @NamedTuple{ best_prob::Float32, 
+                                                        best_ms_file_idx::UInt32,
+                                                        best_scan_idx::UInt32,
+                                                        best_irt::Float32, 
+                                                        mean_irt::Union{Missing, Float32}, 
+                                                        var_irt::Union{Missing, Float32}, 
+                                                        n::Union{Missing, UInt16}, 
+                                                        mz::Float32}}()
 
-    function peptide_key_for_precursor(prec_idx::UInt32)
-        idx = Int(prec_idx)
-        seq_val = sequences[idx]
-        struct_val = structural_mods[idx]
-        seq_key = seq_val === missing ? "" : String(seq_val)
-        struct_key = struct_val === missing ? "" : String(struct_val)
-        return (is_decoy[idx], seq_key, struct_key)
-    end
-
-    prec_to_best_prob = Dictionary{UInt32, @NamedTuple{
-        best_prob::Float32,
-        best_ms_file_idx::UInt32,
-        best_scan_idx::UInt32,
-        best_irt::Float32,
-        mean_irt::Union{Missing, Float32},
-        var_irt::Union{Missing, Float32},
-        n::Union{Missing, UInt16},
-        mz::Float32
-    }}()
+    # First pass: collect best matches and mean iRT
 
     n_precursors_vec = Vector{UInt64}()
-
-    for psms_path in psms_paths
+    for psms_path in psms_paths #For each data frame 
         psms = Arrow.Table(psms_path)
+        
+        # Get the original file index from the PSM data
         if isempty(psms[:ms_file_idx])
-            continue
+            continue  # Skip empty files
         end
-
-        file_idx = Int(first(psms[:ms_file_idx]))
+        file_idx = first(psms[:ms_file_idx])  # All PSMs in a file should have the same ms_file_idx
+        
+        # Check if RT model exists for this file
         if !haskey(rt_irt, file_idx)
             @warn "No RT model found for file index $file_idx, skipping"
             continue
         end
 
-        precursor_idxs = psms[:precursor_idx]
-        prob_col = psms[:prob]
-        q_values = psms[:q_value]
-        rt_vals = psms[:rt]
-        scan_idxs = psms[:scan_idx]
-        iso_available = hasproperty(psms, :isotopes_captured)
-        iso_vals = iso_available ? psms[:isotopes_captured] : nothing
-
-        push!(n_precursors_vec, UInt64(length(precursor_idxs)))
-
-        trace_best = Dict{Tuple{UInt32, Tuple{Int8, Int8}}, Float32}()
-        best_scan_idx = Dict{UInt32, UInt32}()
-        best_psm_prob = Dict{UInt32, Float32}()
-        best_irt = Dict{UInt32, Float32}()
-        irt_sum = Dict{UInt32, Float32}()
-        irt_count = Dict{UInt32, UInt16}()
-
-        rt_model = rt_irt[file_idx]
-
-        @inbounds for row in eachindex(precursor_idxs)
-            prec_idx = precursor_idxs[row]
-            prob = Float32(prob_col[row])
-            iso_key = iso_available ? normalize_isotopes(iso_vals[row]) : (Int8(-1), Int8(-1))
-            combo_key = (prec_idx, iso_key)
-            if prob > get(trace_best, combo_key, 0f0)
-                trace_best[combo_key] = prob
-            end
-
-            if prob > get(best_psm_prob, prec_idx, -Inf32)
-                best_psm_prob[prec_idx] = prob
-                best_scan_idx[prec_idx] = scan_idxs[row]
-                best_irt[prec_idx] = Float32(rt_model(rt_vals[row]))
-            end
-
-            if q_values[row] <= max_q_val
-                irt_val = Float32(rt_model(rt_vals[row]))
-                irt_sum[prec_idx] = get(irt_sum, prec_idx, 0f0) + irt_val
-                irt_count[prec_idx] = get(irt_count, prec_idx, UInt16(0)) + UInt16(1)
-            end
-        end
-
-        if isempty(trace_best)
-            continue
-        end
-
-        precursor_to_trace_probs = Dict{UInt32, Vector{Float32}}()
-        for ((prec_idx, _), prob) in trace_best
-            push!(get!(precursor_to_trace_probs, prec_idx, Float32[]), prob)
-        end
-
-        precursor_combined = Dict{UInt32, Float32}()
-        for (prec_idx, prob_vec) in precursor_to_trace_probs
-            precursor_combined[prec_idx] = combine_probability_evidence(prob_vec)
-        end
-
-        precursor_to_peptide_key = Dict{UInt32, Tuple{Bool, String, String}}()
-        peptide_to_precursor_probs = Dict{Tuple{Bool, String, String}, Vector{Float32}}()
-        for (prec_idx, prec_prob) in precursor_combined
-            key = peptide_key_for_precursor(prec_idx)
-            precursor_to_peptide_key[prec_idx] = key
-            push!(get!(peptide_to_precursor_probs, key, Float32[]), prec_prob)
-        end
-
-        peptide_probs = Dict{Tuple{Bool, String, String}, Float32}()
-        for (key, prob_vec) in peptide_to_precursor_probs
-            peptide_probs[key] = combine_probability_evidence(prob_vec)
-        end
-
-        final_precursor_probs = Dict{UInt32, Float32}()
-        for (prec_idx, prec_prob) in precursor_combined
-            key = precursor_to_peptide_key[prec_idx]
-            peptide_prob = peptide_probs[key]
-            final_precursor_probs[prec_idx] = min(prec_prob, peptide_prob)
-        end
-
-        prec_ids = collect(keys(final_precursor_probs))
-        if isempty(prec_ids)
-            continue
-        end
-
-        scores = Float32[final_precursor_probs[pid] for pid in prec_ids]
-        labels = Bool[!is_decoy[Int(pid)] for pid in prec_ids]
-        peps = Vector{Float32}(undef, length(prec_ids))
-        get_PEP!(scores, labels, peps; fdr_scale_factor=fdr_scale_factor)
-
-        passing_precursors = Set{UInt32}()
-        for (i, prec_idx) in enumerate(prec_ids)
-            if peps[i] <= pep_threshold
-                push!(passing_precursors, prec_idx)
-            end
-        end
-
-        if isempty(passing_precursors)
-            continue
-        end
-
-        for prec_idx in passing_precursors
-            final_prob = final_precursor_probs[prec_idx]
-            best_scan = get(best_scan_idx, prec_idx, UInt32(0))
-            best_irt_val = get(best_irt, prec_idx, 0f0)
-            sum_irt = get(irt_sum, prec_idx, 0f0)
-            count = get(irt_count, prec_idx, UInt16(0))
-            mz_value = Float32(coalesce(prec_mzs[Int(prec_idx)], 0f0))
-
-            if haskey(prec_to_best_prob, prec_idx)
-                old = prec_to_best_prob[prec_idx]
-                best_prob_old = old.best_prob
-                best_scan_old = old.best_scan_idx
-                best_file_old = old.best_ms_file_idx
-                best_irt_old = old.best_irt
-                if final_prob > best_prob_old
-                    best_prob_old = final_prob
-                    best_scan_old = best_scan
-                    best_file_old = UInt32(file_idx)
-                    best_irt_old = best_irt_val
-                end
-                mean_sum_old = Float32(something(old.mean_irt, 0f0))
-                n_old = UInt16(something(old.n, UInt16(0)))
-                var_old = Float32(something(old.var_irt, 0f0))
-                mean_sum_new = mean_sum_old + sum_irt
-                n_new = n_old + count
-                new_entry = (
-                    best_prob = best_prob_old,
-                    best_ms_file_idx = best_file_old,
-                    best_scan_idx = best_scan_old,
-                    best_irt = best_irt_old,
-                    mean_irt = mean_sum_new,
-                    var_irt = var_old,
-                    n = n_new,
-                    mz = old.mz,
-                )
-                prec_to_best_prob[prec_idx] = new_entry
-            else
-                new_entry = (
-                    best_prob = final_prob,
-                    best_ms_file_idx = UInt32(file_idx),
-                    best_scan_idx = best_scan,
-                    best_irt = best_irt_val,
-                    mean_irt = sum_irt,
-                    var_irt = 0f0,
-                    n = count,
-                    mz = mz_value,
-                )
-                insert!(prec_to_best_prob, prec_idx, new_entry)
-            end
-        end
+        push!(n_precursors_vec, length(psms[:precursor_idx]))
+        #One row for each precursor 
+        readPSMs!(
+            prec_to_best_prob,
+            psms[:precursor_idx],
+            psms[:q_value],
+            psms[:prob],
+            psms[:rt],
+            psms[:scan_idx],
+            psms[:ms_file_idx],
+            rt_irt[file_idx],
+            max_q_val
+        )
     end
-
+    
+    # Handle case where no valid files were processed
     if isempty(n_precursors_vec)
         @warn "No valid PSM files found for cross-run analysis"
         return prec_to_best_prob
     end
-
+    
     max_precursors = maximum(n_precursors_vec)
-    if max_precursors > 0
-        sort!(prec_to_best_prob, by = x -> x[:best_prob], alg = PartialQuickSort(1:max_precursors), rev = true)
-        N = 0
-        for key in collect(keys(prec_to_best_prob))
-            N += 1
-            if N > max_precursors
-                delete!(prec_to_best_prob, key)
-            end
+    # Filter to top N precursors by probability
+    sort!(prec_to_best_prob, by = x->x[:best_prob], alg=PartialQuickSort(1:max_precursors), rev = true);
+    N = 0
+    for key in collect(keys(prec_to_best_prob))
+        N += 1
+        if N > max_precursors
+            delete!(prec_to_best_prob, key)
         end
     end
 
-    if isempty(prec_to_best_prob)
-        return prec_to_best_prob
-    end
-
-    for psms_path in psms_paths
+    # Second pass: calculate iRT variance for remaining precursors
+    for psms_path in psms_paths #For each data frame 
         psms = Arrow.Table(psms_path)
+        
+        # Get the original file index from the PSM data
         if isempty(psms[:ms_file_idx])
-            continue
+            continue  # Skip empty files
         end
-
-        file_idx = Int(first(psms[:ms_file_idx]))
+        file_idx = first(psms[:ms_file_idx])  # All PSMs in a file should have the same ms_file_idx
+        
+        # Check if RT model exists for this file
         if !haskey(rt_irt, file_idx)
-            continue
+            continue  # Skip files without RT models (already warned in first pass)
         end
+        
+        #One row for each precursor 
+        getVariance!(
+            prec_to_best_prob,
+            psms[:precursor_idx],
+            psms[:q_value],
+            psms[:rt],
+            rt_irt[file_idx],
+            max_q_val
+        )
+    end 
 
-        precursor_idxs = psms[:precursor_idx]
-        q_values = psms[:q_value]
-        rt_vals = psms[:rt]
-        rt_model = rt_irt[file_idx]
-
-        @inbounds for row in eachindex(precursor_idxs)
-            if q_values[row] > max_q_val
-                continue
-            end
-
-            prec_idx = precursor_idxs[row]
-            if !haskey(prec_to_best_prob, prec_idx)
-                continue
-            end
-
-            entry = prec_to_best_prob[prec_idx]
-            n = UInt16(something(entry.n, UInt16(0)))
-            if n <= 1
-                continue
-            end
-
-            mean_sum = Float32(something(entry.mean_irt, 0f0))
-            mean_val = mean_sum / Float32(n)
-            current_var = Float32(something(entry.var_irt, 0f0))
-            irt_val = Float32(rt_model(rt_vals[row]))
-
-            updated_entry = (
-                best_prob = entry.best_prob,
-                best_ms_file_idx = entry.best_ms_file_idx,
-                best_scan_idx = entry.best_scan_idx,
-                best_irt = entry.best_irt,
-                mean_irt = entry.mean_irt,
-                var_irt = current_var + (irt_val - mean_val)^2,
-                n = entry.n,
-                mz = entry.mz,
-            )
-            prec_to_best_prob[prec_idx] = updated_entry
-        end
-    end
-
-    return prec_to_best_prob
+    
+    return prec_to_best_prob #[(prob, idx) for (idx, prob) in sort(collect(top_probs), rev=true)]
 end

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
@@ -306,7 +306,12 @@ function get_best_psms!(psms::DataFrame,
     get_PEP!(psms[!,:score], psms[!,:target], psms[!,:PEP]; doSort=false, fdr_scale_factor=fdr_scale_factor);
 
     n = size(psms, 1)
-    select!(psms, [:precursor_idx,:log2_summed_intensity,:rt,:irt_predicted,:q_value,:score,:prob,:fwhm,:scan_count,:scan_idx,:PEP,:target])
+    kept_cols = [:precursor_idx, :log2_summed_intensity, :rt, :irt_predicted, :q_value,
+        :score, :prob, :fwhm, :scan_count, :scan_idx, :PEP, :target]
+    if :isotopes_captured in names(psms)
+        insert!(kept_cols, findfirst(==(:scan_idx), kept_cols) + 1, :isotopes_captured)
+    end
+    select!(psms, kept_cols)
 
     first_fail = searchsortedfirst(psms[!,:PEP], Float16(max_PEP))
     if first_fail <= n

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
@@ -212,98 +212,159 @@ end
 
 
 """
-    get_best_psms!(psms::DataFrame, prec_mz::Arrow.Primitive{T, Vector{T}}; 
-                   max_PEP::Float32=0.9f0, fdr_scale_factor::Float32=1.0f0) where {T<:AbstractFloat}
+    get_best_psms!(psms::DataFrame,
+                   prec_mz::Arrow.Primitive{T, Vector{T}},
+                   sequences::AbstractVector,
+                   structural_mods::AbstractVector;
+                   max_PEP::Float32=0.9f0,
+                   fdr_scale_factor::Float32=1.0f0) where {T<:AbstractFloat}
 
-Processes PSMs to identify the best matches and calculate peak characteristics.
+Processes PSMs to identify the best precursor evidence within a single run and calculate aggregated precursor probabilities.
 
 # Arguments
 - `psms`: DataFrame containing peptide-spectrum matches
 - `prec_mz`: Vector of precursor m/z values
-- `max_PEP`: Maximum local FDR threshold for filtering PSMs
-- `fdr_scale_factor`: Scale factor to correct for library target/decoy ratio
+- `sequences`: Peptide sequences indexed by precursor identifier
+- `structural_mods`: Structural modification annotations indexed by precursor identifier
+- `max_PEP`: Maximum local FDR threshold for filtering precursors
+- `fdr_scale_factor`: Scale factor to correct for library target/decoy ratio when estimating PEP
 
 # Modifies PSMs DataFrame to add:
-- `best_psm`: Boolean indicating highest scoring PSM for each precursor
+- `best_psm`: Boolean indicating representative PSM for each precursor
 - `fwhm`: Full width at half maximum of chromatographic peak
-- `scan_count`: Number of scans below q-value threshold
+- `scan_count`: Number of scans above half-maximum intensity
 - `prec_mz`: Precursor m/z values
 
 Note: Assumes psms is sorted by retention time in ascending order.
 """
 function get_best_psms!(psms::DataFrame,
-                        prec_mz::Arrow.Primitive{T, Vector{T}};
+                        prec_mz::Arrow.Primitive{T, Vector{T}},
+                        sequences::AbstractVector,
+                        structural_mods::AbstractVector;
                         max_PEP::Float32 = 0.9f0,
                         fdr_scale_factor::Float32 = 1.0f0
 ) where {T<:AbstractFloat}
 
-    #highest scoring psm for a given precursor
-    psms[!,:PEP] = zeros(Float16, size(psms, 1))
-    #highest scoring psm for a given precursor
-    psms[!,:best_psm] = zeros(Bool, size(psms, 1))
-    #fwhm estimate of the precursor
-    psms[!,:fwhm] = zeros(Union{Missing, Float32}, size(psms, 1))
-    #number of scans below the q value threshold for hte precursor
-    psms[!,:scan_count] = zeros(UInt16,size(psms, 1))
+    n_rows = size(psms, 1)
+    psms[!, :PEP] = zeros(Float16, n_rows)
+    psms[!, :best_psm] = falses(n_rows)
+    psms[!, :fwhm] = zeros(Union{Missing, Float32}, n_rows)
+    psms[!, :scan_count] = zeros(UInt16, n_rows)
 
-    
-    #Get best psm for each precursor 
-    #ASSUMES psms IS SOrtED BY rt IN ASCENDING ORDER
-    gpsms = groupby(psms,:precursor_idx)
-    for (precursor_idx, prec_psms) in pairs(gpsms)
+    has_isotopes = :isotopes_captured in names(psms)
 
-        #Get the best scoring psm, and the its row index. 
-        #Get the maximum intensity psm (under the q_value threshold) and its row index. 
-        max_irt, min_irt = missing, missing
-        max_log2_intensity, max_idx = missing, one(Int64)
-        best_psm_score, best_psm_idx = zero(Float32), one(Int64)
-        scan_count = one(UInt8)
-        for i in range(1, size(prec_psms, 1))
-            if coalesce(max_log2_intensity, zero(Float32)) < prec_psms[i,:log2_summed_intensity]
-                max_log2_intensity = prec_psms[i,:log2_summed_intensity]
-                max_idx = i
+    @inline function combine_probabilities(probabilities::AbstractVector{Float32})
+        combined = 0.0f0
+        @inbounds for p in probabilities
+            p_clamped = clamp(p, 0.0f0, 1.0f0)
+            combined = 1.0f0 - (1.0f0 - combined) * (1.0f0 - p_clamped)
+        end
+        return combined
+    end
+
+    @inline function combine_probabilities(existing::Float32, new::Float32)
+        return 1.0f0 - (1.0f0 - clamp(existing, 0.0f0, 1.0f0)) * (1.0f0 - clamp(new, 0.0f0, 1.0f0))
+    end
+
+    @inline function prob_to_score(prob::Float32)
+        clamped = clamp(prob, eps(Float32), 1.0f0 - eps(Float32))
+        return Float32(sqrt(2.0f0) * SpecialFunctions.erfinv(2.0f0 * clamped - 1.0f0))
+    end
+
+    precursor_probs = Dict{UInt32, Float32}()
+    precursor_keys = Dict{UInt32, Tuple{Bool, Any, Any}}()
+    precursor_best_rows = Dict{UInt32, Int}()
+
+    gpsms = groupby(psms, :precursor_idx)
+    for prec_psms in gpsms
+        parent_rows = parentindices(prec_psms)[1]
+        precursor_idx = prec_psms[1, :precursor_idx]
+        target_flag = prec_psms[1, :target]
+        seq = sequences[Int(precursor_idx)]
+        struct_mod = structural_mods[Int(precursor_idx)]
+        precursor_keys[precursor_idx] = (target_flag, seq, struct_mod)
+
+        combo_to_local_idx = Dict{Any, Int}()
+        max_log2_intensity = typemin(Float32)
+        max_idx = 1
+        n_group_rows = size(prec_psms, 1)
+
+        for local_idx in 1:n_group_rows
+            intensity = prec_psms[local_idx, :log2_summed_intensity]
+            if intensity > max_log2_intensity
+                max_log2_intensity = intensity
+                max_idx = local_idx
             end
-            if prec_psms[i,:score]>best_psm_score
-                best_psm_idx = i
-                best_psm_score = prec_psms[i,:score]
+
+            combo_key = has_isotopes ? prec_psms[local_idx, :isotopes_captured] : nothing
+            prev_idx = get(combo_to_local_idx, combo_key, 0)
+            if prev_idx == 0 || prec_psms[local_idx, :score] > prec_psms[prev_idx, :score]
+                combo_to_local_idx[combo_key] = local_idx
             end
         end
-        #Mark the best psm 
-        prec_psms[best_psm_idx,:best_psm] = true
 
-        #Try to estimate the fwhm. 
+        combo_local_idxs = collect(values(combo_to_local_idx))
+        if isempty(combo_local_idxs)
+            push!(combo_local_idxs, 1)
+        end
+        combo_probs = Float32[Float32(prec_psms[idx, :prob]) for idx in combo_local_idxs]
+        precursor_prob = combine_probabilities(combo_probs)
+        precursor_probs[precursor_idx] = precursor_prob
+
+        best_combo_idx = combo_local_idxs[argmax(combo_probs)]
+
+        max_irt = missing
+        min_irt = missing
+        scan_count = UInt16(1)
+
         i = max_idx - 1
         while i > 0
-            #Is the i'th psm above half the maximum 
-            if (prec_psms[i,:log2_summed_intensity] > (max_log2_intensity - 1.0))
-                scan_count += 1
-                min_irt = prec_psms[i,:irt]
+            if prec_psms[i, :log2_summed_intensity] > (max_log2_intensity - 1.0f0)
+                scan_count += UInt16(1)
+                min_irt = prec_psms[i, :irt]
             else
                 break
             end
             i -= 1
         end
-        
+
         i = max_idx + 1
-        while i <= size(prec_psms, 1)
-            #Is the i'th psm above half the maximum 
-            if (prec_psms[i,:log2_summed_intensity] > (max_log2_intensity - 1.0))
-                scan_count += 1
-                max_irt = prec_psms[i,:irt]
+        while i <= n_group_rows
+            if prec_psms[i, :log2_summed_intensity] > (max_log2_intensity - 1.0f0)
+                scan_count += UInt16(1)
+                max_irt = prec_psms[i, :irt]
             else
                 break
             end
             i += 1
         end
 
-        prec_psms[best_psm_idx,:fwhm] = max_irt - min_irt
-        prec_psms[best_psm_idx,:scan_count] = scan_count
+        prec_psms[best_combo_idx, :best_psm] = true
+        prec_psms[best_combo_idx, :fwhm] = max_irt - min_irt
+        prec_psms[best_combo_idx, :scan_count] = scan_count
+
+        precursor_best_rows[precursor_idx] = parent_rows[best_combo_idx]
     end
 
-    filter!(x->x.best_psm, psms);
-    sort!(psms,:score, rev = true)
-    # Will use PEP for final filter
-    get_PEP!(psms[!,:score], psms[!,:target], psms[!,:PEP]; doSort=false, fdr_scale_factor=fdr_scale_factor);
+    peptide_probs = Dict{Tuple{Bool, Any, Any}, Float32}()
+    for (prec_idx, prob) in precursor_probs
+        key = precursor_keys[prec_idx]
+        existing = get(peptide_probs, key, 0.0f0)
+        peptide_probs[key] = combine_probabilities(existing, prob)
+    end
+
+    for (prec_idx, row_idx) in precursor_best_rows
+        key = precursor_keys[prec_idx]
+        precursor_prob = precursor_probs[prec_idx]
+        peptide_prob = peptide_probs[key]
+        final_prob = max(precursor_prob, peptide_prob)
+        psms[row_idx, :prob] = final_prob
+        psms[row_idx, :score] = prob_to_score(final_prob)
+    end
+
+    filter!(x -> x.best_psm, psms)
+    sort!(psms, :score, rev=true)
+    get_PEP!(psms[!, :score], psms[!, :target], psms[!, :PEP]; doSort=false, fdr_scale_factor=fdr_scale_factor)
 
     n = size(psms, 1)
     kept_cols = [:precursor_idx, :log2_summed_intensity, :rt, :irt_predicted, :q_value,
@@ -313,18 +374,17 @@ function get_best_psms!(psms::DataFrame,
     end
     select!(psms, kept_cols)
 
-    first_fail = searchsortedfirst(psms[!,:PEP], Float16(max_PEP))
+    first_fail = searchsortedfirst(psms[!, :PEP], Float16(max_PEP))
     if first_fail <= n
         deleteat!(psms, first_fail:n)
     end
-    #println("unique IDs prefilter: ", n, " ", first_fail, "\n\n")
 
-    mz = zeros(T, size(psms, 1));
-    precursor_idx = psms[!,:precursor_idx]::Vector{UInt32}
+    mz = zeros(T, size(psms, 1))
+    precursor_idx = psms[!, :precursor_idx]::Vector{UInt32}
     Threads.@threads for i in range(1, size(psms, 1))
-        mz[i] = prec_mz[precursor_idx[i]];
+        mz[i] = prec_mz[precursor_idx[i]]
     end
-    psms[!,:prec_mz] = mz
+    psms[!, :prec_mz] = mz
 
     return
 end


### PR DESCRIPTION
## Summary
- preserve isotopic trace annotations through first-pass scoring output so trace-level filtering can be revisited downstream
- implement per-run precursor aggregation that combines isotope, precursor, and modified-peptide evidence before filtering by precursor-level PEP when building the shared library

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: `julia` command not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163477d7988325928394a7691bc15d)