### PR TITLE
Add chromatogram-level probit model for shared library selection

### DIFF
--- a/src/Routines/SearchDIA/LibrarySearch.jl
+++ b/src/Routines/SearchDIA/LibrarySearch.jl
@@ -230,14 +230,98 @@ function getPSMS(
         reset!(Hs)
     end
     if last_val == 0
+        @user_info "LibrarySearch.getPSMS produced 0 scored PSMs for file $(ms_file_idx); returning empty schema"
         return empty_simple_psm_dataframe()
     end
 
-    df = DataFrame(@view(getScoredPsms(search_data)[1:last_val]))
+    scored_slice = @view(getScoredPsms(search_data)[1:last_val])
+    df = build_simple_psm_dataframe(scored_slice)
 
     if !hasproperty(df, :scribe)
         available = join(string.(propertynames(df)), ", ")
-        @user_error "First-pass search expected :scribe column but found: [$available]"
+        first_type = eltype(scored_slice)
+        @user_error "First-pass search expected :scribe column but found: [$available] from slice type $(first_type)"
+    end
+
+    return df
+end
+
+function build_simple_psm_dataframe(psms::AbstractVector)
+    n = length(psms)
+    if n == 0
+        return empty_simple_psm_dataframe()
+    end
+
+    required_fields = (
+        :best_rank,
+        :topn,
+        :b_count,
+        :y_count,
+        :p_count,
+        :i_count,
+        :poisson,
+        :error,
+        :scribe,
+        :city_block,
+        :spectral_contrast,
+        :matched_ratio,
+        :log2_summed_intensity,
+        :entropy_score,
+        :percent_theoretical_ignored,
+        :precursor_idx,
+        :scan_idx,
+    )
+
+    first_psm = psms[1]
+    fields = fieldnames(typeof(first_psm))
+    has_required = all(field -> field in fields, required_fields)
+
+    if !has_required
+        df = DataFrame(psms)
+        available = join(string.(propertynames(df)), ", ")
+        @user_info "PSM slice converted without schema optimization; available columns: [$available]"
+        return df
+    end
+
+    df = DataFrame(
+        best_rank = Vector{typeof(getfield(first_psm, :best_rank))}(undef, n),
+        topn = Vector{typeof(getfield(first_psm, :topn))}(undef, n),
+        b_count = Vector{typeof(getfield(first_psm, :b_count))}(undef, n),
+        y_count = Vector{typeof(getfield(first_psm, :y_count))}(undef, n),
+        p_count = Vector{typeof(getfield(first_psm, :p_count))}(undef, n),
+        i_count = Vector{typeof(getfield(first_psm, :i_count))}(undef, n),
+        poisson = Vector{typeof(getfield(first_psm, :poisson))}(undef, n),
+        error = Vector{typeof(getfield(first_psm, :error))}(undef, n),
+        scribe = Vector{typeof(getfield(first_psm, :scribe))}(undef, n),
+        city_block = Vector{typeof(getfield(first_psm, :city_block))}(undef, n),
+        spectral_contrast = Vector{typeof(getfield(first_psm, :spectral_contrast))}(undef, n),
+        matched_ratio = Vector{typeof(getfield(first_psm, :matched_ratio))}(undef, n),
+        log2_summed_intensity = Vector{typeof(getfield(first_psm, :log2_summed_intensity))}(undef, n),
+        entropy_score = Vector{typeof(getfield(first_psm, :entropy_score))}(undef, n),
+        percent_theoretical_ignored = Vector{typeof(getfield(first_psm, :percent_theoretical_ignored))}(undef, n),
+        precursor_idx = Vector{typeof(getfield(first_psm, :precursor_idx))}(undef, n),
+        scan_idx = Vector{typeof(getfield(first_psm, :scan_idx))}(undef, n),
+    )
+
+    @inbounds for i in 1:n
+        psm = psms[i]
+        df.best_rank[i] = getfield(psm, :best_rank)
+        df.topn[i] = getfield(psm, :topn)
+        df.b_count[i] = getfield(psm, :b_count)
+        df.y_count[i] = getfield(psm, :y_count)
+        df.p_count[i] = getfield(psm, :p_count)
+        df.i_count[i] = getfield(psm, :i_count)
+        df.poisson[i] = getfield(psm, :poisson)
+        df.error[i] = getfield(psm, :error)
+        df.scribe[i] = getfield(psm, :scribe)
+        df.city_block[i] = getfield(psm, :city_block)
+        df.spectral_contrast[i] = getfield(psm, :spectral_contrast)
+        df.matched_ratio[i] = getfield(psm, :matched_ratio)
+        df.log2_summed_intensity[i] = getfield(psm, :log2_summed_intensity)
+        df.entropy_score[i] = getfield(psm, :entropy_score)
+        df.percent_theoretical_ignored[i] = getfield(psm, :percent_theoretical_ignored)
+        df.precursor_idx[i] = getfield(psm, :precursor_idx)
+        df.scan_idx[i] = getfield(psm, :scan_idx)
     end
 
     return df

--- a/src/Routines/SearchDIA/LibrarySearch.jl
+++ b/src/Routines/SearchDIA/LibrarySearch.jl
@@ -90,6 +90,28 @@ function searchFragmentIndex(
     return precursors_passed_scoring[1:prec_id]
 end
 
+function empty_simple_psm_dataframe()
+    return DataFrame(
+        best_rank = UInt8[],
+        topn = UInt8[],
+        b_count = UInt8[],
+        y_count = UInt8[],
+        p_count = UInt8[],
+        i_count = UInt8[],
+        poisson = Float16[],
+        error = Float32[],
+        scribe = Float16[],
+        city_block = Float16[],
+        spectral_contrast = Float16[],
+        matched_ratio = Float16[],
+        log2_summed_intensity = Float16[],
+        entropy_score = Float16[],
+        percent_theoretical_ignored = Float16[],
+        precursor_idx = UInt32[],
+        scan_idx = UInt32[],
+    )
+end
+
 function getPSMS(
     ms_file_idx::UInt32,
     spectra::MassSpecData,
@@ -207,7 +229,18 @@ function getPSMS(
         reset!(getIdToCol(search_data))
         reset!(Hs)
     end
-    return DataFrame(@view(getScoredPsms(search_data)[1:last_val]))
+    if last_val == 0
+        return empty_simple_psm_dataframe()
+    end
+
+    df = DataFrame(@view(getScoredPsms(search_data)[1:last_val]))
+
+    if !hasproperty(df, :scribe)
+        available = join(string.(propertynames(df)), ", ")
+        @user_error "First-pass search expected :scribe column but found: [$available]"
+    end
+
+    return df
 end
 
 function library_search(spectra::MassSpecData, search_context::SearchContext, search_parameters::P, ms_file_idx::Int64) where {P<:ParameterTuningSearchParameters}

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -456,8 +456,19 @@ function process_file!(
         end
         # Process scores
        
-        select!(psms, [:ms_file_idx, :score, :precursor_idx, :scan_idx,
-            :q_value, :log2_summed_intensity, :irt, :rt, :irt_predicted, :target])
+        select!(psms, [
+            :ms_file_idx,
+            :score,
+            :scribe,
+            :precursor_idx,
+            :scan_idx,
+            :q_value,
+            :log2_summed_intensity,
+            :irt,
+            :rt,
+            :irt_predicted,
+            :target,
+        ])
         get_probs!(psms, psms[!,:score])
     end
 

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -456,7 +456,9 @@ function process_file!(
         end
         # Process scores
        
-        select!(psms, [
+        # Preserve the probit feature inputs alongside the metadata columns needed downstream so
+        # chromatogram aggregation and diagnostics can continue to access them.
+        base_columns = Symbol[
             :ms_file_idx,
             :score,
             :scribe,
@@ -468,7 +470,20 @@ function process_file!(
             :rt,
             :irt_predicted,
             :target,
-        ])
+            :charge,
+        ]
+        preserved_columns = Symbol[]
+        for col in base_columns
+            if hasproperty(psms, col)
+                push!(preserved_columns, col)
+            end
+        end
+        for col in FIRST_PASS_PROBIT_FEATURE_COLUMNS
+            if hasproperty(psms, col) && !(col in preserved_columns)
+                push!(preserved_columns, col)
+            end
+        end
+        select!(psms, preserved_columns)
         get_probs!(psms, psms[!,:score])
     end
 

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -313,6 +313,8 @@ function process_file!(
         # Add columns
         add_psm_columns!(psms, spectra, search_context, rt_model, ms_file_idx)
 
+        chrom_source = prepare_chromatogram_feature_source(psms)
+
         if !isempty(psms)
             target_mask_enter = psms[!, :target]
             decoy_mask_enter = .!target_mask_enter
@@ -330,8 +332,19 @@ function process_file!(
         # Score PSMs
         score_psms!(psms, params, search_context, spectra)
 
-        for prec in psms[!, :precursor_idx]
-            push!(results.probit_precursor_candidates, UInt32(prec))
+        chrom_candidates, target_prec_count, decoy_prec_count = chromatogram_precursor_candidates!(
+            chrom_source,
+            psms,
+            params,
+            search_context,
+            spectra,
+            ms_file_idx
+        )
+
+        @user_info "FirstPassSearch file $(file_label) chromatogram-level probit filter passed $(target_prec_count) target precursors and $(decoy_prec_count) decoy precursors"
+
+        for prec in chrom_candidates
+            push!(results.probit_precursor_candidates, prec)
         end
 
         # Get best PSMs

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
@@ -262,6 +262,7 @@ function score_chromatogram_features!(chrom_summary::DataFrame,
     chrom_summary[!, :score] = zeros(Float32, n)
     chrom_summary[!, :q_value] = ones(Float16, n)
     chrom_summary[!, :PEP] = ones(Float16, n)
+
     feature_columns = [
         :scribe,
         :max_gof,
@@ -279,6 +280,22 @@ function score_chromatogram_features!(chrom_summary::DataFrame,
         :precursor_fraction_transmitted,
         :intercept
     ]
+
+    zero_var_cols = Symbol[]
+    for col in feature_columns
+        col === :intercept && continue
+        min_val, max_val = extrema(chrom_summary[!, col])
+        if min_val == max_val
+            push!(zero_var_cols, col)
+        end
+    end
+    if !isempty(zero_var_cols)
+        feature_columns = filter(col -> !(col in zero_var_cols), feature_columns)
+    end
+    if isempty(feature_columns)
+        return chrom_summary
+    end
+
     fdr_scale_factor = getLibraryFdrScaleFactor(search_context)
     score_main_search_psms!(
         chrom_summary,

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
@@ -257,21 +257,63 @@ function summarize_chromatograms(chrom_df::DataFrame)
     has_err_norm = hasproperty(chrom_df, :err_norm)
     has_spectrum_peaks = hasproperty(chrom_df, :spectrum_peak_count)
 
-    has_spectral_contrast && (summary_cols[:max_spectral_contrast] = Vector{Float32}(undef, n_groups))
-    has_city_block && (summary_cols[:max_city_block] = Vector{Float32}(undef, n_groups))
-    has_entropy_score && (summary_cols[:max_entropy_score] = Vector{Float32}(undef, n_groups))
-    has_scribe && (summary_cols[:max_scribe] = Vector{Float32}(undef, n_groups))
-    has_percent_theoretical_ignored && (summary_cols[:max_percent_theoretical_ignored] = Vector{Float32}(undef, n_groups))
-    has_charge2 && (summary_cols[:max_charge2] = Vector{Float32}(undef, n_groups))
-    has_poisson && (summary_cols[:max_poisson] = Vector{Float32}(undef, n_groups))
-    has_irt_error && (summary_cols[:min_irt_error] = Vector{Float32}(undef, n_groups))
-    has_missed_cleavage && (summary_cols[:max_missed_cleavage] = Vector{Float32}(undef, n_groups))
-    has_Mox && (summary_cols[:max_Mox] = Vector{Float32}(undef, n_groups))
-    has_TIC && (summary_cols[:max_TIC] = Vector{Float32}(undef, n_groups))
-    has_y_count && (summary_cols[:max_y_count] = Vector{Float32}(undef, n_groups))
-    has_y_count && (summary_cols[:sum_y_count] = Vector{Float32}(undef, n_groups))
-    has_err_norm && (summary_cols[:max_err_norm] = Vector{Float32}(undef, n_groups))
-    has_spectrum_peaks && (summary_cols[:max_spectrum_peak_count] = Vector{Float32}(undef, n_groups))
+    has_spectral_contrast && begin
+        summary_cols[:spectral_contrast] = Vector{Float32}(undef, n_groups)
+        summary_cols[:max_spectral_contrast] = Vector{Float32}(undef, n_groups)
+    end
+    has_city_block && begin
+        summary_cols[:city_block] = Vector{Float32}(undef, n_groups)
+        summary_cols[:max_city_block] = Vector{Float32}(undef, n_groups)
+    end
+    has_entropy_score && begin
+        summary_cols[:entropy_score] = Vector{Float32}(undef, n_groups)
+        summary_cols[:max_entropy_score] = Vector{Float32}(undef, n_groups)
+    end
+    has_scribe && begin
+        summary_cols[:scribe] = Vector{Float32}(undef, n_groups)
+        summary_cols[:max_scribe] = Vector{Float32}(undef, n_groups)
+    end
+    has_percent_theoretical_ignored && begin
+        summary_cols[:percent_theoretical_ignored] = Vector{Float32}(undef, n_groups)
+        summary_cols[:max_percent_theoretical_ignored] = Vector{Float32}(undef, n_groups)
+    end
+    has_charge2 && begin
+        summary_cols[:charge2] = Vector{Float32}(undef, n_groups)
+        summary_cols[:max_charge2] = Vector{Float32}(undef, n_groups)
+    end
+    has_poisson && begin
+        summary_cols[:poisson] = Vector{Float32}(undef, n_groups)
+        summary_cols[:max_poisson] = Vector{Float32}(undef, n_groups)
+    end
+    has_irt_error && begin
+        summary_cols[:irt_error] = Vector{Float32}(undef, n_groups)
+        summary_cols[:min_irt_error] = Vector{Float32}(undef, n_groups)
+    end
+    has_missed_cleavage && begin
+        summary_cols[:missed_cleavage] = Vector{Float32}(undef, n_groups)
+        summary_cols[:max_missed_cleavage] = Vector{Float32}(undef, n_groups)
+    end
+    has_Mox && begin
+        summary_cols[:Mox] = Vector{Float32}(undef, n_groups)
+        summary_cols[:max_Mox] = Vector{Float32}(undef, n_groups)
+    end
+    has_TIC && begin
+        summary_cols[:TIC] = Vector{Float32}(undef, n_groups)
+        summary_cols[:max_TIC] = Vector{Float32}(undef, n_groups)
+    end
+    has_y_count && begin
+        summary_cols[:y_count] = Vector{Float32}(undef, n_groups)
+        summary_cols[:max_y_count] = Vector{Float32}(undef, n_groups)
+        summary_cols[:sum_y_count] = Vector{Float32}(undef, n_groups)
+    end
+    has_err_norm && begin
+        summary_cols[:err_norm] = Vector{Float32}(undef, n_groups)
+        summary_cols[:max_err_norm] = Vector{Float32}(undef, n_groups)
+    end
+    has_spectrum_peaks && begin
+        summary_cols[:spectrum_peak_count] = Vector{Float32}(undef, n_groups)
+        summary_cols[:max_spectrum_peak_count] = Vector{Float32}(undef, n_groups)
+    end
 
     max_or_zero(values) = begin
         data = collect(skipmissing(values))
@@ -293,47 +335,75 @@ function summarize_chromatograms(chrom_df::DataFrame)
         summary_cols[:target][i] = Bool(first(coalesce.(group[!, :target], false)))
         summary_cols[:num_scans][i] = Float32(nrow(group))
         if has_spectral_contrast
-            summary_cols[:max_spectral_contrast][i] = max_or_zero(group[!, :spectral_contrast])
+            val = max_or_zero(group[!, :spectral_contrast])
+            summary_cols[:spectral_contrast][i] = val
+            summary_cols[:max_spectral_contrast][i] = val
         end
         if has_city_block
-            summary_cols[:max_city_block][i] = max_or_zero(group[!, :city_block])
+            val = max_or_zero(group[!, :city_block])
+            summary_cols[:city_block][i] = val
+            summary_cols[:max_city_block][i] = val
         end
         if has_entropy_score
-            summary_cols[:max_entropy_score][i] = max_or_zero(group[!, :entropy_score])
+            val = max_or_zero(group[!, :entropy_score])
+            summary_cols[:entropy_score][i] = val
+            summary_cols[:max_entropy_score][i] = val
         end
         if has_scribe
-            summary_cols[:max_scribe][i] = max_or_zero(group[!, :scribe])
+            val = max_or_zero(group[!, :scribe])
+            summary_cols[:scribe][i] = val
+            summary_cols[:max_scribe][i] = val
         end
         if has_percent_theoretical_ignored
-            summary_cols[:max_percent_theoretical_ignored][i] = max_or_zero(group[!, :percent_theoretical_ignored])
+            val = max_or_zero(group[!, :percent_theoretical_ignored])
+            summary_cols[:percent_theoretical_ignored][i] = val
+            summary_cols[:max_percent_theoretical_ignored][i] = val
         end
         if has_charge2
-            summary_cols[:max_charge2][i] = max_or_zero(group[!, :charge2])
+            val = max_or_zero(group[!, :charge2])
+            summary_cols[:charge2][i] = val
+            summary_cols[:max_charge2][i] = val
         end
         if has_poisson
-            summary_cols[:max_poisson][i] = max_or_zero(group[!, :poisson])
+            val = max_or_zero(group[!, :poisson])
+            summary_cols[:poisson][i] = val
+            summary_cols[:max_poisson][i] = val
         end
         if has_irt_error
-            summary_cols[:min_irt_error][i] = min_or_zero(group[!, :irt_error])
+            val = min_or_zero(group[!, :irt_error])
+            summary_cols[:irt_error][i] = val
+            summary_cols[:min_irt_error][i] = val
         end
         if has_missed_cleavage
-            summary_cols[:max_missed_cleavage][i] = max_or_zero(group[!, :missed_cleavage])
+            val = max_or_zero(group[!, :missed_cleavage])
+            summary_cols[:missed_cleavage][i] = val
+            summary_cols[:max_missed_cleavage][i] = val
         end
         if has_Mox
-            summary_cols[:max_Mox][i] = max_or_zero(group[!, :Mox])
+            val = max_or_zero(group[!, :Mox])
+            summary_cols[:Mox][i] = val
+            summary_cols[:max_Mox][i] = val
         end
         if has_TIC
-            summary_cols[:max_TIC][i] = max_or_zero(group[!, :TIC])
+            val = max_or_zero(group[!, :TIC])
+            summary_cols[:TIC][i] = val
+            summary_cols[:max_TIC][i] = val
         end
         if has_y_count
-            summary_cols[:max_y_count][i] = max_or_zero(group[!, :y_count])
+            val = max_or_zero(group[!, :y_count])
+            summary_cols[:y_count][i] = val
+            summary_cols[:max_y_count][i] = val
             summary_cols[:sum_y_count][i] = sum_or_zero(group[!, :y_count])
         end
         if has_err_norm
-            summary_cols[:max_err_norm][i] = max_or_zero(group[!, :err_norm])
+            val = max_or_zero(group[!, :err_norm])
+            summary_cols[:err_norm][i] = val
+            summary_cols[:max_err_norm][i] = val
         end
         if has_spectrum_peaks
-            summary_cols[:max_spectrum_peak_count][i] = max_or_zero(group[!, :spectrum_peak_count])
+            val = max_or_zero(group[!, :spectrum_peak_count])
+            summary_cols[:spectrum_peak_count][i] = val
+            summary_cols[:max_spectrum_peak_count][i] = val
         end
     end
 

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
@@ -120,6 +120,23 @@ function add_main_search_columns!(psms::DataFrame,
     psms[!,:intercept] = ones(Float16, N)
 end
 
+const FIRST_PASS_PROBIT_FEATURE_COLUMNS = (
+    :spectral_contrast,
+    :city_block,
+    :entropy_score,
+    :scribe,
+    :percent_theoretical_ignored,
+    :charge2,
+    :poisson,
+    :irt_error,
+    :missed_cleavage,
+    :Mox,
+    :TIC,
+    :y_count,
+    :err_norm,
+    :spectrum_peak_count,
+)
+
 function prepare_chromatogram_feature_source(psms::DataFrame)
     if nrow(psms) == 0
         return DataFrame()
@@ -129,14 +146,7 @@ function prepare_chromatogram_feature_source(psms::DataFrame)
     mandatory_cols = (:precursor_idx, :scan_idx, :rt, :target)
     optional_cols = (
         :weight,
-        :gof,
-        :matched_ratio,
-        :fitted_manhattan_distance,
-        :fitted_spectral_contrast,
-        :scribe,
-        :y_count,
-        :log2_summed_intensity,
-        :precursor_fraction_transmitted,
+        FIRST_PASS_PROBIT_FEATURE_COLUMNS...,
     )
 
     missing_mandatory = Symbol[]
@@ -259,32 +269,52 @@ function summarize_chromatograms(chrom_df::DataFrame)
     summary_cols[:num_scans] = Vector{Float32}(undef, n_groups)
 
     has_weight = hasproperty(chrom_df, :weight)
-    has_gof = hasproperty(chrom_df, :gof)
-    has_matched_ratio = hasproperty(chrom_df, :matched_ratio)
-    has_fmd = hasproperty(chrom_df, :fitted_manhattan_distance)
-    has_fsc = hasproperty(chrom_df, :fitted_spectral_contrast)
+    has_spectral_contrast = hasproperty(chrom_df, :spectral_contrast)
+    has_city_block = hasproperty(chrom_df, :city_block)
+    has_entropy_score = hasproperty(chrom_df, :entropy_score)
     has_scribe = hasproperty(chrom_df, :scribe)
+    has_percent_theoretical_ignored = hasproperty(chrom_df, :percent_theoretical_ignored)
+    has_charge2 = hasproperty(chrom_df, :charge2)
+    has_poisson = hasproperty(chrom_df, :poisson)
+    has_irt_error = hasproperty(chrom_df, :irt_error)
+    has_missed_cleavage = hasproperty(chrom_df, :missed_cleavage)
+    has_Mox = hasproperty(chrom_df, :Mox)
+    has_TIC = hasproperty(chrom_df, :TIC)
     has_y_count = hasproperty(chrom_df, :y_count)
-    has_log2_sum = hasproperty(chrom_df, :log2_summed_intensity)
-    has_prob = hasproperty(chrom_df, :prob)
-    has_score = hasproperty(chrom_df, :score)
-    has_fraction = hasproperty(chrom_df, :precursor_fraction_transmitted)
+    has_err_norm = hasproperty(chrom_df, :err_norm)
+    has_spectrum_peaks = hasproperty(chrom_df, :spectrum_peak_count)
 
     if has_weight
         summary_cols[:smoothness] = Vector{Float32}(undef, n_groups)
-        summary_cols[:max_weight] = Vector{Float32}(undef, n_groups)
     end
-    has_gof && (summary_cols[:max_gof] = Vector{Float32}(undef, n_groups))
-    has_matched_ratio && (summary_cols[:max_matched_ratio] = Vector{Float32}(undef, n_groups))
-    has_fmd && (summary_cols[:max_fitted_manhattan_distance] = Vector{Float32}(undef, n_groups))
-    has_fsc && (summary_cols[:max_fitted_spectral_contrast] = Vector{Float32}(undef, n_groups))
+    has_spectral_contrast && (summary_cols[:max_spectral_contrast] = Vector{Float32}(undef, n_groups))
+    has_city_block && (summary_cols[:max_city_block] = Vector{Float32}(undef, n_groups))
+    has_entropy_score && (summary_cols[:max_entropy_score] = Vector{Float32}(undef, n_groups))
     has_scribe && (summary_cols[:max_scribe] = Vector{Float32}(undef, n_groups))
-    has_y_count && (summary_cols[:max_y_ions] = Vector{Float32}(undef, n_groups))
-    has_y_count && (summary_cols[:y_ions_sum] = Vector{Float32}(undef, n_groups))
-    has_log2_sum && (summary_cols[:max_log2_summed_intensity] = Vector{Float32}(undef, n_groups))
-    has_prob && (summary_cols[:max_psm_prob] = Vector{Float32}(undef, n_groups))
-    has_score && (summary_cols[:max_score] = Vector{Float32}(undef, n_groups))
-    has_fraction && (summary_cols[:precursor_fraction_transmitted] = Vector{Float32}(undef, n_groups))
+    has_percent_theoretical_ignored && (summary_cols[:max_percent_theoretical_ignored] = Vector{Float32}(undef, n_groups))
+    has_charge2 && (summary_cols[:max_charge2] = Vector{Float32}(undef, n_groups))
+    has_poisson && (summary_cols[:max_poisson] = Vector{Float32}(undef, n_groups))
+    has_irt_error && (summary_cols[:min_irt_error] = Vector{Float32}(undef, n_groups))
+    has_missed_cleavage && (summary_cols[:max_missed_cleavage] = Vector{Float32}(undef, n_groups))
+    has_Mox && (summary_cols[:max_Mox] = Vector{Float32}(undef, n_groups))
+    has_TIC && (summary_cols[:max_TIC] = Vector{Float32}(undef, n_groups))
+    has_y_count && (summary_cols[:max_y_count] = Vector{Float32}(undef, n_groups))
+    has_y_count && (summary_cols[:sum_y_count] = Vector{Float32}(undef, n_groups))
+    has_err_norm && (summary_cols[:max_err_norm] = Vector{Float32}(undef, n_groups))
+    has_spectrum_peaks && (summary_cols[:max_spectrum_peak_count] = Vector{Float32}(undef, n_groups))
+
+    max_or_zero(values) = begin
+        data = collect(skipmissing(values))
+        return isempty(data) ? 0.0f0 : Float32(maximum(data))
+    end
+    sum_or_zero(values) = begin
+        data = collect(skipmissing(values))
+        return isempty(data) ? 0.0f0 : Float32(sum(Float64.(data)))
+    end
+    min_or_zero(values) = begin
+        data = collect(skipmissing(values))
+        return isempty(data) ? 0.0f0 : Float32(minimum(data))
+    end
 
     for (i, group) in enumerate(grouped)
         order = sortperm(group[!, :rt])
@@ -298,39 +328,49 @@ function summarize_chromatograms(chrom_df::DataFrame)
 
         if has_weight
             summary_cols[:smoothness][i] = chromatogram_smoothness(weights, rts)
-            summary_cols[:max_weight][i] = isempty(weights) ? 0.0f0 : maximum(weights)
         end
-        if has_gof
-            summary_cols[:max_gof][i] = maximum(Float32.(coalesce.(group[!, :gof], 0.0f0)))
+        if has_spectral_contrast
+            summary_cols[:max_spectral_contrast][i] = max_or_zero(group[!, :spectral_contrast])
         end
-        if has_matched_ratio
-            summary_cols[:max_matched_ratio][i] = maximum(Float32.(coalesce.(group[!, :matched_ratio], 0.0f0)))
+        if has_city_block
+            summary_cols[:max_city_block][i] = max_or_zero(group[!, :city_block])
         end
-        if has_fmd
-            summary_cols[:max_fitted_manhattan_distance][i] = maximum(Float32.(coalesce.(group[!, :fitted_manhattan_distance], 0.0f0)))
-        end
-        if has_fsc
-            summary_cols[:max_fitted_spectral_contrast][i] = maximum(Float32.(coalesce.(group[!, :fitted_spectral_contrast], 0.0f0)))
+        if has_entropy_score
+            summary_cols[:max_entropy_score][i] = max_or_zero(group[!, :entropy_score])
         end
         if has_scribe
-            summary_cols[:max_scribe][i] = maximum(Float32.(coalesce.(group[!, :scribe], 0.0f0)))
+            summary_cols[:max_scribe][i] = max_or_zero(group[!, :scribe])
+        end
+        if has_percent_theoretical_ignored
+            summary_cols[:max_percent_theoretical_ignored][i] = max_or_zero(group[!, :percent_theoretical_ignored])
+        end
+        if has_charge2
+            summary_cols[:max_charge2][i] = max_or_zero(group[!, :charge2])
+        end
+        if has_poisson
+            summary_cols[:max_poisson][i] = max_or_zero(group[!, :poisson])
+        end
+        if has_irt_error
+            summary_cols[:min_irt_error][i] = min_or_zero(group[!, :irt_error])
+        end
+        if has_missed_cleavage
+            summary_cols[:max_missed_cleavage][i] = max_or_zero(group[!, :missed_cleavage])
+        end
+        if has_Mox
+            summary_cols[:max_Mox][i] = max_or_zero(group[!, :Mox])
+        end
+        if has_TIC
+            summary_cols[:max_TIC][i] = max_or_zero(group[!, :TIC])
         end
         if has_y_count
-            y_vals = Float32.(coalesce.(group[!, :y_count], 0.0f0))
-            summary_cols[:max_y_ions][i] = maximum(y_vals)
-            summary_cols[:y_ions_sum][i] = sum(y_vals)
+            summary_cols[:max_y_count][i] = max_or_zero(group[!, :y_count])
+            summary_cols[:sum_y_count][i] = sum_or_zero(group[!, :y_count])
         end
-        if has_log2_sum
-            summary_cols[:max_log2_summed_intensity][i] = maximum(Float32.(coalesce.(group[!, :log2_summed_intensity], 0.0f0)))
+        if has_err_norm
+            summary_cols[:max_err_norm][i] = max_or_zero(group[!, :err_norm])
         end
-        if has_prob
-            summary_cols[:max_psm_prob][i] = maximum(Float32.(coalesce.(group[!, :prob], 0.0f0)))
-        end
-        if has_score
-            summary_cols[:max_score][i] = maximum(Float32.(coalesce.(group[!, :score], 0.0f0)))
-        end
-        if has_fraction
-            summary_cols[:precursor_fraction_transmitted][i] = maximum(Float32.(coalesce.(group[!, :precursor_fraction_transmitted], 0.0f0)))
+        if has_spectrum_peaks
+            summary_cols[:max_spectrum_peak_count][i] = max_or_zero(group[!, :spectrum_peak_count])
         end
     end
 
@@ -345,9 +385,6 @@ function score_chromatogram_features!(chrom_summary::DataFrame,
         return chrom_summary
     end
 
-    if hasproperty(chrom_summary, :max_scribe)
-        chrom_summary[!, :scribe] = Float32.(chrom_summary[!, :max_scribe])
-    end
     chrom_summary[!, :intercept] = ones(Float32, n)
     chrom_summary[!, :score] = zeros(Float32, n)
     chrom_summary[!, :q_value] = ones(Float16, n)
@@ -356,27 +393,28 @@ function score_chromatogram_features!(chrom_summary::DataFrame,
     feature_candidates = Symbol[]
     has_num_scans = hasproperty(chrom_summary, :num_scans)
     has_num_scans && push!(feature_candidates, :num_scans)
-    if hasproperty(chrom_summary, :scribe)
-        push!(feature_candidates, :scribe)
-    end
+    hasproperty(chrom_summary, :smoothness) && push!(feature_candidates, :smoothness)
 
-    expected_optional = (
-        :max_gof,
-        :max_matched_ratio,
-        :max_fitted_manhattan_distance,
-        :max_fitted_spectral_contrast,
-        :smoothness,
-        :max_y_ions,
-        :y_ions_sum,
-        :max_log2_summed_intensity,
-        :max_weight,
-        :max_psm_prob,
-        :max_score,
-        :precursor_fraction_transmitted,
+    aggregate_feature_order = (
+        :max_spectral_contrast,
+        :max_city_block,
+        :max_entropy_score,
+        :max_scribe,
+        :max_percent_theoretical_ignored,
+        :max_charge2,
+        :max_poisson,
+        :min_irt_error,
+        :max_missed_cleavage,
+        :max_Mox,
+        :max_TIC,
+        :max_y_count,
+        :sum_y_count,
+        :max_err_norm,
+        :max_spectrum_peak_count,
     )
 
     missing_for_scoring = Symbol[]
-    for col in expected_optional
+    for col in aggregate_feature_order
         if hasproperty(chrom_summary, col)
             push!(feature_candidates, col)
         else

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
@@ -179,7 +179,7 @@ function prepare_chromatogram_feature_source(psms::DataFrame)
         @user_warn "Chromatogram feature source missing mandatory columns: $(join(string.(missing_mandatory), ", "))"
     end
     if !isempty(missing_optional)
-        @user_debug "Chromatogram feature source missing optional columns: $(join(string.(missing_optional), ", "))"
+        @user_info "Chromatogram feature source missing optional columns: $(join(string.(missing_optional), ", "))"
     end
 
     return chrom_df
@@ -423,7 +423,7 @@ function score_chromatogram_features!(chrom_summary::DataFrame,
     end
 
     if !isempty(missing_for_scoring)
-        @user_debug "Skipping unavailable chromatogram-level features: $(join(string.(missing_for_scoring), ", "))"
+        @user_info "Skipping unavailable chromatogram-level features: $(join(string.(missing_for_scoring), ", "))"
     end
 
     push!(feature_candidates, :intercept)

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
@@ -47,16 +47,16 @@ Adds essential columns to PSM DataFrame for scoring and analysis.
 - Scoring columns: score, q_value
 - Analysis columns: target, spectrum_peak_count, err_norm
 """
-function add_main_search_columns!(psms::DataFrame, 
+function add_main_search_columns!(psms::DataFrame,
                                 rt_irt::T,
                                 structural_mods::AbstractVector{Union{Missing, String}},
                                 prec_missed_cleavages::Arrow.Primitive{UInt8, Vector{UInt8}},
                                 prec_is_decoy::Arrow.BoolVector{Bool},
                                 prec_irt::Arrow.Primitive{U, Vector{U}},
                                 prec_charge::Arrow.Primitive{UInt8, Vector{UInt8}},
-                                scan_retention_time::AbstractVector{Float32},
-                                tic::AbstractVector{Float32},
-                                masses::AbstractArray;
+    scan_retention_time::AbstractVector{Float32},
+    tic::AbstractVector{Float32},
+    masses::AbstractArray;
 ) where {T,U<:AbstractFloat}
     
     ###########################
@@ -118,6 +118,204 @@ function add_main_search_columns!(psms::DataFrame,
     psms[!,:score] = zeros(Float32, N);
     psms[!,:q_value] = zeros(Float16, N);
     psms[!,:intercept] = ones(Float16, N)
+end
+
+function prepare_chromatogram_feature_source(psms::DataFrame)
+    if nrow(psms) == 0
+        return DataFrame()
+    end
+    required_cols = (
+        :precursor_idx,
+        :scan_idx,
+        :rt,
+        :weight,
+        :gof,
+        :matched_ratio,
+        :fitted_manhattan_distance,
+        :fitted_spectral_contrast,
+        :scribe,
+        :y_count,
+        :log2_summed_intensity,
+        :target
+    )
+
+    chrom_df = DataFrame()
+    for col in required_cols
+        if hasproperty(psms, col)
+            chrom_df[!, col] = copy(psms[!, col])
+        else
+            default_value = col === :target ? false : 0
+            chrom_df[!, col] = fill(default_value, nrow(psms))
+        end
+    end
+    return chrom_df
+end
+
+function assign_pair_indices!(chrom_df::DataFrame, search_context::SearchContext)
+    if nrow(chrom_df) == 0 || hasproperty(chrom_df, :pair_idx)
+        return chrom_df
+    end
+    pair_ids = getPairIdx(getPrecursors(getSpecLib(search_context)))
+    chrom_df[!, :pair_idx] = Vector{UInt32}(undef, nrow(chrom_df))
+    @inbounds for (idx, prec_idx) in enumerate(chrom_df[!, :precursor_idx])
+        chrom_df[idx, :pair_idx] = extract_pair_idx(pair_ids, prec_idx)
+    end
+    return chrom_df
+end
+
+function annotate_isotopes!(chrom_df::DataFrame,
+                            search_context::SearchContext,
+                            spectra::MassSpecData,
+                            ms_file_idx::Int)
+    if nrow(chrom_df) == 0
+        return chrom_df
+    end
+    quad_model = getQuadTransmissionModel(search_context, ms_file_idx)
+    precursors = getPrecursors(getSpecLib(search_context))
+    get_isotopes_captured!(
+        chrom_df,
+        SeperateTraces(),
+        quad_model,
+        getSearchData(search_context),
+        chrom_df[!, :scan_idx],
+        getCharge(precursors),
+        getMz(precursors),
+        getSulfurCount(precursors),
+        getCenterMzs(spectra),
+        getIsolationWidthMzs(spectra)
+    )
+    return chrom_df
+end
+
+function chromatogram_smoothness(weights::Vector{<:Real}, rts::Vector{<:Real})
+    n = length(weights)
+    if n == 0
+        return 0.0f0
+    end
+    apex_idx = argmax(weights)
+    apex_weight = weights[apex_idx]
+    if apex_weight == 0
+        return 0.0f0
+    end
+    smoothness = 0.0f0
+    for i in 1:n
+        if n == 1
+            smoothness += (-2 * weights[i] / apex_weight)^2
+        elseif i == 1
+            smoothness += (((weights[i+1] - weights[i]) / (rts[i+1] - rts[i]) + (-weights[i]) / (rts[i+1] - rts[i])) / apex_weight)^2
+        elseif i == n
+            smoothness += (((weights[i-1] - weights[i]) / (rts[i] - rts[i-1]) + (-weights[i]) / (rts[i] - rts[i-1])) / apex_weight)^2
+        else
+            smoothness += (((weights[i-1] - weights[i]) / (rts[i] - rts[i-1]) + (weights[i+1] - weights[i]) / (rts[i+1] - rts[i])) / apex_weight)^2
+        end
+    end
+    return Float32(smoothness)
+end
+
+function summarize_chromatograms(chrom_df::DataFrame)
+    if nrow(chrom_df) == 0 || !hasproperty(chrom_df, :isotopes_captured)
+        return DataFrame()
+    end
+    grouped = groupby(chrom_df, [:precursor_idx, :pair_idx, :isotopes_captured])
+    rows = Vector{NamedTuple}(undef, length(grouped))
+    for (i, group) in enumerate(grouped)
+        order = sortperm(group[!, :rt])
+        weights = Float32.(coalesce.(group[order, :weight], 0.0f0))
+        rts = Float32.(coalesce.(group[order, :rt], 0.0f0))
+        smoothness = chromatogram_smoothness(weights, rts)
+        score_vals = Float32.(coalesce.(group[!, :score], 0.0f0))
+        prob_vals = hasproperty(group, :prob) ? Float32.(coalesce.(group[!, :prob], 0.0f0)) : fill(0.5f0, nrow(group))
+        fraction_vals = hasproperty(group, :precursor_fraction_transmitted) ? Float32.(coalesce.(group[!, :precursor_fraction_transmitted], 0.0f0)) : fill(0.0f0, nrow(group))
+        rows[i] = (
+            precursor_idx = first(group[!, :precursor_idx]),
+            pair_idx = first(group[!, :pair_idx]),
+            isotopes_captured = first(group[!, :isotopes_captured]),
+            target = Bool(first(coalesce.(group[!, :target], false))),
+            max_gof = maximum(Float32.(coalesce.(group[!, :gof], 0.0f0))),
+            max_matched_ratio = maximum(Float32.(coalesce.(group[!, :matched_ratio], 0.0f0))),
+            max_fitted_manhattan_distance = maximum(Float32.(coalesce.(group[!, :fitted_manhattan_distance], 0.0f0))),
+            max_fitted_spectral_contrast = maximum(Float32.(coalesce.(group[!, :fitted_spectral_contrast], 0.0f0))),
+            max_scribe = maximum(Float32.(coalesce.(group[!, :scribe], 0.0f0))),
+            max_y_ions = maximum(Float32.(coalesce.(group[!, :y_count], 0.0f0))),
+            y_ions_sum = Float32(sum(coalesce.(group[!, :y_count], 0))),
+            num_scans = Float32(nrow(group)),
+            smoothness = smoothness,
+            max_log2_summed_intensity = maximum(Float32.(coalesce.(group[!, :log2_summed_intensity], 0.0f0))),
+            max_weight = maximum(weights),
+            max_psm_prob = maximum(prob_vals),
+            max_score = maximum(score_vals),
+            precursor_fraction_transmitted = maximum(fraction_vals)
+        )
+    end
+    return DataFrame(rows)
+end
+
+function score_chromatogram_features!(chrom_summary::DataFrame,
+                                      params::FirstPassSearchParameters,
+                                      search_context::SearchContext)
+    n = nrow(chrom_summary)
+    if n == 0
+        return chrom_summary
+    end
+    chrom_summary[!, :scribe] = Float32.(chrom_summary[!, :max_scribe])
+    chrom_summary[!, :intercept] = ones(Float32, n)
+    chrom_summary[!, :score] = zeros(Float32, n)
+    chrom_summary[!, :q_value] = ones(Float16, n)
+    chrom_summary[!, :PEP] = ones(Float16, n)
+    feature_columns = [
+        :scribe,
+        :max_gof,
+        :max_matched_ratio,
+        :max_fitted_manhattan_distance,
+        :max_fitted_spectral_contrast,
+        :smoothness,
+        :num_scans,
+        :max_y_ions,
+        :y_ions_sum,
+        :max_log2_summed_intensity,
+        :max_weight,
+        :max_psm_prob,
+        :max_score,
+        :precursor_fraction_transmitted,
+        :intercept
+    ]
+    fdr_scale_factor = getLibraryFdrScaleFactor(search_context)
+    score_main_search_psms!(
+        chrom_summary,
+        feature_columns,
+        n_train_rounds = params.n_train_rounds_probit,
+        max_iter_per_round = params.max_iter_probit,
+        max_q_value = Float64(params.max_q_value_probit_rescore),
+        fdr_scale_factor = fdr_scale_factor
+    )
+    get_probs!(chrom_summary, chrom_summary[!, :score])
+    get_PEP!(chrom_summary[!, :score], chrom_summary[!, :target], chrom_summary[!, :PEP]; doSort=false, fdr_scale_factor=fdr_scale_factor)
+    return chrom_summary
+end
+
+function chromatogram_precursor_candidates!(chrom_source::DataFrame,
+                                            scored_psms::DataFrame,
+                                            params::FirstPassSearchParameters,
+                                            search_context::SearchContext,
+                                            spectra::MassSpecData,
+                                            ms_file_idx::Int)
+    if nrow(chrom_source) == 0 || nrow(scored_psms) == 0
+        return (Set{UInt32}(), 0, 0)
+    end
+    scores_df = select(scored_psms, [:precursor_idx, :scan_idx, :score, :prob])
+    chrom_data = leftjoin(chrom_source, scores_df, on=[:precursor_idx, :scan_idx]; makeunique=true)
+    assign_pair_indices!(chrom_data, search_context)
+    annotate_isotopes!(chrom_data, search_context, spectra, ms_file_idx)
+    chrom_summary = summarize_chromatograms(chrom_data)
+    chrom_summary = score_chromatogram_features!(chrom_summary, params, search_context)
+    if nrow(chrom_summary) == 0
+        return (Set{UInt32}(), 0, 0)
+    end
+    passing_mask = chrom_summary[!, :PEP] .<= Float16(params.max_PEP)
+    passing = chrom_summary[passing_mask, :]
+    targets = Set{UInt32}(passing[passing[!, :target], :precursor_idx])
+    decoys = Set{UInt32}(passing[.!passing[!, :target], :precursor_idx])
+    return (Set{UInt32}(passing[!, :precursor_idx]), length(targets), length(decoys))
 end
 
 """

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
@@ -290,9 +290,12 @@ function score_chromatogram_features!(chrom_summary::DataFrame,
         end
     end
     if !isempty(zero_var_cols)
-        feature_columns = filter(col -> !(col in zero_var_cols), feature_columns)
+        dropped = join(string.(zero_var_cols), ", ")
+        @user_warn "Dropping $(length(zero_var_cols)) zero-variance chromatogram features: $dropped"
+        filter!(col -> !(col in zero_var_cols), feature_columns)
     end
-    if isempty(feature_columns)
+    if length(feature_columns) <= 1
+        @user_warn "Skipping chromatogram-level probit scoring because no varying features remain after filtering"
         return chrom_summary
     end
 

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
@@ -124,10 +124,10 @@ function prepare_chromatogram_feature_source(psms::DataFrame)
     if nrow(psms) == 0
         return DataFrame()
     end
-    required_cols = (
-        :precursor_idx,
-        :scan_idx,
-        :rt,
+
+    chrom_df = DataFrame()
+    mandatory_cols = (:precursor_idx, :scan_idx, :rt, :target)
+    optional_cols = (
         :weight,
         :gof,
         :matched_ratio,
@@ -136,18 +136,42 @@ function prepare_chromatogram_feature_source(psms::DataFrame)
         :scribe,
         :y_count,
         :log2_summed_intensity,
-        :target
+        :precursor_fraction_transmitted,
     )
 
-    chrom_df = DataFrame()
-    for col in required_cols
+    missing_mandatory = Symbol[]
+    for col in mandatory_cols
         if hasproperty(psms, col)
             chrom_df[!, col] = copy(psms[!, col])
         else
-            default_value = col === :target ? false : 0
+            push!(missing_mandatory, col)
+            default_value = if col === :target
+                false
+            elseif col === :rt
+                0.0f0
+            else
+                UInt32(0)
+            end
             chrom_df[!, col] = fill(default_value, nrow(psms))
         end
     end
+
+    missing_optional = Symbol[]
+    for col in optional_cols
+        if hasproperty(psms, col)
+            chrom_df[!, col] = copy(psms[!, col])
+        else
+            push!(missing_optional, col)
+        end
+    end
+
+    if !isempty(missing_mandatory)
+        @user_warn "Chromatogram feature source missing mandatory columns: $(join(string.(missing_mandatory), ", "))"
+    end
+    if !isempty(missing_optional)
+        @user_debug "Chromatogram feature source missing optional columns: $(join(string.(missing_optional), ", "))"
+    end
+
     return chrom_df
 end
 
@@ -216,38 +240,101 @@ function summarize_chromatograms(chrom_df::DataFrame)
     if nrow(chrom_df) == 0 || !hasproperty(chrom_df, :isotopes_captured)
         return DataFrame()
     end
+
     grouped = groupby(chrom_df, [:precursor_idx, :pair_idx, :isotopes_captured])
-    rows = Vector{NamedTuple}(undef, length(grouped))
+    n_groups = length(grouped)
+    if n_groups == 0
+        return DataFrame()
+    end
+
+    precursor_type = eltype(chrom_df[!, :precursor_idx])
+    pair_type = hasproperty(chrom_df, :pair_idx) ? eltype(chrom_df[!, :pair_idx]) : UInt32
+    isotope_type = eltype(chrom_df[!, :isotopes_captured])
+
+    summary_cols = Dict{Symbol, AbstractVector}()
+    summary_cols[:precursor_idx] = Vector{precursor_type}(undef, n_groups)
+    summary_cols[:pair_idx] = Vector{pair_type}(undef, n_groups)
+    summary_cols[:isotopes_captured] = Vector{isotope_type}(undef, n_groups)
+    summary_cols[:target] = Vector{Bool}(undef, n_groups)
+    summary_cols[:num_scans] = Vector{Float32}(undef, n_groups)
+
+    has_weight = hasproperty(chrom_df, :weight)
+    has_gof = hasproperty(chrom_df, :gof)
+    has_matched_ratio = hasproperty(chrom_df, :matched_ratio)
+    has_fmd = hasproperty(chrom_df, :fitted_manhattan_distance)
+    has_fsc = hasproperty(chrom_df, :fitted_spectral_contrast)
+    has_scribe = hasproperty(chrom_df, :scribe)
+    has_y_count = hasproperty(chrom_df, :y_count)
+    has_log2_sum = hasproperty(chrom_df, :log2_summed_intensity)
+    has_prob = hasproperty(chrom_df, :prob)
+    has_score = hasproperty(chrom_df, :score)
+    has_fraction = hasproperty(chrom_df, :precursor_fraction_transmitted)
+
+    if has_weight
+        summary_cols[:smoothness] = Vector{Float32}(undef, n_groups)
+        summary_cols[:max_weight] = Vector{Float32}(undef, n_groups)
+    end
+    has_gof && (summary_cols[:max_gof] = Vector{Float32}(undef, n_groups))
+    has_matched_ratio && (summary_cols[:max_matched_ratio] = Vector{Float32}(undef, n_groups))
+    has_fmd && (summary_cols[:max_fitted_manhattan_distance] = Vector{Float32}(undef, n_groups))
+    has_fsc && (summary_cols[:max_fitted_spectral_contrast] = Vector{Float32}(undef, n_groups))
+    has_scribe && (summary_cols[:max_scribe] = Vector{Float32}(undef, n_groups))
+    has_y_count && (summary_cols[:max_y_ions] = Vector{Float32}(undef, n_groups))
+    has_y_count && (summary_cols[:y_ions_sum] = Vector{Float32}(undef, n_groups))
+    has_log2_sum && (summary_cols[:max_log2_summed_intensity] = Vector{Float32}(undef, n_groups))
+    has_prob && (summary_cols[:max_psm_prob] = Vector{Float32}(undef, n_groups))
+    has_score && (summary_cols[:max_score] = Vector{Float32}(undef, n_groups))
+    has_fraction && (summary_cols[:precursor_fraction_transmitted] = Vector{Float32}(undef, n_groups))
+
     for (i, group) in enumerate(grouped)
         order = sortperm(group[!, :rt])
-        weights = Float32.(coalesce.(group[order, :weight], 0.0f0))
+        weights = has_weight ? Float32.(coalesce.(group[order, :weight], 0.0f0)) : Float32[]
         rts = Float32.(coalesce.(group[order, :rt], 0.0f0))
-        smoothness = chromatogram_smoothness(weights, rts)
-        score_vals = Float32.(coalesce.(group[!, :score], 0.0f0))
-        prob_vals = hasproperty(group, :prob) ? Float32.(coalesce.(group[!, :prob], 0.0f0)) : fill(0.5f0, nrow(group))
-        fraction_vals = hasproperty(group, :precursor_fraction_transmitted) ? Float32.(coalesce.(group[!, :precursor_fraction_transmitted], 0.0f0)) : fill(0.0f0, nrow(group))
-        rows[i] = (
-            precursor_idx = first(group[!, :precursor_idx]),
-            pair_idx = first(group[!, :pair_idx]),
-            isotopes_captured = first(group[!, :isotopes_captured]),
-            target = Bool(first(coalesce.(group[!, :target], false))),
-            max_gof = maximum(Float32.(coalesce.(group[!, :gof], 0.0f0))),
-            max_matched_ratio = maximum(Float32.(coalesce.(group[!, :matched_ratio], 0.0f0))),
-            max_fitted_manhattan_distance = maximum(Float32.(coalesce.(group[!, :fitted_manhattan_distance], 0.0f0))),
-            max_fitted_spectral_contrast = maximum(Float32.(coalesce.(group[!, :fitted_spectral_contrast], 0.0f0))),
-            max_scribe = maximum(Float32.(coalesce.(group[!, :scribe], 0.0f0))),
-            max_y_ions = maximum(Float32.(coalesce.(group[!, :y_count], 0.0f0))),
-            y_ions_sum = Float32(sum(coalesce.(group[!, :y_count], 0))),
-            num_scans = Float32(nrow(group)),
-            smoothness = smoothness,
-            max_log2_summed_intensity = maximum(Float32.(coalesce.(group[!, :log2_summed_intensity], 0.0f0))),
-            max_weight = maximum(weights),
-            max_psm_prob = maximum(prob_vals),
-            max_score = maximum(score_vals),
-            precursor_fraction_transmitted = maximum(fraction_vals)
-        )
+        summary_cols[:precursor_idx][i] = first(group[!, :precursor_idx])
+        summary_cols[:pair_idx][i] = first(group[!, :pair_idx])
+        summary_cols[:isotopes_captured][i] = first(group[!, :isotopes_captured])
+        summary_cols[:target][i] = Bool(first(coalesce.(group[!, :target], false)))
+        summary_cols[:num_scans][i] = Float32(nrow(group))
+
+        if has_weight
+            summary_cols[:smoothness][i] = chromatogram_smoothness(weights, rts)
+            summary_cols[:max_weight][i] = isempty(weights) ? 0.0f0 : maximum(weights)
+        end
+        if has_gof
+            summary_cols[:max_gof][i] = maximum(Float32.(coalesce.(group[!, :gof], 0.0f0)))
+        end
+        if has_matched_ratio
+            summary_cols[:max_matched_ratio][i] = maximum(Float32.(coalesce.(group[!, :matched_ratio], 0.0f0)))
+        end
+        if has_fmd
+            summary_cols[:max_fitted_manhattan_distance][i] = maximum(Float32.(coalesce.(group[!, :fitted_manhattan_distance], 0.0f0)))
+        end
+        if has_fsc
+            summary_cols[:max_fitted_spectral_contrast][i] = maximum(Float32.(coalesce.(group[!, :fitted_spectral_contrast], 0.0f0)))
+        end
+        if has_scribe
+            summary_cols[:max_scribe][i] = maximum(Float32.(coalesce.(group[!, :scribe], 0.0f0)))
+        end
+        if has_y_count
+            y_vals = Float32.(coalesce.(group[!, :y_count], 0.0f0))
+            summary_cols[:max_y_ions][i] = maximum(y_vals)
+            summary_cols[:y_ions_sum][i] = sum(y_vals)
+        end
+        if has_log2_sum
+            summary_cols[:max_log2_summed_intensity][i] = maximum(Float32.(coalesce.(group[!, :log2_summed_intensity], 0.0f0)))
+        end
+        if has_prob
+            summary_cols[:max_psm_prob][i] = maximum(Float32.(coalesce.(group[!, :prob], 0.0f0)))
+        end
+        if has_score
+            summary_cols[:max_score][i] = maximum(Float32.(coalesce.(group[!, :score], 0.0f0)))
+        end
+        if has_fraction
+            summary_cols[:precursor_fraction_transmitted][i] = maximum(Float32.(coalesce.(group[!, :precursor_fraction_transmitted], 0.0f0)))
+        end
     end
-    return DataFrame(rows)
+
+    return DataFrame(summary_cols)
 end
 
 function score_chromatogram_features!(chrom_summary::DataFrame,
@@ -257,20 +344,28 @@ function score_chromatogram_features!(chrom_summary::DataFrame,
     if n == 0
         return chrom_summary
     end
-    chrom_summary[!, :scribe] = Float32.(chrom_summary[!, :max_scribe])
+
+    if hasproperty(chrom_summary, :max_scribe)
+        chrom_summary[!, :scribe] = Float32.(chrom_summary[!, :max_scribe])
+    end
     chrom_summary[!, :intercept] = ones(Float32, n)
     chrom_summary[!, :score] = zeros(Float32, n)
     chrom_summary[!, :q_value] = ones(Float16, n)
     chrom_summary[!, :PEP] = ones(Float16, n)
 
-    feature_columns = [
-        :scribe,
+    feature_candidates = Symbol[]
+    has_num_scans = hasproperty(chrom_summary, :num_scans)
+    has_num_scans && push!(feature_candidates, :num_scans)
+    if hasproperty(chrom_summary, :scribe)
+        push!(feature_candidates, :scribe)
+    end
+
+    expected_optional = (
         :max_gof,
         :max_matched_ratio,
         :max_fitted_manhattan_distance,
         :max_fitted_spectral_contrast,
         :smoothness,
-        :num_scans,
         :max_y_ions,
         :y_ions_sum,
         :max_log2_summed_intensity,
@@ -278,8 +373,23 @@ function score_chromatogram_features!(chrom_summary::DataFrame,
         :max_psm_prob,
         :max_score,
         :precursor_fraction_transmitted,
-        :intercept
-    ]
+    )
+
+    missing_for_scoring = Symbol[]
+    for col in expected_optional
+        if hasproperty(chrom_summary, col)
+            push!(feature_candidates, col)
+        else
+            push!(missing_for_scoring, col)
+        end
+    end
+
+    if !isempty(missing_for_scoring)
+        @user_debug "Skipping unavailable chromatogram-level features: $(join(string.(missing_for_scoring), ", "))"
+    end
+
+    push!(feature_candidates, :intercept)
+    feature_columns = feature_candidates
 
     zero_var_cols = Symbol[]
     for col in feature_columns

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
@@ -145,7 +145,6 @@ function prepare_chromatogram_feature_source(psms::DataFrame)
     chrom_df = DataFrame()
     mandatory_cols = (:precursor_idx, :scan_idx, :rt, :target)
     optional_cols = (
-        :weight,
         FIRST_PASS_PROBIT_FEATURE_COLUMNS...,
     )
 
@@ -221,31 +220,6 @@ function annotate_isotopes!(chrom_df::DataFrame,
     return chrom_df
 end
 
-function chromatogram_smoothness(weights::Vector{<:Real}, rts::Vector{<:Real})
-    n = length(weights)
-    if n == 0
-        return 0.0f0
-    end
-    apex_idx = argmax(weights)
-    apex_weight = weights[apex_idx]
-    if apex_weight == 0
-        return 0.0f0
-    end
-    smoothness = 0.0f0
-    for i in 1:n
-        if n == 1
-            smoothness += (-2 * weights[i] / apex_weight)^2
-        elseif i == 1
-            smoothness += (((weights[i+1] - weights[i]) / (rts[i+1] - rts[i]) + (-weights[i]) / (rts[i+1] - rts[i])) / apex_weight)^2
-        elseif i == n
-            smoothness += (((weights[i-1] - weights[i]) / (rts[i] - rts[i-1]) + (-weights[i]) / (rts[i] - rts[i-1])) / apex_weight)^2
-        else
-            smoothness += (((weights[i-1] - weights[i]) / (rts[i] - rts[i-1]) + (weights[i+1] - weights[i]) / (rts[i+1] - rts[i])) / apex_weight)^2
-        end
-    end
-    return Float32(smoothness)
-end
-
 function summarize_chromatograms(chrom_df::DataFrame)
     if nrow(chrom_df) == 0 || !hasproperty(chrom_df, :isotopes_captured)
         return DataFrame()
@@ -268,7 +242,6 @@ function summarize_chromatograms(chrom_df::DataFrame)
     summary_cols[:target] = Vector{Bool}(undef, n_groups)
     summary_cols[:num_scans] = Vector{Float32}(undef, n_groups)
 
-    has_weight = hasproperty(chrom_df, :weight)
     has_spectral_contrast = hasproperty(chrom_df, :spectral_contrast)
     has_city_block = hasproperty(chrom_df, :city_block)
     has_entropy_score = hasproperty(chrom_df, :entropy_score)
@@ -284,9 +257,6 @@ function summarize_chromatograms(chrom_df::DataFrame)
     has_err_norm = hasproperty(chrom_df, :err_norm)
     has_spectrum_peaks = hasproperty(chrom_df, :spectrum_peak_count)
 
-    if has_weight
-        summary_cols[:smoothness] = Vector{Float32}(undef, n_groups)
-    end
     has_spectral_contrast && (summary_cols[:max_spectral_contrast] = Vector{Float32}(undef, n_groups))
     has_city_block && (summary_cols[:max_city_block] = Vector{Float32}(undef, n_groups))
     has_entropy_score && (summary_cols[:max_entropy_score] = Vector{Float32}(undef, n_groups))
@@ -317,18 +287,11 @@ function summarize_chromatograms(chrom_df::DataFrame)
     end
 
     for (i, group) in enumerate(grouped)
-        order = sortperm(group[!, :rt])
-        weights = has_weight ? Float32.(coalesce.(group[order, :weight], 0.0f0)) : Float32[]
-        rts = Float32.(coalesce.(group[order, :rt], 0.0f0))
         summary_cols[:precursor_idx][i] = first(group[!, :precursor_idx])
         summary_cols[:pair_idx][i] = first(group[!, :pair_idx])
         summary_cols[:isotopes_captured][i] = first(group[!, :isotopes_captured])
         summary_cols[:target][i] = Bool(first(coalesce.(group[!, :target], false)))
         summary_cols[:num_scans][i] = Float32(nrow(group))
-
-        if has_weight
-            summary_cols[:smoothness][i] = chromatogram_smoothness(weights, rts)
-        end
         if has_spectral_contrast
             summary_cols[:max_spectral_contrast][i] = max_or_zero(group[!, :spectral_contrast])
         end
@@ -393,7 +356,6 @@ function score_chromatogram_features!(chrom_summary::DataFrame,
     feature_candidates = Symbol[]
     has_num_scans = hasproperty(chrom_summary, :num_scans)
     has_num_scans && push!(feature_candidates, :num_scans)
-    hasproperty(chrom_summary, :smoothness) && push!(feature_candidates, :smoothness)
 
     aggregate_feature_order = (
         :max_spectral_contrast,

--- a/src/importScripts.jl
+++ b/src/importScripts.jl
@@ -218,6 +218,7 @@ function importScripts()
     # Include remaining SearchMethods files (excluding old FileReferences and FileOperations)
     # Skip ParameterTuningSearch and ScoringSearch since we loaded them above
     safe_include!(joinpath(search_methods_dir, "FirstPassSearch", "irt_error_correction.jl"))
+    safe_include!(joinpath(search_methods_dir, "FirstPassSearch", "utils.jl"))
     for (root, dirs, files) in walkdir(search_methods_dir)
         # Skip ParameterTuningSearch and ScoringSearch directories
         if occursin("ParameterTuningSearch", root) || occursin("ScoringSearch", root)


### PR DESCRIPTION
## Summary
- add helpers to build chromatogram-level feature tables and train a probit model on precursor/isotope groups
- replace the first-pass shared library population with the chromatogram-level filter and log per-file target/decoy counts

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: julia executable not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916838d0400832596b78f8161d640f8)