### PR TITLE
feat: add fragment compensation log-likelihood metrics

### DIFF
--- a/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
+++ b/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
@@ -77,9 +77,10 @@ struct ComplexScoredPSM{H,L<:AbstractFloat} <: ScoredPSM{H,L}
     gof::L
     max_matched_residual::L
     max_unmatched_residual::L 
-    fitted_manhattan_distance::L 
-    matched_ratio::L 
+    fitted_manhattan_distance::L
+    matched_ratio::L
     percent_theoretical_ignored::L
+    frag_compensation_loglik::L
     scribe::L
     #entropy_score::L
     weight::H
@@ -311,6 +312,7 @@ function Score!(scored_psms::Vector{ComplexScoredPSM{H, L}},
             spectral_scores[scores_idx].fitted_manhattan_distance,
             spectral_scores[scores_idx].matched_ratio,
             spectral_scores[scores_idx].percent_theoretical_ignored,
+            spectral_scores[scores_idx].frag_compensation_loglik,
             spectral_scores[scores_idx].scribe,
             #spectral_scores[scores_idx].entropy_score,
             weight[scores_idx],

--- a/src/Routines/SearchDIA/PSMs/spectralDistanceMetrics.jl
+++ b/src/Routines/SearchDIA/PSMs/spectralDistanceMetrics.jl
@@ -17,6 +17,9 @@
 
 abstract type SpectralScores{T<:AbstractFloat} end
 
+const FRAG_COMP_PRIOR_STRENGTH = 1.0
+const FRAG_COMP_PRIOR_OFFSET = 1.0e-3
+
 struct SpectralScoresComplex{T<:AbstractFloat} <: SpectralScores{T}
     spectral_contrast::T
     fitted_spectral_contrast::T
@@ -27,6 +30,7 @@ struct SpectralScoresComplex{T<:AbstractFloat} <: SpectralScores{T}
     matched_ratio::T
     scribe::T
     percent_theoretical_ignored::T
+    frag_compensation_loglik::T
     #entropy_score::T
 end
 
@@ -267,12 +271,12 @@ function getDistanceMetrics(w::Vector{T},
         num_matching_peaks = min_frags
 
         while num_matching_peaks ≥ min_frags
-            scr, spectral_contrast, fitted_spectral_contrast, gof, max_matched_residual, max_unmatched_residual, 
-            fitted_manhattan_distance, matched_ratio, worst_pos, worst_pred, num_matching_peaks = computeFittedMetricsFor(w, H, r, col, incl)
+            scr, spectral_contrast, fitted_spectral_contrast, gof, max_matched_residual, max_unmatched_residual,
+            fitted_manhattan_distance, matched_ratio, frag_loglik, worst_pos, worst_pred, num_matching_peaks = computeFittedMetricsFor(w, H, r, col, incl)
 
             if best === nothing || scr > best.scribe * relative_improvement_threshold
-                best = (scribe=scr, sc=spectral_contrast, fsc=fitted_spectral_contrast, gof=gof, mmr=max_matched_residual, 
-                        mur=max_unmatched_residual, fmd=fitted_manhattan_distance, mr=matched_ratio)
+                best = (scribe=scr, sc=spectral_contrast, fsc=fitted_spectral_contrast, gof=gof, mmr=max_matched_residual,
+                        mur=max_unmatched_residual, fmd=fitted_manhattan_distance, mr=matched_ratio, loglik=frag_loglik)
                 pct_ignored += worst_pred
             else
                 break                     # improvement too small
@@ -294,7 +298,8 @@ function getDistanceMetrics(w::Vector{T},
             Float16(best.fmd),                        # fitted manhattan (−log)
             Float16(best.mr),                         # matched / unmatched
             Float16(best.scribe),                     # scribe
-            Float16(pct_ignored)                      # percent_theoretical_ignored
+            Float16(pct_ignored),                     # percent_theoretical_ignored
+            Float16(best.loglik)                      # frag_compensation_loglik
         )
     end
 end
@@ -320,6 +325,18 @@ function computeFittedMetricsFor(w::Vector{T}, H::SparseArray{Ti,T}, r::Vector{T
             num_matching_peaks += 1
         end
     end
+
+    total_h = max(total_h, eps(T))
+    total_x = max(total_x, eps(T))
+    total_counts = max(total_x, eps(T))
+
+    prior_strength = convert(T, FRAG_COMP_PRIOR_STRENGTH)
+    prior_offset = convert(T, FRAG_COMP_PRIOR_OFFSET)
+
+    alpha_sum = zero(T)
+    sum_lgamma_counts = zero(T)
+    sum_lgamma_prior = zero(T)
+    sum_lgamma_post = zero(T)
 
     h_sqrt_sum = zero(T)
     x_sqrt_sum = zero(T)
@@ -357,9 +374,11 @@ function computeFittedMetricsFor(w::Vector{T}, H::SparseArray{Ti,T}, r::Vector{T
 
         fitted_peak = w[col]*H.nzval[i]
         shadow_peak = fitted_peak - r[H.rowval[i]]
+        fitted_val = max(fitted_peak, eps(T))
+        shadow_val = max(shadow_peak, eps(T))
 
         r_abs = abs(r[H.rowval[i]])
-        sum_of_residuals += r_abs  
+        sum_of_residuals += r_abs
 
          #For scribe
          h_sqrt_sum += sqrt(fitted_peak)
@@ -386,8 +405,19 @@ function computeFittedMetricsFor(w::Vector{T}, H::SparseArray{Ti,T}, r::Vector{T
 
 
         # "normalized" predicted and observed, so we can know which peak is the worst for spectral angle
-        h_val_v2 = fitted_peak / total_h
-        x_val_v2 = shadow_peak / total_x
+        h_val_v2 = fitted_val / total_h
+        x_val_v2 = shadow_val / total_x
+
+        fitted_norm = h_val_v2
+        shadow_norm = x_val_v2
+
+        alpha_i = prior_strength * fitted_norm + prior_offset
+        observed_count = shadow_norm * total_counts
+
+        alpha_sum += alpha_i
+        sum_lgamma_counts += lgamma(observed_count + one(T))
+        sum_lgamma_prior += lgamma(alpha_i)
+        sum_lgamma_post += lgamma(observed_count + alpha_i)
 
         diff = x_val_v2 - h_val_v2 # only look for positive difference because it implies there's interference
         if (diff > worst_val) && (x_val_v2 > 0)
@@ -426,8 +456,16 @@ function computeFittedMetricsFor(w::Vector{T}, H::SparseArray{Ti,T}, r::Vector{T
     matched_ratio = log2(matched_sum/unmatched_sum)
     worst_intensity_ignored = worst_idx > 0 ? H.nzval[worst_idx] : 0.0
 
-    return (scribe_score, spectral_contrast, fitted_spectral_contrast, gof, max_matched_residual, max_unmatched_residual, 
-            fitted_manhattan_distance, matched_ratio, worst_pos, worst_intensity_ignored, num_matching_peaks)
+    log_comb = lgamma(total_counts + one(T)) - sum_lgamma_counts
+    log_prior = lgamma(alpha_sum) - lgamma(total_counts + alpha_sum)
+    log_post = sum_lgamma_post - sum_lgamma_prior
+    frag_loglik = log_comb + log_prior + log_post
+    if !isfinite(frag_loglik)
+        frag_loglik = zero(T)
+    end
+
+    return (scribe_score, spectral_contrast, fitted_spectral_contrast, gof, max_matched_residual, max_unmatched_residual,
+            fitted_manhattan_distance, matched_ratio, frag_loglik, worst_pos, worst_intensity_ignored, num_matching_peaks)
 end
 
 function getDistanceMetrics(w::Vector{T}, 

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
@@ -72,6 +72,9 @@ const ADVANCED_FEATURE_SET = [
     :fitted_spectral_contrast,
     :spectral_contrast,
     :max_matched_ratio,
+    :frag_compensation_loglik,
+    :mean_frag_compensation_loglik,
+    :std_frag_compensation_loglik,
     :err_norm,
     :poisson,
     :weight_qbin,      # Quantile-binned version of :weight
@@ -118,6 +121,7 @@ const REDUCED_FEATURE_SET = [
     :max_fitted_manhattan_distance, :max_fitted_spectral_contrast,
     :max_matched_residual, :max_unmatched_residual, :max_gof,
     :fitted_spectral_contrast, :spectral_contrast, :max_matched_ratio,
+    :frag_compensation_loglik, :mean_frag_compensation_loglik, :std_frag_compensation_loglik,
     :err_norm, :poisson, :weight_qbin, :log2_intensity_explained, :tic_qbin, :num_scans,
     :smoothness, :percent_theoretical_ignored, :scribe, :max_scribe,
     # MS1 features

--- a/src/Routines/SearchDIA/SearchMethods/SearchTypes.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SearchTypes.jl
@@ -194,58 +194,6 @@ mutable struct SimpleLibrarySearch{I<:IsotopeSplineModel} <: SearchDataStructure
     precursor_transmission::Vector{Float32}
 end
 
-function SimpleLibrarySearch(
-    ion_matches::Vector{FragmentMatch{Float32}},
-    ion_misses::Vector{FragmentMatch{Float32}},
-    mass_err_matches::Vector{FragmentMatch{Float32}},
-    id_to_col::ArrayDict{UInt32, UInt16},
-    prec_count::Counter{UInt32, UInt8},
-    ion_templates::Vector{DetailedFrag{Float32}},
-    iso_splines::I,
-    scored_psms::Vector{SimpleScoredPSM{Float32, Float16}},
-    unscored_psms::Vector{SimpleUnscoredPSM{Float32}},
-    spectral_scores::Vector{SpectralScoresSimple{Float16}},
-    complex_scored_psms::Vector{ComplexScoredPSM{Float32, Float16}},
-    complex_unscored_psms::Vector{ComplexUnscoredPSM{Float32}},
-    complex_spectral_scores::Vector{SpectralScoresComplex{Float16}},
-    ms1_scored_psms::Vector{Ms1ScoredPSM{Float32, Float16}},
-    ms1_unscored_psms::Vector{Ms1UnscoredPSM{Float32}},
-    ms1_spectral_scores::Vector{SpectralScoresMs1{Float16}},
-    Hs::SparseArray,
-    prec_ids::Vector{UInt32},
-    precursor_weights::Vector{Float32},
-    temp_weights::Vector{Float32},
-    residuals::Vector{Float32},
-    isotopes::Vector{Float32},
-    precursor_transmission::Vector{Float32},
-) where {I<:IsotopeSplineModel}
-    return SimpleLibrarySearch{I}(
-        ion_matches,
-        ion_misses,
-        mass_err_matches,
-        id_to_col,
-        prec_count,
-        ion_templates,
-        iso_splines,
-        scored_psms,
-        unscored_psms,
-        spectral_scores,
-        complex_scored_psms,
-        complex_unscored_psms,
-        complex_spectral_scores,
-        ms1_scored_psms,
-        ms1_unscored_psms,
-        ms1_spectral_scores,
-        Hs,
-        prec_ids,
-        precursor_weights,
-        temp_weights,
-        residuals,
-        isotopes,
-        precursor_transmission,
-    )
-end
-
 """
 Primary search context holding all data structures and state for search execution.
 """

--- a/src/Routines/SearchDIA/SearchMethods/SearchTypes.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SearchTypes.jl
@@ -194,6 +194,58 @@ mutable struct SimpleLibrarySearch{I<:IsotopeSplineModel} <: SearchDataStructure
     precursor_transmission::Vector{Float32}
 end
 
+function SimpleLibrarySearch(
+    ion_matches::Vector{FragmentMatch{Float32}},
+    ion_misses::Vector{FragmentMatch{Float32}},
+    mass_err_matches::Vector{FragmentMatch{Float32}},
+    id_to_col::ArrayDict{UInt32, UInt16},
+    prec_count::Counter{UInt32, UInt8},
+    ion_templates::Vector{DetailedFrag{Float32}},
+    iso_splines::I,
+    scored_psms::Vector{SimpleScoredPSM{Float32, Float16}},
+    unscored_psms::Vector{SimpleUnscoredPSM{Float32}},
+    spectral_scores::Vector{SpectralScoresSimple{Float16}},
+    complex_scored_psms::Vector{ComplexScoredPSM{Float32, Float16}},
+    complex_unscored_psms::Vector{ComplexUnscoredPSM{Float32}},
+    complex_spectral_scores::Vector{SpectralScoresComplex{Float16}},
+    ms1_scored_psms::Vector{Ms1ScoredPSM{Float32, Float16}},
+    ms1_unscored_psms::Vector{Ms1UnscoredPSM{Float32}},
+    ms1_spectral_scores::Vector{SpectralScoresMs1{Float16}},
+    Hs::SparseArray,
+    prec_ids::Vector{UInt32},
+    precursor_weights::Vector{Float32},
+    temp_weights::Vector{Float32},
+    residuals::Vector{Float32},
+    isotopes::Vector{Float32},
+    precursor_transmission::Vector{Float32},
+) where {I<:IsotopeSplineModel}
+    return SimpleLibrarySearch{I}(
+        ion_matches,
+        ion_misses,
+        mass_err_matches,
+        id_to_col,
+        prec_count,
+        ion_templates,
+        iso_splines,
+        scored_psms,
+        unscored_psms,
+        spectral_scores,
+        complex_scored_psms,
+        complex_unscored_psms,
+        complex_spectral_scores,
+        ms1_scored_psms,
+        ms1_unscored_psms,
+        ms1_spectral_scores,
+        Hs,
+        prec_ids,
+        precursor_weights,
+        temp_weights,
+        residuals,
+        isotopes,
+        precursor_transmission,
+    )
+end
+
 """
 Primary search context holding all data structures and state for search execution.
 """

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/SecondPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/SecondPassSearch.jl
@@ -484,10 +484,11 @@ function process_search_results!(
         # Calculate summary scores for each PSM group
         for (key, gpsms) in pairs(groupby(psms, getPsmGroupbyCols(getIsotopeTraceType(params))))
             get_summary_scores!(
-                gpsms, 
+                gpsms,
                 gpsms[!,:weight],
                 gpsms[!,:gof],
                 gpsms[!,:matched_ratio],
+                gpsms[!,:frag_compensation_loglik],
                 gpsms[!,:fitted_manhattan_distance],
                 gpsms[!,:fitted_spectral_contrast],
                 gpsms[!,:scribe],

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -990,6 +990,8 @@ function init_summary_columns!(
         (:max_matched_ratio,        Float16)
         (:num_scans,        UInt16)
         (:smoothness,        Float32)
+        (:mean_frag_compensation_loglik, Float32)
+        (:std_frag_compensation_loglik, Float32)
         (:weights,        Vector{Float32})
         (:irts,         Vector{Float32})
         ];
@@ -1021,6 +1023,7 @@ function get_summary_scores!(
                             weight::AbstractVector{Float32},
                             gof::AbstractVector{Float16},
                             matched_ratio::AbstractVector{Float16},
+                            frag_comp_loglik::AbstractVector{<:AbstractFloat},
                             #entropy::AbstractVector{Float16},
                             fitted_manhattan_distance::AbstractVector{Float16},
                             fitted_spectral_contrast::AbstractVector{Float16},
@@ -1039,9 +1042,11 @@ function get_summary_scores!(
     y_ions_sum = 0
     max_y_ions = 0
     smoothness = 0.0f0
+    frag_loglik_sum = 0.0f0
+    frag_loglik_sum_sq = 0.0f0
 
     apex_scan = argmax(psms[!,:weight])
-    #Need to make sure there is not a big gap. 
+    #Need to make sure there is not a big gap.
     start = max(1, apex_scan - 2)
     stop = min(length(weight), apex_scan + 2)
 
@@ -1075,8 +1080,12 @@ function get_summary_scores!(
             max_y_ions = y_count[i]
         end
 
+        val = Float32(frag_comp_loglik[i])
+        frag_loglik_sum += val
+        frag_loglik_sum_sq += val * val
+
         count += 1
-    end    
+    end
 
     irts = rt_to_irt_interp.(psms.rt)
     
@@ -1094,7 +1103,7 @@ function get_summary_scores!(
         end
     end
 
-   
+
 
     psms.max_gof[apex_scan] = max_gof
     psms.max_matched_ratio[apex_scan] = max_matched_ratio
@@ -1108,6 +1117,12 @@ function get_summary_scores!(
     psms.smoothness[apex_scan] = smoothness
     psms.weights[apex_scan] = weight
     psms.irts[apex_scan] = irts
+    if count > 0
+        mean_loglik = frag_loglik_sum / Float32(count)
+        variance = max(frag_loglik_sum_sq / Float32(count) - mean_loglik^2, 0.0f0)
+        psms.mean_frag_compensation_loglik[apex_scan] = mean_loglik
+        psms.std_frag_compensation_loglik[apex_scan] = sqrt(variance)
+    end
     psms.best_scan[apex_scan] = true
 
 end

--- a/test/Routines/SearchDIA/PSMs/test_frag_compensation_loglik.jl
+++ b/test/Routines/SearchDIA/PSMs/test_frag_compensation_loglik.jl
@@ -1,0 +1,80 @@
+using Test
+using DataFrames
+using Pioneer
+using Pioneer: SparseArray, computeFittedMetricsFor, init_summary_columns!, get_summary_scores!, RtConversionModel
+
+@testset "Fragment compensation log-likelihood" begin
+    H = SparseArray{Int64, Float32}(2)
+    H.n_vals = 2
+    H.m = 2
+    H.n = 1
+    H.rowval = Int64[1, 2]
+    H.colval = UInt16[1, 1]
+    H.nzval = Float32[0.6, 0.4]
+    H.matched = Bool[true, false]
+    H.isotope = UInt8[0, 0]
+    H.x = Float32[0.5, 0.3]
+    H.colptr = Int64[1, 3]
+
+    w = Float32[1.0]
+    r = Float32[0.1, 0.1]
+    included = [1, 2]
+
+    metrics = computeFittedMetricsFor(w, H, r, 1, included)
+    (_, _, _, _, _, _, _, _, frag_loglik, _, _, _) = metrics
+
+    fitted_peaks = Float32.(w[1] .* H.nzval[included])
+    shadow_peaks = fitted_peaks .- r[H.rowval[included]]
+    total_counts = sum(shadow_peaks)
+    fitted_norm = fitted_peaks ./ sum(fitted_peaks)
+    shadow_norm = shadow_peaks ./ total_counts
+    prior_strength = Float32(Pioneer.FRAG_COMP_PRIOR_STRENGTH)
+    prior_offset = Float32(Pioneer.FRAG_COMP_PRIOR_OFFSET)
+    alpha = prior_strength .* fitted_norm .+ prior_offset
+    alpha0 = sum(alpha)
+    log_comb = lgamma(total_counts + 1f0) - sum(lgamma.(shadow_peaks .+ 1f0))
+    log_prior = lgamma(alpha0) - lgamma(total_counts + alpha0)
+    log_post = sum(lgamma.(shadow_peaks .+ alpha) .- lgamma.(alpha))
+    expected_loglik = log_comb + log_prior + log_post
+
+    @test isapprox(frag_loglik, expected_loglik; atol=1f-3)
+
+    psms = DataFrame(
+        weight = Float32[0.2, 0.5, 0.3],
+        gof = Float16[1, 2, 3],
+        matched_ratio = Float16[-1, 0, 1],
+        frag_compensation_loglik = Float16.([-0.5, -0.2, -0.3]),
+        fitted_manhattan_distance = Float16[-2, -1, -0.5],
+        fitted_spectral_contrast = Float16[0.1, 0.2, 0.3],
+        scribe = Float16[0.2, 0.4, 0.3],
+        y_count = UInt8[2, 3, 1],
+        rt = Float32[10.0, 10.1, 10.2]
+    )
+    psms.best_scan = falses(3)
+
+    init_summary_columns!(psms)
+
+    get_summary_scores!(
+        SubDataFrame(psms, 1:3),
+        psms.weight,
+        psms.gof,
+        psms.matched_ratio,
+        psms.frag_compensation_loglik,
+        psms.fitted_manhattan_distance,
+        psms.fitted_spectral_contrast,
+        psms.scribe,
+        psms.y_count,
+        RtConversionModel()
+    )
+
+    apex = argmax(psms.weight)
+    vals = Float32.(psms.frag_compensation_loglik)
+    expected_mean = sum(vals) / length(vals)
+    expected_std = sqrt(max(sum(vals .^ 2) / length(vals) - expected_mean^2, 0f0))
+
+    @test psms.best_scan[apex]
+    @test psms.mean_frag_compensation_loglik[apex] ≈ expected_mean atol=1f-6
+    @test psms.std_frag_compensation_loglik[apex] ≈ expected_std atol=1f-6
+    @test all(psms.mean_frag_compensation_loglik[setdiff(1:3, apex)] .== 0f0)
+    @test all(psms.std_frag_compensation_loglik[setdiff(1:3, apex)] .== 0f0)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -176,6 +176,7 @@ end
     include("./utils/FileOperations/streaming/test_stream_sorted_merge_basic.jl")
     include("./Routines/SearchDIA/SearchMethods/FirstPassSearch/test_irt_error_correction.jl")
     include("./Routines/SearchDIA/SearchMethods/ParameterTuningSearch/test_irt_propagation.jl")
+    include("./Routines/SearchDIA/PSMs/test_frag_compensation_loglik.jl")
     # ScoringSearch interface tests
 
     #include("./Routines/SearchDIA/SearchMethods/ScoringSearch/test_scoring_interface.jl")


### PR DESCRIPTION
## Summary
- compute the fragment compensation log-likelihood during complex spectral scoring and store it in the score structs
- surface the log-likelihood in SecondPassSearch outputs, aggregate apex summaries, and wire the features into the scoring models
- add a focused unit test covering the synthetic log-likelihood calculation and summary aggregation

## Testing
- not run (Julia executable unavailable in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69165c1f0dd8832586eba415854ee208)