### PR TITLE
feat: add unique fragment coverage feature to first pass probit model

### DIFF
--- a/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
+++ b/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
@@ -40,6 +40,7 @@ struct SimpleScoredPSM{H,L<:AbstractFloat} <: ScoredPSM{H,L}
     spectral_contrast::L
     matched_ratio::L
     fragment_coverage::L
+    unique_fragment_coverage::L
     log2_summed_intensity::L
     entropy_score::L
     percent_theoretical_ignored::L
@@ -202,6 +203,7 @@ function Score!(scored_psms::Vector{SimpleScoredPSM{H, L}},
             spectral_scores[scores_idx].spectral_contrast,
             spectral_scores[scores_idx].matched_ratio,
             spectral_scores[scores_idx].fragment_coverage,
+            spectral_scores[scores_idx].unique_fragment_coverage,
             #Float16(log2((unscored_PSMs[i].intensity)/spectrum_intensity)),
             Float16(log2(unscored_PSMs[i].intensity)),
             spectral_scores[scores_idx].entropy_score,

--- a/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
+++ b/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
@@ -41,6 +41,7 @@ struct SimpleScoredPSM{H,L<:AbstractFloat} <: ScoredPSM{H,L}
     matched_ratio::L
     fragment_coverage::L
     unique_fragment_coverage::L
+    interference_penalized_fragment_coverage::L
     log2_summed_intensity::L
     entropy_score::L
     percent_theoretical_ignored::L
@@ -204,6 +205,7 @@ function Score!(scored_psms::Vector{SimpleScoredPSM{H, L}},
             spectral_scores[scores_idx].matched_ratio,
             spectral_scores[scores_idx].fragment_coverage,
             spectral_scores[scores_idx].unique_fragment_coverage,
+            spectral_scores[scores_idx].interference_penalized_fragment_coverage,
             #Float16(log2((unscored_PSMs[i].intensity)/spectrum_intensity)),
             Float16(log2(unscored_PSMs[i].intensity)),
             spectral_scores[scores_idx].entropy_score,

--- a/src/Routines/SearchDIA/PSMs/spectralDistanceMetrics.jl
+++ b/src/Routines/SearchDIA/PSMs/spectralDistanceMetrics.jl
@@ -37,6 +37,7 @@ struct SpectralScoresSimple{T<:AbstractFloat} <: SpectralScores{T}
     matched_ratio::T
     fragment_coverage::T
     unique_fragment_coverage::T
+    interference_penalized_fragment_coverage::T
     entropy_score::T
     percent_theoretical_ignored::T
 end
@@ -79,12 +80,12 @@ function getDistanceMetrics(H::SparseArray{Ti,T},
             tot_pred_signal += H.nzval[i]
         end
 
-        scribe_best, city_best, cosine_similarity_best, matched_ratio_best, fragment_coverage_best, unique_fragment_coverage_best, ent_best, next_worst_pos, next_worst_pred_signal, num_matching_peaks = computeMetricsFor(H, col, included, row_match_counts)
+        scribe_best, city_best, cosine_similarity_best, matched_ratio_best, fragment_coverage_best, unique_fragment_coverage_best, interference_penalized_fragment_coverage_best, ent_best, next_worst_pos, next_worst_pred_signal, num_matching_peaks = computeMetricsFor(H, col, included, row_match_counts)
 
         percent_theoretical_ignored = 0.0f0
         while (num_matching_peaks > min_frags) && (next_worst_pos > 0)
             deleteat!(included, next_worst_pos)
-            scribe, city, cosine_similarity, matched_ratio, fragment_coverage, unique_fragment_coverage, ent, worst_pos, worst_pred_signal, num_matching_peaks = computeMetricsFor(H, col, included, row_match_counts)
+            scribe, city, cosine_similarity, matched_ratio, fragment_coverage, unique_fragment_coverage, interference_penalized_fragment_coverage, ent, worst_pos, worst_pred_signal, num_matching_peaks = computeMetricsFor(H, col, included, row_match_counts)
 
             # If ignoring the worst peak doesn't increase the scribe score enough, then we're done
             if (scribe < (scribe_best * relative_improvement_threshold))
@@ -100,6 +101,7 @@ function getDistanceMetrics(H::SparseArray{Ti,T},
             matched_ratio_best = matched_ratio
             fragment_coverage_best = fragment_coverage
             unique_fragment_coverage_best = unique_fragment_coverage
+            interference_penalized_fragment_coverage_best = interference_penalized_fragment_coverage
             ent_best = ent
             next_worst_pos = worst_pos
             next_worst_pred_signal = worst_pred_signal
@@ -113,6 +115,7 @@ function getDistanceMetrics(H::SparseArray{Ti,T},
                     Float16(matched_ratio_best),
                     Float16(fragment_coverage_best),
                     Float16(unique_fragment_coverage_best),
+                    Float16(interference_penalized_fragment_coverage_best),
                     Float16(ent_best),
                     Float16(percent_theoretical_fraction)
                 )
@@ -130,11 +133,16 @@ function computeMetricsFor(H::SparseArray{Ti,T}, col, included_indices, row_matc
     worst_idx = 0
     num_matching_peaks = 0
     unique_matching_peaks = 0
+    interference_penalized_matching_sum = zero(T)
 
     # Sums for numerator/denominator
     # We also want the "normalized" predicted and observed, so we can correctly find the worst inteferring peak
     total_h = zero(T)
     total_x = zero(T)
+
+    num_precursors = H.n
+    has_multiple_precursors = num_precursors > 1
+    denom = has_multiple_precursors ? T(num_precursors - 1) : one(T)
 
     @inbounds @fastmath for i in included_indices
         total_h += H.nzval[i]
@@ -143,6 +151,14 @@ function computeMetricsFor(H::SparseArray{Ti,T}, col, included_indices, row_matc
             num_matching_peaks += 1
             if row_match_counts[H.rowval[i]] == 1
                 unique_matching_peaks += 1
+            end
+            if row_match_counts[H.rowval[i]] > 0
+                other_precursors = row_match_counts[H.rowval[i]] - 1
+                penalty_fraction = (has_multiple_precursors && other_precursors > 0) ? T(other_precursors) / denom : zero(T)
+                weight = one(T) - penalty_fraction
+                weight = weight < zero(T) ? zero(T) : weight
+                weight = weight > one(T) ? one(T) : weight
+                interference_penalized_matching_sum += weight
             end
         end
     end
@@ -232,8 +248,9 @@ function computeMetricsFor(H::SparseArray{Ti,T}, col, included_indices, row_matc
     # Raw fraction of predicted fragments that register any observed intensity.
     fragment_coverage = total_included == 0 ? zero(T) : T(num_matching_peaks) / T(total_included)
     unique_fragment_coverage = total_included == 0 ? zero(T) : T(unique_matching_peaks) / T(total_included)
+    interference_penalized_fragment_coverage = total_included == 0 ? zero(T) : interference_penalized_matching_sum / T(total_included)
 
-    return (scribe_score, city_block_dist, cosine_similarity, matched_ratio, fragment_coverage, unique_fragment_coverage, ent_val, worst_pos, worst_intensity_ignored, num_matching_peaks)
+    return (scribe_score, city_block_dist, cosine_similarity, matched_ratio, fragment_coverage, unique_fragment_coverage, interference_penalized_fragment_coverage, ent_val, worst_pos, worst_intensity_ignored, num_matching_peaks)
 end
 
 function getDistanceMetrics(w::Vector{T},

--- a/src/Routines/SearchDIA/PSMs/spectralDistanceMetrics.jl
+++ b/src/Routines/SearchDIA/PSMs/spectralDistanceMetrics.jl
@@ -36,6 +36,7 @@ struct SpectralScoresSimple{T<:AbstractFloat} <: SpectralScores{T}
     spectral_contrast::T
     matched_ratio::T
     fragment_coverage::T
+    unique_fragment_coverage::T
     entropy_score::T
     percent_theoretical_ignored::T
 end
@@ -51,14 +52,21 @@ struct SpectralScoresMs1{T<:AbstractFloat} <: SpectralScores{T}
     #entropy_score::T
 end
 
-function getDistanceMetrics(H::SparseArray{Ti,T}, 
+function getDistanceMetrics(H::SparseArray{Ti,T},
     spectral_scores::Vector{SpectralScoresSimple{U}};
     relative_improvement_threshold::Float32 = 1.25f0,
     min_frags::Int64 = 5) where {Ti<:Integer,T,U<:AbstractFloat}
 
+    row_match_counts = zeros(Int, max(H.m, 0))
+    @inbounds @fastmath for idx in range(1, H.n_vals)
+        if H.x[idx] > 0
+            row_match_counts[H.rowval[idx]] += 1
+        end
+    end
+
     @inbounds @fastmath for col in range(1, H.n)
 
-        # Gather the indices of relevant peaks in this spectrum. 
+        # Gather the indices of relevant peaks in this spectrum.
         # We'll iteratively drop one at a time if they have too much interference
         included = Int[]  # We'll store the indices from H.colptr[col] : H.colptr[col+1]-1
         tot_pred_signal = 0.0
@@ -71,12 +79,12 @@ function getDistanceMetrics(H::SparseArray{Ti,T},
             tot_pred_signal += H.nzval[i]
         end
 
-        scribe_best, city_best, cosine_similarity_best, matched_ratio_best, fragment_coverage_best, ent_best, next_worst_pos, next_worst_pred_signal, num_matching_peaks = computeMetricsFor(H, col, included)
-        
+        scribe_best, city_best, cosine_similarity_best, matched_ratio_best, fragment_coverage_best, unique_fragment_coverage_best, ent_best, next_worst_pos, next_worst_pred_signal, num_matching_peaks = computeMetricsFor(H, col, included, row_match_counts)
+
         percent_theoretical_ignored = 0.0f0
         while (num_matching_peaks > min_frags) && (next_worst_pos > 0)
             deleteat!(included, next_worst_pos)
-            scribe, city, cosine_similarity, matched_ratio, fragment_coverage, ent, worst_pos, worst_pred_signal, num_matching_peaks = computeMetricsFor(H, col, included)
+            scribe, city, cosine_similarity, matched_ratio, fragment_coverage, unique_fragment_coverage, ent, worst_pos, worst_pred_signal, num_matching_peaks = computeMetricsFor(H, col, included, row_match_counts)
 
             # If ignoring the worst peak doesn't increase the scribe score enough, then we're done
             if (scribe < (scribe_best * relative_improvement_threshold))
@@ -91,6 +99,7 @@ function getDistanceMetrics(H::SparseArray{Ti,T},
             cosine_similarity_best = cosine_similarity
             matched_ratio_best = matched_ratio
             fragment_coverage_best = fragment_coverage
+            unique_fragment_coverage_best = unique_fragment_coverage
             ent_best = ent
             next_worst_pos = worst_pos
             next_worst_pred_signal = worst_pred_signal
@@ -103,6 +112,7 @@ function getDistanceMetrics(H::SparseArray{Ti,T},
                     Float16(cosine_similarity_best),
                     Float16(matched_ratio_best),
                     Float16(fragment_coverage_best),
+                    Float16(unique_fragment_coverage_best),
                     Float16(ent_best),
                     Float16(percent_theoretical_fraction)
                 )
@@ -110,7 +120,7 @@ function getDistanceMetrics(H::SparseArray{Ti,T},
     end
 end
 
-function computeMetricsFor(H::SparseArray{Ti,T}, col, included_indices) where {Ti<:Integer,T<:AbstractFloat}
+function computeMetricsFor(H::SparseArray{Ti,T}, col, included_indices, row_match_counts) where {Ti<:Integer,T<:AbstractFloat}
     # We'll accumulate partial sums and compute the same metrics as your snippet.
     # (For clarity, we skip inlining optimizations like @inbounds, @fastmath here.)
 
@@ -119,6 +129,7 @@ function computeMetricsFor(H::SparseArray{Ti,T}, col, included_indices) where {T
     worst_pos = 0
     worst_idx = 0
     num_matching_peaks = 0
+    unique_matching_peaks = 0
 
     # Sums for numerator/denominator
     # We also want the "normalized" predicted and observed, so we can correctly find the worst inteferring peak
@@ -130,6 +141,9 @@ function computeMetricsFor(H::SparseArray{Ti,T}, col, included_indices) where {T
         total_x += H.x[i]
         if H.x[i] > 0
             num_matching_peaks += 1
+            if row_match_counts[H.rowval[i]] == 1
+                unique_matching_peaks += 1
+            end
         end
     end
 
@@ -217,8 +231,9 @@ function computeMetricsFor(H::SparseArray{Ti,T}, col, included_indices) where {T
     total_included = length(included_indices)
     # Raw fraction of predicted fragments that register any observed intensity.
     fragment_coverage = total_included == 0 ? zero(T) : T(num_matching_peaks) / T(total_included)
+    unique_fragment_coverage = total_included == 0 ? zero(T) : T(unique_matching_peaks) / T(total_included)
 
-    return (scribe_score, city_block_dist, cosine_similarity, matched_ratio, fragment_coverage, ent_val, worst_pos, worst_intensity_ignored, num_matching_peaks)
+    return (scribe_score, city_block_dist, cosine_similarity, matched_ratio, fragment_coverage, unique_fragment_coverage, ent_val, worst_pos, worst_intensity_ignored, num_matching_peaks)
 end
 
 function getDistanceMetrics(w::Vector{T},

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -397,7 +397,7 @@ function process_file!(
         search_context::SearchContext,
         spectra::MassSpecData)
         column_names = [
-            :spectral_contrast, :city_block, :entropy_score, :scribe, :fragment_coverage, :percent_theoretical_ignored,
+            :spectral_contrast, :city_block, :entropy_score, :scribe, :fragment_coverage, :unique_fragment_coverage, :percent_theoretical_ignored,
             :charge2, :poisson, :irt_error,
             :missed_cleavage,
             :Mox,
@@ -409,6 +409,10 @@ function process_file!(
         # Avoid singular error if no peaks were ignored
         if maximum(psms.fragment_coverage) == minimum(psms.fragment_coverage)
             deleteat!(column_names, findfirst(==(:fragment_coverage), column_names))
+        end
+
+        if maximum(psms.unique_fragment_coverage) == minimum(psms.unique_fragment_coverage)
+            deleteat!(column_names, findfirst(==(:unique_fragment_coverage), column_names))
         end
 
         if maximum(psms.percent_theoretical_ignored) == 0
@@ -433,11 +437,14 @@ function process_file!(
             )
         catch
             column_names = [
-            :spectral_contrast, :city_block, :entropy_score, :scribe, :fragment_coverage,
+            :spectral_contrast, :city_block, :entropy_score, :scribe, :fragment_coverage, :unique_fragment_coverage,
             :charge2, :poisson, :irt_error, :TIC, :y_count, :err_norm, :spectrum_peak_count, :intercept
             ]
             if maximum(psms.fragment_coverage) == minimum(psms.fragment_coverage)
                 deleteat!(column_names, findfirst(==(:fragment_coverage), column_names))
+            end
+            if maximum(psms.unique_fragment_coverage) == minimum(psms.unique_fragment_coverage)
+                deleteat!(column_names, findfirst(==(:unique_fragment_coverage), column_names))
             end
             score_main_search_psms!(
                 psms,

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -397,7 +397,7 @@ function process_file!(
         search_context::SearchContext,
         spectra::MassSpecData)
         column_names = [
-            :spectral_contrast, :city_block, :entropy_score, :scribe, :fragment_coverage, :unique_fragment_coverage, :percent_theoretical_ignored,
+            :spectral_contrast, :city_block, :entropy_score, :scribe, :fragment_coverage, :unique_fragment_coverage, :interference_penalized_fragment_coverage, :percent_theoretical_ignored,
             :charge2, :poisson, :irt_error,
             :missed_cleavage,
             :Mox,
@@ -413,6 +413,10 @@ function process_file!(
 
         if maximum(psms.unique_fragment_coverage) == minimum(psms.unique_fragment_coverage)
             deleteat!(column_names, findfirst(==(:unique_fragment_coverage), column_names))
+        end
+
+        if maximum(psms.interference_penalized_fragment_coverage) == minimum(psms.interference_penalized_fragment_coverage)
+            deleteat!(column_names, findfirst(==(:interference_penalized_fragment_coverage), column_names))
         end
 
         if maximum(psms.percent_theoretical_ignored) == 0
@@ -437,7 +441,7 @@ function process_file!(
             )
         catch
             column_names = [
-            :spectral_contrast, :city_block, :entropy_score, :scribe, :fragment_coverage, :unique_fragment_coverage,
+            :spectral_contrast, :city_block, :entropy_score, :scribe, :fragment_coverage, :unique_fragment_coverage, :interference_penalized_fragment_coverage,
             :charge2, :poisson, :irt_error, :TIC, :y_count, :err_norm, :spectrum_peak_count, :intercept
             ]
             if maximum(psms.fragment_coverage) == minimum(psms.fragment_coverage)
@@ -445,6 +449,9 @@ function process_file!(
             end
             if maximum(psms.unique_fragment_coverage) == minimum(psms.unique_fragment_coverage)
                 deleteat!(column_names, findfirst(==(:unique_fragment_coverage), column_names))
+            end
+            if maximum(psms.interference_penalized_fragment_coverage) == minimum(psms.interference_penalized_fragment_coverage)
+                deleteat!(column_names, findfirst(==(:interference_penalized_fragment_coverage), column_names))
             end
             score_main_search_psms!(
                 psms,


### PR DESCRIPTION
## Summary
- compute a unique fragment coverage metric that ignores peaks shared by multiple precursors
- store the new metric on SimpleScoredPSM records so it is emitted with first-pass PSM tables
- include the unique fragment coverage feature in the first-pass probit regression feature set with constant-column guards

## Testing
- `julia --project -e 'using Pioneer; println("Pioneer loaded")'` *(fails: julia executable not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918d36baec48325b4c47198bb007d8f)