### PR TITLE
Add log-weight regression features to scoring summaries

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/README.md
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/README.md
@@ -91,7 +91,11 @@ PSM Count Decision Tree:
 ### Feature Sets
 
 - **ADVANCED_FEATURE_SET**: 50+ features including all spectral, RT, MS1, and quality metrics
-- **REDUCED_FEATURE_SET**: 40+ core features for balanced performance  
+  - Includes chromatographic weight-trend regressions (:weight_scribe_slope, :weight_scribe_rho,
+    :weight_fitted_spectral_contrast_slope, :weight_fitted_spectral_contrast_rho,
+    :weight_matched_ratio_slope, :weight_matched_ratio_rho) derived from scan-level log-weight fits
+- **REDUCED_FEATURE_SET**: 40+ core features for balanced performance
+  - Shares the same weight-trend regression metrics to capture peak shape agreement between scores and log(weight)
 - **MINIMAL_FEATURE_SET**: 5 essential features (spectral contrast, residuals, error norms, intensity explained)
 - **MBR Features**: Automatically appended when match_between_runs=true
 

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
@@ -100,7 +100,13 @@ const ADVANCED_FEATURE_SET = [
     
     :percent_theoretical_ignored,
     :scribe,
-    :max_scribe
+    :max_scribe,
+    :weight_scribe_slope,
+    :weight_scribe_rho,
+    :weight_fitted_spectral_contrast_slope,
+    :weight_fitted_spectral_contrast_rho,
+    :weight_matched_ratio_slope,
+    :weight_matched_ratio_rho
     # MBR features added automatically if match_between_runs=true
 ]
 
@@ -120,6 +126,9 @@ const REDUCED_FEATURE_SET = [
     :fitted_spectral_contrast, :spectral_contrast, :max_matched_ratio,
     :err_norm, :poisson, :weight_qbin, :log2_intensity_explained, :tic_qbin, :num_scans,
     :smoothness, :percent_theoretical_ignored, :scribe, :max_scribe,
+    :weight_scribe_slope, :weight_scribe_rho,
+    :weight_fitted_spectral_contrast_slope, :weight_fitted_spectral_contrast_rho,
+    :weight_matched_ratio_slope, :weight_matched_ratio_rho,
     # MS1 features
     :weight_ms1,
     :gof_ms1, :max_matched_residual_ms1, :max_unmatched_residual_ms1,

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -990,6 +990,12 @@ function init_summary_columns!(
         (:max_matched_ratio,        Float16)
         (:num_scans,        UInt16)
         (:smoothness,        Float32)
+        (:weight_scribe_slope, Float32)
+        (:weight_scribe_rho, Float32)
+        (:weight_fitted_spectral_contrast_slope, Float32)
+        (:weight_fitted_spectral_contrast_rho, Float32)
+        (:weight_matched_ratio_slope, Float32)
+        (:weight_matched_ratio_rho, Float32)
         (:weights,        Vector{Float32})
         (:irts,         Vector{Float32})
         ];
@@ -1006,6 +1012,40 @@ function init_summary_columns!(
             end
         end
         return psms
+end
+
+function compute_weight_regression(
+    weight::AbstractVector,
+    feature::AbstractVector,
+)
+    valid_indices = Int[]
+    for idx in eachindex(weight, feature)
+        w = weight[idx]
+        f = feature[idx]
+        if !ismissing(w) && !ismissing(f) && w > 0 && isfinite(w) && isfinite(f)
+            push!(valid_indices, idx)
+        end
+    end
+
+    if length(valid_indices) < 2
+        return 0.0f0, 0.0f0
+    end
+
+    log_weight = log.(Float64.(view(weight, valid_indices)))
+    feature_vals = Float64.(view(feature, valid_indices))
+
+    centered_log_weight = log_weight .- Statistics.mean(log_weight)
+    centered_feature = feature_vals .- Statistics.mean(feature_vals)
+
+    numerator = sum(centered_log_weight .* centered_feature)
+    denom = sum(centered_log_weight .^ 2)
+    slope = denom > 0 ? numerator / denom : 0.0
+
+    denom_x = sqrt(denom)
+    denom_y = sqrt(sum(centered_feature .^ 2))
+    rho = (denom_x > 0 && denom_y > 0) ? numerator / (denom_x * denom_y) : 0.0
+
+    return Float32(slope), Float32(rho)
 end
 
 """
@@ -1108,6 +1148,15 @@ function get_summary_scores!(
     psms.smoothness[apex_scan] = smoothness
     psms.weights[apex_scan] = weight
     psms.irts[apex_scan] = irts
+    scribe_slope, scribe_rho = compute_weight_regression(weight, scribe)
+    fsc_slope, fsc_rho = compute_weight_regression(weight, fitted_spectral_contrast)
+    matched_ratio_slope, matched_ratio_rho = compute_weight_regression(weight, matched_ratio)
+    psms.weight_scribe_slope[apex_scan] = scribe_slope
+    psms.weight_scribe_rho[apex_scan] = scribe_rho
+    psms.weight_fitted_spectral_contrast_slope[apex_scan] = fsc_slope
+    psms.weight_fitted_spectral_contrast_rho[apex_scan] = fsc_rho
+    psms.weight_matched_ratio_slope[apex_scan] = matched_ratio_slope
+    psms.weight_matched_ratio_rho[apex_scan] = matched_ratio_rho
     psms.best_scan[apex_scan] = true
 
 end

--- a/test/Routines/SearchDIA/SearchMethods/ScoringSearch/test_model_config.jl
+++ b/test/Routines/SearchDIA/SearchMethods/ScoringSearch/test_model_config.jl
@@ -18,4 +18,18 @@ using Pioneer
     @test :intercept ∉ model_by_name["SimpleLightGBM"].features
     @test :intercept ∉ model_by_name["AdvancedLightGBM"].features
     @test :intercept ∉ model_by_name["SuperSimplified"].features
+
+    weight_trend_features = [
+        :weight_scribe_slope,
+        :weight_scribe_rho,
+        :weight_fitted_spectral_contrast_slope,
+        :weight_fitted_spectral_contrast_rho,
+        :weight_matched_ratio_slope,
+        :weight_matched_ratio_rho,
+    ]
+
+    for feature in weight_trend_features
+        @test feature in model_by_name["SimpleLightGBM"].features
+        @test feature in model_by_name["AdvancedLightGBM"].features
+    end
 end


### PR DESCRIPTION
## Summary
- add placeholder summary columns for log-weight regression slopes and correlations
- populate the new summary metrics from per-group scan data and surface them to LightGBM configs
- document the new features and extend model configuration tests to cover them

## Testing
- `julia --project -e 'using Pkg; Pkg.test(; test_args=["Routines/SearchDIA/SearchMethods/ScoringSearch"])'` *(fails: `julia` command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691666b3addc8325b34bac2e2c484cfa)