### PR TITLE
feat: add fragment coverage metric to simple spectral scores

### DIFF
--- a/src/Routines/SearchDIA/DataStructures_CLAUDE.md
+++ b/src/Routines/SearchDIA/DataStructures_CLAUDE.md
@@ -122,7 +122,8 @@ abstract type SpectralScores{T<:AbstractFloat} end
 
 **SpectralScoresSimple** - Basic spectral similarity
 - scribe, city_block, spectral_contrast
-- entropy_score, matched_ratio
+- matched_ratio, fragment_coverage (fraction of predicted fragments with any observed intensity)
+- entropy_score
 - Used with SimpleScoredPSM
 
 **SpectralScoresComplex** - Advanced deconvolution metrics

--- a/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
+++ b/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
@@ -39,6 +39,7 @@ struct SimpleScoredPSM{H,L<:AbstractFloat} <: ScoredPSM{H,L}
     city_block::L
     spectral_contrast::L
     matched_ratio::L
+    fragment_coverage::L
     log2_summed_intensity::L
     entropy_score::L
     percent_theoretical_ignored::L
@@ -200,6 +201,7 @@ function Score!(scored_psms::Vector{SimpleScoredPSM{H, L}},
             spectral_scores[scores_idx].city_block,
             spectral_scores[scores_idx].spectral_contrast,
             spectral_scores[scores_idx].matched_ratio,
+            spectral_scores[scores_idx].fragment_coverage,
             #Float16(log2((unscored_PSMs[i].intensity)/spectrum_intensity)),
             Float16(log2(unscored_PSMs[i].intensity)),
             spectral_scores[scores_idx].entropy_score,

--- a/src/Routines/SearchDIA/PSMs/spectralDistanceMetrics.jl
+++ b/src/Routines/SearchDIA/PSMs/spectralDistanceMetrics.jl
@@ -30,11 +30,12 @@ struct SpectralScoresComplex{T<:AbstractFloat} <: SpectralScores{T}
     #entropy_score::T
 end
 
-struct SpectralScoresSimple{T<:AbstractFloat} <: SpectralScores{T} 
+struct SpectralScoresSimple{T<:AbstractFloat} <: SpectralScores{T}
     scribe::T
     city_block::T
     spectral_contrast::T
     matched_ratio::T
+    fragment_coverage::T
     entropy_score::T
     percent_theoretical_ignored::T
 end
@@ -70,12 +71,12 @@ function getDistanceMetrics(H::SparseArray{Ti,T},
             tot_pred_signal += H.nzval[i]
         end
 
-        scribe_best, city_best, cosine_similarity_best, matched_ratio_best, ent_best, next_worst_pos, next_worst_pred_signal, num_matching_peaks = computeMetricsFor(H, col, included)
+        scribe_best, city_best, cosine_similarity_best, matched_ratio_best, fragment_coverage_best, ent_best, next_worst_pos, next_worst_pred_signal, num_matching_peaks = computeMetricsFor(H, col, included)
         
         percent_theoretical_ignored = 0.0f0
         while (num_matching_peaks > min_frags) && (next_worst_pos > 0)
             deleteat!(included, next_worst_pos)
-            scribe, city, cosine_similarity, matched_ratio, ent, worst_pos, worst_pred_signal, num_matching_peaks = computeMetricsFor(H, col, included)
+            scribe, city, cosine_similarity, matched_ratio, fragment_coverage, ent, worst_pos, worst_pred_signal, num_matching_peaks = computeMetricsFor(H, col, included)
 
             # If ignoring the worst peak doesn't increase the scribe score enough, then we're done
             if (scribe < (scribe_best * relative_improvement_threshold))
@@ -89,18 +90,21 @@ function getDistanceMetrics(H::SparseArray{Ti,T},
             city_best = city
             cosine_similarity_best = cosine_similarity
             matched_ratio_best = matched_ratio
+            fragment_coverage_best = fragment_coverage
             ent_best = ent
             next_worst_pos = worst_pos
             next_worst_pred_signal = worst_pred_signal
         end
 
+        percent_theoretical_fraction = tot_pred_signal > 0 ? percent_theoretical_ignored / tot_pred_signal : 0.0
         spectral_scores[col] = SpectralScoresSimple(
                     Float16(scribe_best),
                     Float16(city_best),
                     Float16(cosine_similarity_best),
                     Float16(matched_ratio_best),
+                    Float16(fragment_coverage_best),
                     Float16(ent_best),
-                    Float16(percent_theoretical_ignored / tot_pred_signal)
+                    Float16(percent_theoretical_fraction)
                 )
 
     end
@@ -210,7 +214,11 @@ function computeMetricsFor(H::SparseArray{Ti,T}, col, included_indices) where {T
     ent_val = -1.0 * getEntropy(H, col, included_indices)
     worst_intensity_ignored = worst_idx > 0 ? H.nzval[worst_idx] : 0.0
 
-    return (scribe_score, city_block_dist, cosine_similarity, matched_ratio, ent_val, worst_pos, worst_intensity_ignored, num_matching_peaks)
+    total_included = length(included_indices)
+    # Raw fraction of predicted fragments that register any observed intensity.
+    fragment_coverage = total_included == 0 ? zero(T) : T(num_matching_peaks) / T(total_included)
+
+    return (scribe_score, city_block_dist, cosine_similarity, matched_ratio, fragment_coverage, ent_val, worst_pos, worst_intensity_ignored, num_matching_peaks)
 end
 
 function getDistanceMetrics(w::Vector{T},

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -397,9 +397,9 @@ function process_file!(
         search_context::SearchContext,
         spectra::MassSpecData)
         column_names = [
-            :spectral_contrast, :city_block, :entropy_score, :scribe, :percent_theoretical_ignored,
-            :charge2, :poisson, :irt_error, 
-            :missed_cleavage, 
+            :spectral_contrast, :city_block, :entropy_score, :scribe, :fragment_coverage, :percent_theoretical_ignored,
+            :charge2, :poisson, :irt_error,
+            :missed_cleavage,
             :Mox,
             #:charge, Only works with charge 2 if at least 3 charge states presence. otherwise singular error
             #:b_count, might be good for non-tryptic enzymes
@@ -407,6 +407,10 @@ function process_file!(
         ]
 
         # Avoid singular error if no peaks were ignored
+        if maximum(psms.fragment_coverage) == minimum(psms.fragment_coverage)
+            deleteat!(column_names, findfirst(==(:fragment_coverage), column_names))
+        end
+
         if maximum(psms.percent_theoretical_ignored) == 0
             deleteat!(column_names, findfirst(==(:percent_theoretical_ignored), column_names))
         end
@@ -429,9 +433,12 @@ function process_file!(
             )
         catch
             column_names = [
-            :spectral_contrast, :city_block, :entropy_score, :scribe,
+            :spectral_contrast, :city_block, :entropy_score, :scribe, :fragment_coverage,
             :charge2, :poisson, :irt_error, :TIC, :y_count, :err_norm, :spectrum_peak_count, :intercept
             ]
+            if maximum(psms.fragment_coverage) == minimum(psms.fragment_coverage)
+                deleteat!(column_names, findfirst(==(:fragment_coverage), column_names))
+            end
             score_main_search_psms!(
                 psms,
                 column_names,


### PR DESCRIPTION
## Summary
- add a fragment_coverage field to `SpectralScoresSimple` and compute raw coverage from matching peaks
- carry the coverage metric through `computeMetricsFor` and `getDistanceMetrics` when instantiating simple spectral scores
- document the new coverage metric so analysts understand it measures fragment presence/absence

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918ad85b1748325b674b77829a03e04)