### PR TITLE
feat: add residual profile summaries for second pass scoring

### DIFF
--- a/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
+++ b/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
@@ -82,6 +82,7 @@ struct ComplexScoredPSM{H,L<:AbstractFloat} <: ScoredPSM{H,L}
     percent_theoretical_ignored::L
     scribe::L
     #entropy_score::L
+    residual_profile::Vector{Float32}
     weight::H
 
     #Non-scores/Labels
@@ -312,6 +313,7 @@ function Score!(scored_psms::Vector{ComplexScoredPSM{H, L}},
             spectral_scores[scores_idx].matched_ratio,
             spectral_scores[scores_idx].percent_theoretical_ignored,
             spectral_scores[scores_idx].scribe,
+            Vector{Float32}(spectral_scores[scores_idx].residual_profile),
             #spectral_scores[scores_idx].entropy_score,
             weight[scores_idx],
 

--- a/src/Routines/SearchDIA/PSMs/spectralDistanceMetrics.jl
+++ b/src/Routines/SearchDIA/PSMs/spectralDistanceMetrics.jl
@@ -17,6 +17,8 @@
 
 abstract type SpectralScores{T<:AbstractFloat} end
 
+const RESIDUAL_PROFILE_LENGTH = 6
+
 struct SpectralScoresComplex{T<:AbstractFloat} <: SpectralScores{T}
     spectral_contrast::T
     fitted_spectral_contrast::T
@@ -28,6 +30,7 @@ struct SpectralScoresComplex{T<:AbstractFloat} <: SpectralScores{T}
     scribe::T
     percent_theoretical_ignored::T
     #entropy_score::T
+    residual_profile::NTuple{RESIDUAL_PROFILE_LENGTH, Float32}
 end
 
 struct SpectralScoresSimple{T<:AbstractFloat} <: SpectralScores{T} 
@@ -267,12 +270,13 @@ function getDistanceMetrics(w::Vector{T},
         num_matching_peaks = min_frags
 
         while num_matching_peaks ≥ min_frags
-            scr, spectral_contrast, fitted_spectral_contrast, gof, max_matched_residual, max_unmatched_residual, 
-            fitted_manhattan_distance, matched_ratio, worst_pos, worst_pred, num_matching_peaks = computeFittedMetricsFor(w, H, r, col, incl)
+            scr, spectral_contrast, fitted_spectral_contrast, gof, max_matched_residual, max_unmatched_residual,
+            fitted_manhattan_distance, matched_ratio, worst_pos, worst_pred, num_matching_peaks, residual_profile = computeFittedMetricsFor(w, H, r, col, incl)
 
             if best === nothing || scr > best.scribe * relative_improvement_threshold
-                best = (scribe=scr, sc=spectral_contrast, fsc=fitted_spectral_contrast, gof=gof, mmr=max_matched_residual, 
-                        mur=max_unmatched_residual, fmd=fitted_manhattan_distance, mr=matched_ratio)
+                best = (scribe=scr, sc=spectral_contrast, fsc=fitted_spectral_contrast, gof=gof, mmr=max_matched_residual,
+                        mur=max_unmatched_residual, fmd=fitted_manhattan_distance, mr=matched_ratio,
+                        residual_profile=residual_profile)
                 pct_ignored += worst_pred
             else
                 break                     # improvement too small
@@ -294,7 +298,8 @@ function getDistanceMetrics(w::Vector{T},
             Float16(best.fmd),                        # fitted manhattan (−log)
             Float16(best.mr),                         # matched / unmatched
             Float16(best.scribe),                     # scribe
-            Float16(pct_ignored)                      # percent_theoretical_ignored
+            Float16(pct_ignored),                     # percent_theoretical_ignored
+            best.residual_profile
         )
     end
 end
@@ -344,6 +349,9 @@ function computeFittedMetricsFor(w::Vector{T}, H::SparseArray{Ti,T}, r::Vector{T
     sum_of_fitted_peaks_unmatched_squared = zero(T)
 
     N = 0
+    residual_rank_keys = fill(-Inf32, RESIDUAL_PROFILE_LENGTH)
+    residual_profile_values = fill(0f0, RESIDUAL_PROFILE_LENGTH)
+
     @inbounds @fastmath for (local_pos, i) in enumerate(included_indices)
         #Fitted Manhattan Distance
         x_sum += H.x[i]
@@ -359,7 +367,7 @@ function computeFittedMetricsFor(w::Vector{T}, H::SparseArray{Ti,T}, r::Vector{T
         shadow_peak = fitted_peak - r[H.rowval[i]]
 
         r_abs = abs(r[H.rowval[i]])
-        sum_of_residuals += r_abs  
+        sum_of_residuals += r_abs
 
          #For scribe
          h_sqrt_sum += sqrt(fitted_peak)
@@ -382,6 +390,23 @@ function computeFittedMetricsFor(w::Vector{T}, H::SparseArray{Ti,T}, r::Vector{T
             if r_abs > max_unmatched_residual
                 max_unmatched_residual = r_abs
             end
+        end
+
+        # Track the strongest normalized residuals using absolute residual magnitude
+        fitted_peak_nonzero = max(fitted_peak, eps(T))
+        normalized_residual = Float32(r_abs / fitted_peak_nonzero)
+        key = Float32(r_abs)
+        min_idx = 1
+        min_val = residual_rank_keys[1]
+        @inbounds @fastmath for j in 2:RESIDUAL_PROFILE_LENGTH
+            if residual_rank_keys[j] < min_val
+                min_val = residual_rank_keys[j]
+                min_idx = j
+            end
+        end
+        if key > residual_rank_keys[min_idx]
+            residual_rank_keys[min_idx] = key
+            residual_profile_values[min_idx] = normalized_residual
         end
 
 
@@ -426,8 +451,11 @@ function computeFittedMetricsFor(w::Vector{T}, H::SparseArray{Ti,T}, r::Vector{T
     matched_ratio = log2(matched_sum/unmatched_sum)
     worst_intensity_ignored = worst_idx > 0 ? H.nzval[worst_idx] : 0.0
 
-    return (scribe_score, spectral_contrast, fitted_spectral_contrast, gof, max_matched_residual, max_unmatched_residual, 
-            fitted_manhattan_distance, matched_ratio, worst_pos, worst_intensity_ignored, num_matching_peaks)
+    order = sortperm(residual_rank_keys; rev=true)
+    ordered_profile = ntuple(i -> residual_profile_values[order[i]], RESIDUAL_PROFILE_LENGTH)
+
+    return (scribe_score, spectral_contrast, fitted_spectral_contrast, gof, max_matched_residual, max_unmatched_residual,
+            fitted_manhattan_distance, matched_ratio, worst_pos, worst_intensity_ignored, num_matching_peaks, ordered_profile)
 end
 
 function getDistanceMetrics(w::Vector{T}, 

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
@@ -16,10 +16,10 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 #==========================================================
-Model Configuration for ScoringSearch
-This file contains only the minimal functionality needed for model selection.
-The full model_comparison.jl file is deprecated and should not be used.
-==========================================================#
+# Model Configuration for ScoringSearch
+# This file contains only the minimal functionality needed for model selection.
+# The full model_comparison.jl file is deprecated and should not be used.
+#==========================================================#
 
 """
 Configuration for a single model in the scoring framework.

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
@@ -19,7 +19,7 @@
 # Model Configuration for ScoringSearch
 # This file contains only the minimal functionality needed for model selection.
 # The full model_comparison.jl file is deprecated and should not be used.
-#==========================================================#
+#==========================================================
 
 """
 Configuration for a single model in the scoring framework.

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
@@ -81,7 +81,10 @@ const ADVANCED_FEATURE_SET = [
     #:tic,
     :num_scans,
     :smoothness,
-    
+    :residual_corr_mean,
+    :residual_corr_negative_fraction,
+    :residual_corr_dom_eig_ratio,
+
     :ms1_ms2_rt_diff,  # MS1-MS2 RT difference in iRT space
     #:ms1_irt_diff,
     #:weight_ms1,
@@ -119,7 +122,8 @@ const REDUCED_FEATURE_SET = [
     :max_matched_residual, :max_unmatched_residual, :max_gof,
     :fitted_spectral_contrast, :spectral_contrast, :max_matched_ratio,
     :err_norm, :poisson, :weight_qbin, :log2_intensity_explained, :tic_qbin, :num_scans,
-    :smoothness, :percent_theoretical_ignored, :scribe, :max_scribe,
+    :smoothness, :residual_corr_mean, :residual_corr_negative_fraction,
+    :residual_corr_dom_eig_ratio, :percent_theoretical_ignored, :scribe, :max_scribe,
     # MS1 features
     :weight_ms1,
     :gof_ms1, :max_matched_residual_ms1, :max_unmatched_residual_ms1,

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -16,6 +16,10 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 #==========================================================
+using LinearAlgebra: Symmetric, eigvals
+using Statistics: cor
+
+#==========================================================
 Core Search Funtions
 ==========================================================#
 """
@@ -990,6 +994,9 @@ function init_summary_columns!(
         (:max_matched_ratio,        Float16)
         (:num_scans,        UInt16)
         (:smoothness,        Float32)
+        (:residual_corr_mean, Float32)
+        (:residual_corr_negative_fraction, Float32)
+        (:residual_corr_dom_eig_ratio, Float32)
         (:weights,        Vector{Float32})
         (:irts,         Vector{Float32})
         ];
@@ -1039,6 +1046,9 @@ function get_summary_scores!(
     y_ions_sum = 0
     max_y_ions = 0
     smoothness = 0.0f0
+    residual_corr_mean = 0.0f0
+    residual_corr_negative_fraction = 0.0f0
+    residual_corr_dom_eig_ratio = 0.0f0
 
     apex_scan = argmax(psms[!,:weight])
     #Need to make sure there is not a big gap. 
@@ -1078,6 +1088,53 @@ function get_summary_scores!(
         count += 1
     end    
 
+    raw_profiles = psms[!, :residual_profile]
+    profiles = [profile for profile in raw_profiles if !(profile isa Missing)]
+    if length(profiles) > 1
+        first_profile = profiles[1]
+        profile_length = length(first_profile)
+        consistent_length = profile_length > 0
+        profile_matrix = Matrix{Float32}(undef, length(profiles), profile_length)
+        @inbounds for (row_idx, profile) in enumerate(profiles)
+            if length(profile) != profile_length
+                consistent_length = false
+                break
+            end
+            @inbounds for col_idx in 1:profile_length
+                profile_matrix[row_idx, col_idx] = Float32(profile[col_idx])
+            end
+        end
+        if consistent_length && profile_length > 0
+            corr_matrix = cor(profile_matrix; dims=1)
+            corr_matrix = Float32.(corr_matrix)
+            @inbounds for idx in eachindex(corr_matrix)
+                if !isfinite(corr_matrix[idx])
+                    corr_matrix[idx] = 0.0f0
+                end
+            end
+            if profile_length > 1
+                total_pairs = profile_length * (profile_length - 1)
+                sum_corr = 0.0f0
+                negative_corr_count = 0
+                @inbounds @fastmath for i in 1:profile_length, j in 1:profile_length
+                    if i == j
+                        continue
+                    end
+                    val = corr_matrix[i, j]
+                    sum_corr += val
+                    negative_corr_count += val < 0.0f0
+                end
+                residual_corr_mean = sum_corr / Float32(total_pairs)
+                residual_corr_negative_fraction = Float32(negative_corr_count) / Float32(total_pairs)
+            end
+            eigenvalues = eigvals(Symmetric(corr_matrix))
+            total_eigen = sum(eigenvalues)
+            if total_eigen != 0
+                residual_corr_dom_eig_ratio = Float32(maximum(eigenvalues) / total_eigen)
+            end
+        end
+    end
+
     irts = rt_to_irt_interp.(psms.rt)
     
     @inbounds @fastmath for i in range(1, length(weight))
@@ -1106,6 +1163,9 @@ function get_summary_scores!(
     psms.max_y_ions[apex_scan] = max_y_ions
     psms.num_scans[apex_scan] = length(weight)
     psms.smoothness[apex_scan] = smoothness
+    psms.residual_corr_mean[apex_scan] = residual_corr_mean
+    psms.residual_corr_negative_fraction[apex_scan] = residual_corr_negative_fraction
+    psms.residual_corr_dom_eig_ratio[apex_scan] = residual_corr_dom_eig_ratio
     psms.weights[apex_scan] = weight
     psms.irts[apex_scan] = irts
     psms.best_scan[apex_scan] = true

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -21,7 +21,7 @@ using Statistics: cor
 
 #==========================================================
 # Core Search Functions
-#==========================================================#
+#==========================================================
 """
     perform_second_pass_search(spectra::MassSpecData, rt_index::retentionTimeIndex,
                              search_context::SearchContext, params::SecondPassSearchParameters,
@@ -586,8 +586,8 @@ end
 
 
 #==========================================================
-Temporarry array management functions
-==========================================================#
+# Temporary array management functions
+#==========================================================
 """
     resize_arrays!(search_data::SearchDataStructures, weights::Vector{Float32})
 
@@ -968,7 +968,7 @@ end
 
 #==========================================================
 # Summary Statistics
-#==========================================================#
+#==========================================================
 """
     init_summary_columns!(psms::DataFrame)
 
@@ -1133,7 +1133,7 @@ function get_summary_scores!(
         end
     end
 
-    irts = rt_to_irt_interp.(psms.rt)
+    irts = collect(Float32, rt_to_irt_interp.(psms.rt))
     
     @inbounds @fastmath for i in range(1, length(weight))
         if length(weight) == 1
@@ -1164,7 +1164,7 @@ function get_summary_scores!(
     psms.residual_corr_mean[apex_scan] = residual_corr_mean
     psms.residual_corr_negative_fraction[apex_scan] = residual_corr_negative_fraction
     psms.residual_corr_dom_eig_ratio[apex_scan] = residual_corr_dom_eig_ratio
-    psms.weights[apex_scan] = weight
+    psms.weights[apex_scan] = collect(Float32, weight)
     psms.irts[apex_scan] = irts
     psms.best_scan[apex_scan] = true
 

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -20,8 +20,8 @@ using LinearAlgebra: Symmetric, eigvals
 using Statistics: cor
 
 #==========================================================
-Core Search Funtions
-==========================================================#
+# Core Search Functions
+#==========================================================#
 """
     perform_second_pass_search(spectra::MassSpecData, rt_index::retentionTimeIndex,
                              search_context::SearchContext, params::SecondPassSearchParameters,
@@ -967,8 +967,8 @@ function add_features!(psms::DataFrame,
 end
 
 #==========================================================
-Summary Statistics 
-==========================================================#
+# Summary Statistics
+#==========================================================#
 """
     init_summary_columns!(psms::DataFrame)
 
@@ -979,9 +979,7 @@ Initialize columns for summary statistics across PSM groups.
 - Peak intensity metrics
 - Ion coverage statistics
 """
-function init_summary_columns!(
-    psms::DataFrame,
-    )
+function init_summary_columns!(psms::DataFrame)
 
     new_cols = [
         (:max_entropy,              Float16)

--- a/test/Routines/SearchDIA/SearchMethods/SecondPassSearch/test_residual_summary.jl
+++ b/test/Routines/SearchDIA/SearchMethods/SecondPassSearch/test_residual_summary.jl
@@ -1,0 +1,105 @@
+using Test
+using DataFrames
+using LinearAlgebra
+using Statistics
+using Pioneer: ComplexScoredPSM, init_summary_columns!, get_summary_scores!, RtConversionModel,
+                RESIDUAL_PROFILE_LENGTH
+
+@testset "Residual profile summaries" begin
+    K = RESIDUAL_PROFILE_LENGTH
+    profiles = [
+        Float32[0.45, 0.12, 0.18, 0.04, 0.06, 0.03],
+        Float32[0.22, 0.35, 0.08, 0.02, 0.05, 0.07],
+        Float32[0.38, 0.07, 0.16, 0.05, 0.03, 0.02]
+    ]
+
+    weights = Float32[0.4, 0.9, 0.6]
+    gof = Float16[1.1, 1.5, 1.3]
+    matched_ratio = Float16[0.2, 0.4, 0.3]
+    fitted_manhattan = Float16[1.2, 1.6, 1.4]
+    fitted_spectral = Float16[0.9, 1.1, 1.0]
+    spectral_contrast = Float16[0.95, 1.05, 0.98]
+    scribe = Float16[0.8, 1.0, 0.95]
+    y_counts = UInt8[5, 6, 5]
+
+    psms_vec = ComplexScoredPSM{Float32, Float16}[
+        ComplexScoredPSM(
+            UInt8(1), UInt8(1), UInt8(3), UInt8(3),
+            UInt8(2), UInt8(2), UInt8(4), y_counts[i], UInt8(1), UInt8(0), UInt8(0),
+            Float16(0.0),
+            Float16(-0.5),
+            Float16(0.1),
+            spectral_contrast[i],
+            fitted_spectral[i],
+            gof[i],
+            Float16(0.2),
+            Float16(0.15),
+            fitted_manhattan[i],
+            matched_ratio[i],
+            Float16(0.05),
+            scribe[i],
+            copy(profiles[i]),
+            weights[i],
+            UInt32(42),
+            UInt32(7),
+            UInt32(i)
+        ) for i in 1:length(profiles)
+    ]
+
+    df = DataFrame(psms_vec)
+    df.rt = Float32[101.0, 101.4, 100.9]
+    df.best_scan = falses(nrow(df))
+
+    init_summary_columns!(df)
+
+    grouped = groupby(df, :precursor_idx)
+    rt_model = RtConversionModel()
+
+    @test length(grouped) == 1
+    group = first(grouped)
+
+    get_summary_scores!(
+        group,
+        group[!, :weight],
+        group[!, :gof],
+        group[!, :matched_ratio],
+        group[!, :fitted_manhattan_distance],
+        group[!, :fitted_spectral_contrast],
+        group[!, :scribe],
+        group[!, :y_count],
+        rt_model
+    )
+
+    @test df.residual_profile isa Vector{Vector{Float32}}
+    @test df.residual_profile[2] == profiles[2]
+
+    apex_index = argmax(group[!, :weight])
+    apex_row = group[apex_index, :]
+
+    matrix = Matrix{Float32}(undef, length(profiles), K)
+    for (row, profile) in enumerate(profiles)
+        matrix[row, :] = profile
+    end
+    corr_matrix = cor(matrix; dims=1)
+    corr_matrix = Float32.(corr_matrix)
+    corr_matrix .= isfinite.(corr_matrix) .* corr_matrix
+
+    total_pairs = K * (K - 1)
+    off_diag_sum = 0.0f0
+    negative_count = 0
+    for i in 1:K, j in 1:K
+        i == j && continue
+        val = corr_matrix[i, j]
+        off_diag_sum += val
+        negative_count += val < 0.0f0
+    end
+
+    expected_mean = off_diag_sum / Float32(total_pairs)
+    expected_neg_fraction = Float32(negative_count) / Float32(total_pairs)
+    eigenvalues = eigvals(Symmetric(corr_matrix))
+    expected_ratio = Float32(maximum(eigenvalues) / sum(eigenvalues))
+
+    @test isapprox(apex_row.residual_corr_mean, expected_mean; atol=1f-6)
+    @test isapprox(apex_row.residual_corr_negative_fraction, expected_neg_fraction; atol=1f-6)
+    @test isapprox(apex_row.residual_corr_dom_eig_ratio, expected_ratio; atol=1f-6)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -176,6 +176,7 @@ end
     include("./utils/FileOperations/streaming/test_stream_sorted_merge_basic.jl")
     include("./Routines/SearchDIA/SearchMethods/FirstPassSearch/test_irt_error_correction.jl")
     include("./Routines/SearchDIA/SearchMethods/ParameterTuningSearch/test_irt_propagation.jl")
+    include("./Routines/SearchDIA/SearchMethods/SecondPassSearch/test_residual_summary.jl")
     # ScoringSearch interface tests
 
     #include("./Routines/SearchDIA/SearchMethods/ScoringSearch/test_scoring_interface.jl")


### PR DESCRIPTION
## Summary
- capture the strongest normalized residuals during complex spectral scoring and persist them on each ComplexScoredPSM
- compute group-level residual correlation metrics in second-pass summaries and surface them in the advanced and reduced feature sets
- add a regression test that exercises the new aggregation logic on mocked residual profiles

## Testing
- Not run (Julia executable unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916669cda548325886236d54e9d373b)