### PR TITLE
feat: add intensity-weighted coverage metric

### DIFF
--- a/src/Routines/SearchDIA/DataStructures_CLAUDE.md
+++ b/src/Routines/SearchDIA/DataStructures_CLAUDE.md
@@ -123,6 +123,7 @@ abstract type SpectralScores{T<:AbstractFloat} end
 **SpectralScoresSimple** - Basic spectral similarity
 - scribe, city_block, spectral_contrast
 - matched_ratio, fragment_coverage (fraction of predicted fragments with any observed intensity)
+- intensity_coverage (log-scaled coverage of observed intensity concentrated in matched ions)
 - entropy_score
 - Used with SimpleScoredPSM
 

--- a/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
+++ b/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
@@ -40,6 +40,7 @@ struct SimpleScoredPSM{H,L<:AbstractFloat} <: ScoredPSM{H,L}
     spectral_contrast::L
     matched_ratio::L
     fragment_coverage::L
+    intensity_coverage::L
     log2_summed_intensity::L
     entropy_score::L
     percent_theoretical_ignored::L
@@ -202,6 +203,7 @@ function Score!(scored_psms::Vector{SimpleScoredPSM{H, L}},
             spectral_scores[scores_idx].spectral_contrast,
             spectral_scores[scores_idx].matched_ratio,
             spectral_scores[scores_idx].fragment_coverage,
+            spectral_scores[scores_idx].intensity_coverage,
             #Float16(log2((unscored_PSMs[i].intensity)/spectrum_intensity)),
             Float16(log2(unscored_PSMs[i].intensity)),
             spectral_scores[scores_idx].entropy_score,

--- a/src/Routines/SearchDIA/PSMs/spectralDistanceMetrics.jl
+++ b/src/Routines/SearchDIA/PSMs/spectralDistanceMetrics.jl
@@ -36,6 +36,7 @@ struct SpectralScoresSimple{T<:AbstractFloat} <: SpectralScores{T}
     spectral_contrast::T
     matched_ratio::T
     fragment_coverage::T
+    intensity_coverage::T
     entropy_score::T
     percent_theoretical_ignored::T
 end
@@ -71,12 +72,12 @@ function getDistanceMetrics(H::SparseArray{Ti,T},
             tot_pred_signal += H.nzval[i]
         end
 
-        scribe_best, city_best, cosine_similarity_best, matched_ratio_best, fragment_coverage_best, ent_best, next_worst_pos, next_worst_pred_signal, num_matching_peaks = computeMetricsFor(H, col, included)
+        scribe_best, city_best, cosine_similarity_best, matched_ratio_best, fragment_coverage_best, intensity_coverage_best, ent_best, next_worst_pos, next_worst_pred_signal, num_matching_peaks = computeMetricsFor(H, col, included)
         
         percent_theoretical_ignored = 0.0f0
         while (num_matching_peaks > min_frags) && (next_worst_pos > 0)
             deleteat!(included, next_worst_pos)
-            scribe, city, cosine_similarity, matched_ratio, fragment_coverage, ent, worst_pos, worst_pred_signal, num_matching_peaks = computeMetricsFor(H, col, included)
+            scribe, city, cosine_similarity, matched_ratio, fragment_coverage, intensity_coverage, ent, worst_pos, worst_pred_signal, num_matching_peaks = computeMetricsFor(H, col, included)
 
             # If ignoring the worst peak doesn't increase the scribe score enough, then we're done
             if (scribe < (scribe_best * relative_improvement_threshold))
@@ -91,6 +92,7 @@ function getDistanceMetrics(H::SparseArray{Ti,T},
             cosine_similarity_best = cosine_similarity
             matched_ratio_best = matched_ratio
             fragment_coverage_best = fragment_coverage
+            intensity_coverage_best = intensity_coverage
             ent_best = ent
             next_worst_pos = worst_pos
             next_worst_pred_signal = worst_pred_signal
@@ -103,6 +105,7 @@ function getDistanceMetrics(H::SparseArray{Ti,T},
                     Float16(cosine_similarity_best),
                     Float16(matched_ratio_best),
                     Float16(fragment_coverage_best),
+                    Float16(intensity_coverage_best),
                     Float16(ent_best),
                     Float16(percent_theoretical_fraction)
                 )
@@ -153,6 +156,9 @@ function computeMetricsFor(H::SparseArray{Ti,T}, col, included_indices) where {T
     matched_sum = zero(T)
     unmatched_sum = zero(T)
 
+    intensity_numerator = zero(T)
+    intensity_denominator = zero(T)
+
     N = 0
     @inbounds @fastmath for (local_pos, i) in enumerate(included_indices)
         if iszero(H.isotope[i])==false
@@ -161,6 +167,12 @@ function computeMetricsFor(H::SparseArray{Ti,T}, col, included_indices) where {T
 
         h_sqrt_sum += sqrt(H.nzval[i])
         x_sqrt_sum += sqrt(H.x[i])#/Xsum
+
+        transformed_intensity = sqrt(max(H.x[i], zero(T)))
+        intensity_denominator += transformed_intensity
+        if H.matched[i]
+            intensity_numerator += transformed_intensity
+        end
 
         h2_norm += H.nzval[i]^2
         x2_norm += H.x[i]^2
@@ -218,7 +230,11 @@ function computeMetricsFor(H::SparseArray{Ti,T}, col, included_indices) where {T
     # Raw fraction of predicted fragments that register any observed intensity.
     fragment_coverage = total_included == 0 ? zero(T) : T(num_matching_peaks) / T(total_included)
 
-    return (scribe_score, city_block_dist, cosine_similarity, matched_ratio, fragment_coverage, ent_val, worst_pos, worst_intensity_ignored, num_matching_peaks)
+    intensity_denominator = max(intensity_denominator, eps(T))
+    intensity_ratio = clamp(intensity_numerator / intensity_denominator, zero(T), one(T))
+    intensity_coverage = -log1p(one(T) - intensity_ratio)
+
+    return (scribe_score, city_block_dist, cosine_similarity, matched_ratio, fragment_coverage, intensity_coverage, ent_val, worst_pos, worst_intensity_ignored, num_matching_peaks)
 end
 
 function getDistanceMetrics(w::Vector{T},

--- a/src/Routines/SearchDIA/PSMs/spectralDistanceMetrics.jl
+++ b/src/Routines/SearchDIA/PSMs/spectralDistanceMetrics.jl
@@ -168,10 +168,11 @@ function computeMetricsFor(H::SparseArray{Ti,T}, col, included_indices) where {T
         h_sqrt_sum += sqrt(H.nzval[i])
         x_sqrt_sum += sqrt(H.x[i])#/Xsum
 
-        transformed_intensity = sqrt(max(H.x[i], zero(T)))
-        intensity_denominator += transformed_intensity
+        transformed_observed = sqrt(max(H.x[i], zero(T)))
+        transformed_theoretical = sqrt(max(H.nzval[i], zero(T)))
+        intensity_denominator += transformed_theoretical
         if H.matched[i]
-            intensity_numerator += transformed_intensity
+            intensity_numerator += transformed_observed
         end
 
         h2_norm += H.nzval[i]^2

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -397,7 +397,7 @@ function process_file!(
         search_context::SearchContext,
         spectra::MassSpecData)
         column_names = [
-            :spectral_contrast, :city_block, :entropy_score, :scribe, :fragment_coverage, :percent_theoretical_ignored,
+            :spectral_contrast, :city_block, :entropy_score, :scribe, :fragment_coverage, :intensity_coverage, :percent_theoretical_ignored,
             :charge2, :poisson, :irt_error,
             :missed_cleavage,
             :Mox,
@@ -409,6 +409,10 @@ function process_file!(
         # Avoid singular error if no peaks were ignored
         if maximum(psms.fragment_coverage) == minimum(psms.fragment_coverage)
             deleteat!(column_names, findfirst(==(:fragment_coverage), column_names))
+        end
+
+        if maximum(psms.intensity_coverage) == minimum(psms.intensity_coverage)
+            deleteat!(column_names, findfirst(==(:intensity_coverage), column_names))
         end
 
         if maximum(psms.percent_theoretical_ignored) == 0
@@ -433,11 +437,14 @@ function process_file!(
             )
         catch
             column_names = [
-            :spectral_contrast, :city_block, :entropy_score, :scribe, :fragment_coverage,
+            :spectral_contrast, :city_block, :entropy_score, :scribe, :fragment_coverage, :intensity_coverage,
             :charge2, :poisson, :irt_error, :TIC, :y_count, :err_norm, :spectrum_peak_count, :intercept
             ]
             if maximum(psms.fragment_coverage) == minimum(psms.fragment_coverage)
                 deleteat!(column_names, findfirst(==(:fragment_coverage), column_names))
+            end
+            if maximum(psms.intensity_coverage) == minimum(psms.intensity_coverage)
+                deleteat!(column_names, findfirst(==(:intensity_coverage), column_names))
             end
             score_main_search_psms!(
                 psms,
@@ -451,7 +458,8 @@ function process_file!(
         # Process scores
        
         select!(psms, [:ms_file_idx, :score, :precursor_idx, :scan_idx,
-            :q_value, :log2_summed_intensity, :irt, :rt, :irt_predicted, :target])
+            :q_value, :log2_summed_intensity, :fragment_coverage, :intensity_coverage,
+            :irt, :rt, :irt_predicted, :target])
         get_probs!(psms, psms[!,:score])
     end
 
@@ -584,7 +592,8 @@ function process_search_results!(
     Arrow.write(
         temp_path,
         select!(psms, [:ms_file_idx, :scan_idx, :precursor_idx, :rt,
-            :irt_predicted, :q_value, :score, :prob, :scan_count])
+            :irt_predicted, :fragment_coverage, :intensity_coverage,
+            :q_value, :score, :prob, :scan_count])
     )
     setFirstPassPsms!(getMSData(search_context), ms_file_idx, temp_path)
 


### PR DESCRIPTION
## Summary
- compute an intensity-aware coverage ratio in `computeMetricsFor` and expose it via `SpectralScoresSimple`
- persist the new metric through `SimpleScoredPSM`, first-pass search scoring columns, and reporting outputs
- document the spectral score fields to describe the intensity coverage feature

## Testing
- julia --project -e 'using Pkg; Pkg.test()' *(fails: `julia` executable is not available in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918bb135a748325bd18017171b0fd49)