### PR TITLE
Add fragment coverage features to scoring search models

### DIFF
--- a/src/Routines/SearchDIA/DataStructures_CLAUDE.md
+++ b/src/Routines/SearchDIA/DataStructures_CLAUDE.md
@@ -128,7 +128,8 @@ abstract type SpectralScores{T<:AbstractFloat} end
 
 **SpectralScoresComplex** - Advanced deconvolution metrics
 - fitted_spectral_contrast, goodness-of-fit
-- max_matched_residual, fitted_manhattan_distance  
+- max_matched_residual, fitted_manhattan_distance
+- fragment_coverage, unique_fragment_coverage (recomputed from second-pass evidence)
 - Used with ComplexScoredPSM
 
 **SpectralScoresMs1** - Precursor-level scoring

--- a/src/Routines/SearchDIA/DataStructures_CLAUDE.md
+++ b/src/Routines/SearchDIA/DataStructures_CLAUDE.md
@@ -123,13 +123,14 @@ abstract type SpectralScores{T<:AbstractFloat} end
 **SpectralScoresSimple** - Basic spectral similarity
 - scribe, city_block, spectral_contrast
 - matched_ratio, fragment_coverage (fraction of predicted fragments with any observed intensity)
+- unique_fragment_coverage, unique_fragment_count (raw number of uniquely matched fragments)
 - entropy_score
 - Used with SimpleScoredPSM
 
 **SpectralScoresComplex** - Advanced deconvolution metrics
 - fitted_spectral_contrast, goodness-of-fit
 - max_matched_residual, fitted_manhattan_distance
-- fragment_coverage, unique_fragment_coverage (recomputed from second-pass evidence)
+- fragment_coverage, unique_fragment_coverage, unique_fragment_count (recomputed from second-pass evidence)
 - Used with ComplexScoredPSM
 
 **SpectralScoresMs1** - Precursor-level scoring

--- a/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
+++ b/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
@@ -78,9 +78,11 @@ struct ComplexScoredPSM{H,L<:AbstractFloat} <: ScoredPSM{H,L}
     fitted_spectral_contrast::L
     gof::L
     max_matched_residual::L
-    max_unmatched_residual::L 
-    fitted_manhattan_distance::L 
-    matched_ratio::L 
+    max_unmatched_residual::L
+    fitted_manhattan_distance::L
+    matched_ratio::L
+    fragment_coverage::L
+    unique_fragment_coverage::L
     percent_theoretical_ignored::L
     scribe::L
     #entropy_score::L
@@ -314,6 +316,8 @@ function Score!(scored_psms::Vector{ComplexScoredPSM{H, L}},
             spectral_scores[scores_idx].max_unmatched_residual,
             spectral_scores[scores_idx].fitted_manhattan_distance,
             spectral_scores[scores_idx].matched_ratio,
+            spectral_scores[scores_idx].fragment_coverage,
+            spectral_scores[scores_idx].unique_fragment_coverage,
             spectral_scores[scores_idx].percent_theoretical_ignored,
             spectral_scores[scores_idx].scribe,
             #spectral_scores[scores_idx].entropy_score,

--- a/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
+++ b/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
@@ -41,6 +41,7 @@ struct SimpleScoredPSM{H,L<:AbstractFloat} <: ScoredPSM{H,L}
     matched_ratio::L
     fragment_coverage::L
     unique_fragment_coverage::L
+    unique_fragment_count::L
     log2_summed_intensity::L
     entropy_score::L
     percent_theoretical_ignored::L
@@ -83,6 +84,7 @@ struct ComplexScoredPSM{H,L<:AbstractFloat} <: ScoredPSM{H,L}
     matched_ratio::L
     fragment_coverage::L
     unique_fragment_coverage::L
+    unique_fragment_count::L
     percent_theoretical_ignored::L
     scribe::L
     #entropy_score::L
@@ -206,6 +208,7 @@ function Score!(scored_psms::Vector{SimpleScoredPSM{H, L}},
             spectral_scores[scores_idx].matched_ratio,
             spectral_scores[scores_idx].fragment_coverage,
             spectral_scores[scores_idx].unique_fragment_coverage,
+            spectral_scores[scores_idx].unique_fragment_count,
             #Float16(log2((unscored_PSMs[i].intensity)/spectrum_intensity)),
             Float16(log2(unscored_PSMs[i].intensity)),
             spectral_scores[scores_idx].entropy_score,
@@ -318,6 +321,7 @@ function Score!(scored_psms::Vector{ComplexScoredPSM{H, L}},
             spectral_scores[scores_idx].matched_ratio,
             spectral_scores[scores_idx].fragment_coverage,
             spectral_scores[scores_idx].unique_fragment_coverage,
+            spectral_scores[scores_idx].unique_fragment_count,
             spectral_scores[scores_idx].percent_theoretical_ignored,
             spectral_scores[scores_idx].scribe,
             #spectral_scores[scores_idx].entropy_score,

--- a/src/Routines/SearchDIA/PSMs/spectralDistanceMetrics.jl
+++ b/src/Routines/SearchDIA/PSMs/spectralDistanceMetrics.jl
@@ -27,6 +27,7 @@ struct SpectralScoresComplex{T<:AbstractFloat} <: SpectralScores{T}
     matched_ratio::T
     fragment_coverage::T
     unique_fragment_coverage::T
+    unique_fragment_count::T
     scribe::T
     percent_theoretical_ignored::T
     #entropy_score::T
@@ -39,6 +40,7 @@ struct SpectralScoresSimple{T<:AbstractFloat} <: SpectralScores{T}
     matched_ratio::T
     fragment_coverage::T
     unique_fragment_coverage::T
+    unique_fragment_count::T
     entropy_score::T
     percent_theoretical_ignored::T
 end
@@ -81,12 +83,12 @@ function getDistanceMetrics(H::SparseArray{Ti,T},
             tot_pred_signal += H.nzval[i]
         end
 
-        scribe_best, city_best, cosine_similarity_best, matched_ratio_best, fragment_coverage_best, unique_fragment_coverage_best, ent_best, next_worst_pos, next_worst_pred_signal, num_matching_peaks = computeMetricsFor(H, col, included, row_match_counts)
+        scribe_best, city_best, cosine_similarity_best, matched_ratio_best, fragment_coverage_best, unique_fragment_coverage_best, unique_fragment_count_best, ent_best, next_worst_pos, next_worst_pred_signal, num_matching_peaks = computeMetricsFor(H, col, included, row_match_counts)
 
         percent_theoretical_ignored = 0.0f0
         while (num_matching_peaks > min_frags) && (next_worst_pos > 0)
             deleteat!(included, next_worst_pos)
-            scribe, city, cosine_similarity, matched_ratio, fragment_coverage, unique_fragment_coverage, ent, worst_pos, worst_pred_signal, num_matching_peaks = computeMetricsFor(H, col, included, row_match_counts)
+            scribe, city, cosine_similarity, matched_ratio, fragment_coverage, unique_fragment_coverage, unique_fragment_count, ent, worst_pos, worst_pred_signal, num_matching_peaks = computeMetricsFor(H, col, included, row_match_counts)
 
             # If ignoring the worst peak doesn't increase the scribe score enough, then we're done
             if (scribe < (scribe_best * relative_improvement_threshold))
@@ -102,6 +104,7 @@ function getDistanceMetrics(H::SparseArray{Ti,T},
             matched_ratio_best = matched_ratio
             fragment_coverage_best = fragment_coverage
             unique_fragment_coverage_best = unique_fragment_coverage
+            unique_fragment_count_best = unique_fragment_count
             ent_best = ent
             next_worst_pos = worst_pos
             next_worst_pred_signal = worst_pred_signal
@@ -115,6 +118,7 @@ function getDistanceMetrics(H::SparseArray{Ti,T},
                     Float16(matched_ratio_best),
                     Float16(fragment_coverage_best),
                     Float16(unique_fragment_coverage_best),
+                    Float16(unique_fragment_count_best),
                     Float16(ent_best),
                     Float16(percent_theoretical_fraction)
                 )
@@ -235,7 +239,7 @@ function computeMetricsFor(H::SparseArray{Ti,T}, col, included_indices, row_matc
     fragment_coverage = total_included == 0 ? zero(T) : T(num_matching_peaks) / T(total_included)
     unique_fragment_coverage = total_included == 0 ? zero(T) : T(unique_matching_peaks) / T(total_included)
 
-    return (scribe_score, city_block_dist, cosine_similarity, matched_ratio, fragment_coverage, unique_fragment_coverage, ent_val, worst_pos, worst_intensity_ignored, num_matching_peaks)
+    return (scribe_score, city_block_dist, cosine_similarity, matched_ratio, fragment_coverage, unique_fragment_coverage, unique_matching_peaks, ent_val, worst_pos, worst_intensity_ignored, num_matching_peaks)
 end
 
 function getDistanceMetrics(w::Vector{T},
@@ -307,9 +311,10 @@ function getDistanceMetrics(w::Vector{T},
             if best === nothing || scr > best.scribe * relative_improvement_threshold
                 fragment_cov = total_considered == 0 ? zero(Float32) : Float32(matched_count / total_considered)
                 unique_fragment_cov = total_considered == 0 ? zero(Float32) : Float32(unique_matched_count / total_considered)
+                unique_fragment_count = Float32(unique_matched_count)
                 best = (scribe=scr, sc=spectral_contrast, fsc=fitted_spectral_contrast, gof=gof, mmr=max_matched_residual,
                         mur=max_unmatched_residual, fmd=fitted_manhattan_distance, mr=matched_ratio,
-                        fc=fragment_cov, ufc=unique_fragment_cov)
+                        fc=fragment_cov, ufc=unique_fragment_cov, ufc_count=unique_fragment_count)
                 pct_ignored += worst_pred
             else
                 break                     # improvement too small
@@ -332,6 +337,7 @@ function getDistanceMetrics(w::Vector{T},
             Float16(best.mr),                         # matched / unmatched
             Float16(best.fc),                         # fragment coverage
             Float16(best.ufc),                        # unique fragment coverage
+            Float16(best.ufc_count),                  # unique fragment count
             Float16(best.scribe),                     # scribe
             Float16(pct_ignored)                      # percent_theoretical_ignored
         )

--- a/src/Routines/SearchDIA/PSMs/spectralDistanceMetrics.jl
+++ b/src/Routines/SearchDIA/PSMs/spectralDistanceMetrics.jl
@@ -25,6 +25,8 @@ struct SpectralScoresComplex{T<:AbstractFloat} <: SpectralScores{T}
     max_unmatched_residual::T
     fitted_manhattan_distance::T
     matched_ratio::T
+    fragment_coverage::T
+    unique_fragment_coverage::T
     scribe::T
     percent_theoretical_ignored::T
     #entropy_score::T
@@ -244,6 +246,13 @@ function getDistanceMetrics(w::Vector{T},
     min_frags::Int = 3
    ) where {Ti<:Integer,T,U<:AbstractFloat}
 
+    row_match_counts = zeros(Int, max(H.m, 0))
+    @inbounds @fastmath for idx in range(1, H.n_vals)
+        if H.x[idx] > 0
+            row_match_counts[H.rowval[idx]] += 1
+        end
+    end
+
     # zero residual vector (can be re‑used between columns)
     fill!(r, zero(T))
 
@@ -290,12 +299,17 @@ function getDistanceMetrics(w::Vector{T},
         num_matching_peaks = min_frags
 
         while num_matching_peaks ≥ min_frags
-            scr, spectral_contrast, fitted_spectral_contrast, gof, max_matched_residual, max_unmatched_residual, 
+            scr, spectral_contrast, fitted_spectral_contrast, gof, max_matched_residual, max_unmatched_residual,
             fitted_manhattan_distance, matched_ratio, worst_pos, worst_pred, num_matching_peaks = computeFittedMetricsFor(w, H, r, col, incl)
 
+            matched_count, unique_matched_count, total_considered = compute_fragment_coverage_counts(H, incl, row_match_counts)
+
             if best === nothing || scr > best.scribe * relative_improvement_threshold
-                best = (scribe=scr, sc=spectral_contrast, fsc=fitted_spectral_contrast, gof=gof, mmr=max_matched_residual, 
-                        mur=max_unmatched_residual, fmd=fitted_manhattan_distance, mr=matched_ratio)
+                fragment_cov = total_considered == 0 ? zero(Float32) : Float32(matched_count / total_considered)
+                unique_fragment_cov = total_considered == 0 ? zero(Float32) : Float32(unique_matched_count / total_considered)
+                best = (scribe=scr, sc=spectral_contrast, fsc=fitted_spectral_contrast, gof=gof, mmr=max_matched_residual,
+                        mur=max_unmatched_residual, fmd=fitted_manhattan_distance, mr=matched_ratio,
+                        fc=fragment_cov, ufc=unique_fragment_cov)
                 pct_ignored += worst_pred
             else
                 break                     # improvement too small
@@ -316,6 +330,8 @@ function getDistanceMetrics(w::Vector{T},
             Float16(best.mur),                        # max unmatched residual (−log)
             Float16(best.fmd),                        # fitted manhattan (−log)
             Float16(best.mr),                         # matched / unmatched
+            Float16(best.fc),                         # fragment coverage
+            Float16(best.ufc),                        # unique fragment coverage
             Float16(best.scribe),                     # scribe
             Float16(pct_ignored)                      # percent_theoretical_ignored
         )
@@ -453,9 +469,35 @@ function computeFittedMetricsFor(w::Vector{T}, H::SparseArray{Ti,T}, r::Vector{T
             fitted_manhattan_distance, matched_ratio, worst_pos, worst_intensity_ignored, num_matching_peaks)
 end
 
-function getDistanceMetrics(w::Vector{T}, 
-                            r::Vector{T}, 
-                            H::SparseArray{Ti,T}, 
+function compute_fragment_coverage_counts(
+    H::SparseArray{Ti,T},
+    indices::Vector{Int},
+    row_match_counts::Vector{Int}
+) where {Ti<:Integer,T<:AbstractFloat}
+    matched = 0
+    unique_matched = 0
+    total = 0
+
+    @inbounds @fastmath for idx in indices
+        if !iszero(H.isotope[idx])
+            continue
+        end
+
+        total += 1
+        if H.matched[idx]
+            matched += 1
+            if row_match_counts[H.rowval[idx]] == 1
+                unique_matched += 1
+            end
+        end
+    end
+
+    return matched, unique_matched, total
+end
+
+function getDistanceMetrics(w::Vector{T},
+                            r::Vector{T},
+                            H::SparseArray{Ti,T},
                             spectral_scores::Vector{SpectralScoresMs1{U}}) where {Ti<:Integer,T,U<:AbstractFloat}
 
 

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -397,7 +397,7 @@ function process_file!(
         search_context::SearchContext,
         spectra::MassSpecData)
         column_names = [
-            :spectral_contrast, :city_block, :entropy_score, :scribe, :fragment_coverage, :unique_fragment_coverage, :percent_theoretical_ignored,
+            :spectral_contrast, :city_block, :entropy_score, :scribe, :fragment_coverage, :unique_fragment_coverage, :unique_fragment_count, :percent_theoretical_ignored,
             :charge2, :poisson, :irt_error,
             :missed_cleavage,
             :Mox,
@@ -413,6 +413,10 @@ function process_file!(
 
         if maximum(psms.unique_fragment_coverage) == minimum(psms.unique_fragment_coverage)
             deleteat!(column_names, findfirst(==(:unique_fragment_coverage), column_names))
+        end
+
+        if maximum(psms.unique_fragment_count) == minimum(psms.unique_fragment_count)
+            deleteat!(column_names, findfirst(==(:unique_fragment_count), column_names))
         end
 
         if maximum(psms.percent_theoretical_ignored) == 0
@@ -447,7 +451,7 @@ function process_file!(
             )
         catch
             column_names = [
-            :spectral_contrast, :city_block, :entropy_score, :scribe, :fragment_coverage, :unique_fragment_coverage,
+            :spectral_contrast, :city_block, :entropy_score, :scribe, :fragment_coverage, :unique_fragment_coverage, :unique_fragment_count,
             :charge2, :poisson, :irt_error, :TIC, :y_count, :err_norm, :spectrum_peak_count, :intercept
             ]
             if maximum(psms.fragment_coverage) == minimum(psms.fragment_coverage)
@@ -455,6 +459,9 @@ function process_file!(
             end
             if maximum(psms.unique_fragment_coverage) == minimum(psms.unique_fragment_coverage)
                 deleteat!(column_names, findfirst(==(:unique_fragment_coverage), column_names))
+            end
+            if maximum(psms.unique_fragment_count) == minimum(psms.unique_fragment_count)
+                deleteat!(column_names, findfirst(==(:unique_fragment_count), column_names))
             end
             score_main_search_psms!(
                 psms,

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
@@ -72,6 +72,8 @@ const ADVANCED_FEATURE_SET = [
     :fitted_spectral_contrast,
     :spectral_contrast,
     :max_matched_ratio,
+    :fragment_coverage,
+    :unique_fragment_coverage,
     :err_norm,
     :poisson,
     :weight_qbin,      # Quantile-binned version of :weight
@@ -118,6 +120,7 @@ const REDUCED_FEATURE_SET = [
     :max_fitted_manhattan_distance, :max_fitted_spectral_contrast,
     :max_matched_residual, :max_unmatched_residual, :max_gof,
     :fitted_spectral_contrast, :spectral_contrast, :max_matched_ratio,
+    :fragment_coverage, :unique_fragment_coverage,
     :err_norm, :poisson, :weight_qbin, :log2_intensity_explained, :tic_qbin, :num_scans,
     :smoothness, :percent_theoretical_ignored, :scribe, :max_scribe,
     # MS1 features
@@ -144,6 +147,7 @@ const PROBIT_FEATURE_SET = [
     :max_matched_residual, :max_unmatched_residual, :max_gof,
     :err_norm, :poisson, :weight, :log2_intensity_explained, :tic, :num_scans,
     :smoothness, :percent_theoretical_ignored, :scribe, :max_scribe,
+    :fragment_coverage, :unique_fragment_coverage,
     # MS1 features
     :weight_ms1, :gof_ms1, :error_ms1, :ms1_features_missing
     # MBR features added automatically if match_between_runs=true
@@ -156,7 +160,9 @@ const MINIMAL_FEATURE_SET = [
     :max_matched_residual,
     :max_unmatched_residual,
     :err_norm,
-    :log2_intensity_explained
+    :log2_intensity_explained,
+    :fragment_coverage,
+    :unique_fragment_coverage
 ]
 
 """
@@ -239,6 +245,8 @@ function create_model_configurations(ms1_scoring::Bool = true)
                 :irt_error,
                 :err_norm,
                 :y_count,
+                :fragment_coverage,
+                :unique_fragment_coverage,
                 :tic
             ], [:intercept]),
             Dict(

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
@@ -75,6 +75,9 @@ const ADVANCED_FEATURE_SET = [
     :fragment_coverage,
     :unique_fragment_coverage,
     :unique_fragment_count,
+    :max_fragment_coverage,
+    :max_unique_fragment_coverage,
+    :max_unique_fragment_count,
     :err_norm,
     :poisson,
     :weight_qbin,      # Quantile-binned version of :weight
@@ -122,6 +125,7 @@ const REDUCED_FEATURE_SET = [
     :max_matched_residual, :max_unmatched_residual, :max_gof,
     :fitted_spectral_contrast, :spectral_contrast, :max_matched_ratio,
     :fragment_coverage, :unique_fragment_coverage, :unique_fragment_count,
+    :max_fragment_coverage, :max_unique_fragment_coverage, :max_unique_fragment_count,
     :err_norm, :poisson, :weight_qbin, :log2_intensity_explained, :tic_qbin, :num_scans,
     :smoothness, :percent_theoretical_ignored, :scribe, :max_scribe,
     # MS1 features
@@ -164,7 +168,10 @@ const MINIMAL_FEATURE_SET = [
     :log2_intensity_explained,
     :fragment_coverage,
     :unique_fragment_coverage,
-    :unique_fragment_count
+    :unique_fragment_count,
+    :max_fragment_coverage,
+    :max_unique_fragment_coverage,
+    :max_unique_fragment_count
 ]
 
 """
@@ -250,6 +257,9 @@ function create_model_configurations(ms1_scoring::Bool = true)
                 :fragment_coverage,
                 :unique_fragment_coverage,
                 :unique_fragment_count,
+                :max_fragment_coverage,
+                :max_unique_fragment_coverage,
+                :max_unique_fragment_count,
                 :tic
             ], [:intercept]),
             Dict(

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
@@ -74,6 +74,7 @@ const ADVANCED_FEATURE_SET = [
     :max_matched_ratio,
     :fragment_coverage,
     :unique_fragment_coverage,
+    :unique_fragment_count,
     :err_norm,
     :poisson,
     :weight_qbin,      # Quantile-binned version of :weight
@@ -120,7 +121,7 @@ const REDUCED_FEATURE_SET = [
     :max_fitted_manhattan_distance, :max_fitted_spectral_contrast,
     :max_matched_residual, :max_unmatched_residual, :max_gof,
     :fitted_spectral_contrast, :spectral_contrast, :max_matched_ratio,
-    :fragment_coverage, :unique_fragment_coverage,
+    :fragment_coverage, :unique_fragment_coverage, :unique_fragment_count,
     :err_norm, :poisson, :weight_qbin, :log2_intensity_explained, :tic_qbin, :num_scans,
     :smoothness, :percent_theoretical_ignored, :scribe, :max_scribe,
     # MS1 features
@@ -147,7 +148,7 @@ const PROBIT_FEATURE_SET = [
     :max_matched_residual, :max_unmatched_residual, :max_gof,
     :err_norm, :poisson, :weight, :log2_intensity_explained, :tic, :num_scans,
     :smoothness, :percent_theoretical_ignored, :scribe, :max_scribe,
-    :fragment_coverage, :unique_fragment_coverage,
+    :fragment_coverage, :unique_fragment_coverage, :unique_fragment_count,
     # MS1 features
     :weight_ms1, :gof_ms1, :error_ms1, :ms1_features_missing
     # MBR features added automatically if match_between_runs=true
@@ -162,7 +163,8 @@ const MINIMAL_FEATURE_SET = [
     :err_norm,
     :log2_intensity_explained,
     :fragment_coverage,
-    :unique_fragment_coverage
+    :unique_fragment_coverage,
+    :unique_fragment_count
 ]
 
 """
@@ -247,6 +249,7 @@ function create_model_configurations(ms1_scoring::Bool = true)
                 :y_count,
                 :fragment_coverage,
                 :unique_fragment_coverage,
+                :unique_fragment_count,
                 :tic
             ], [:intercept]),
             Dict(

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/SecondPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/SecondPassSearch.jl
@@ -484,7 +484,7 @@ function process_search_results!(
         # Calculate summary scores for each PSM group
         for (key, gpsms) in pairs(groupby(psms, getPsmGroupbyCols(getIsotopeTraceType(params))))
             get_summary_scores!(
-                gpsms, 
+                gpsms,
                 gpsms[!,:weight],
                 gpsms[!,:gof],
                 gpsms[!,:matched_ratio],
@@ -492,6 +492,9 @@ function process_search_results!(
                 gpsms[!,:fitted_spectral_contrast],
                 gpsms[!,:scribe],
                 gpsms[!,:y_count],
+                gpsms[!,:fragment_coverage],
+                gpsms[!,:unique_fragment_coverage],
+                gpsms[!,:unique_fragment_count],
                 getRtIrtModel(search_context, ms_file_idx)
             );
         end

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -988,6 +988,9 @@ function init_summary_columns!(
         (:y_ions_sum,               UInt16)
         (:max_y_ions,               UInt16)
         (:max_matched_ratio,        Float16)
+        (:max_fragment_coverage,    Float16)
+        (:max_unique_fragment_coverage, Float16)
+        (:max_unique_fragment_count, Float16)
         (:num_scans,        UInt16)
         (:smoothness,        Float32)
         (:weights,        Vector{Float32})
@@ -1026,6 +1029,9 @@ function get_summary_scores!(
                             fitted_spectral_contrast::AbstractVector{Float16},
                             scribe::AbstractVector{Float16},
                             y_count::AbstractVector{UInt8},
+                            fragment_coverage::AbstractVector{Float16},
+                            unique_fragment_coverage::AbstractVector{Float16},
+                            unique_fragment_count::AbstractVector{Float16},
                             rt_to_irt_interp::RtConversionModel
                         )
 
@@ -1035,6 +1041,9 @@ function get_summary_scores!(
     max_fitted_manhattan_distance = -100.0
     max_fitted_spectral_contrast= -100
     max_scribe = -100
+    max_fragment_coverage = -100.0
+    max_unique_fragment_coverage = -100.0
+    max_unique_fragment_count = -100.0
     count = 0
     y_ions_sum = 0
     max_y_ions = 0
@@ -1069,7 +1078,19 @@ function get_summary_scores!(
         if scribe[i]>max_scribe
             max_scribe = scribe[i]
         end
-    
+
+        if fragment_coverage[i] > max_fragment_coverage
+            max_fragment_coverage = fragment_coverage[i]
+        end
+
+        if unique_fragment_coverage[i] > max_unique_fragment_coverage
+            max_unique_fragment_coverage = unique_fragment_coverage[i]
+        end
+
+        if unique_fragment_count[i] > max_unique_fragment_count
+            max_unique_fragment_count = unique_fragment_count[i]
+        end
+
         y_ions_sum += y_count[i]
         if y_count[i] > max_y_ions
             max_y_ions = y_count[i]
@@ -1102,6 +1123,9 @@ function get_summary_scores!(
     psms.max_fitted_manhattan_distance[apex_scan] = max_fitted_manhattan_distance
     psms.max_fitted_spectral_contrast[apex_scan] = max_fitted_spectral_contrast
     psms.max_scribe[apex_scan] = max_scribe
+    psms.max_fragment_coverage[apex_scan] = max_fragment_coverage
+    psms.max_unique_fragment_coverage[apex_scan] = max_unique_fragment_coverage
+    psms.max_unique_fragment_count[apex_scan] = max_unique_fragment_count
     psms.y_ions_sum[apex_scan] = y_ions_sum
     psms.max_y_ions[apex_scan] = max_y_ions
     psms.num_scans[apex_scan] = length(weight)


### PR DESCRIPTION
## Summary
- compute fragment_coverage and unique_fragment_coverage during complex spectral scoring so second-pass PSMs expose the metrics
- extend ComplexScoredPSM and documentation to surface the new coverage features
- include the coverage metrics in every scoring search feature set, including simplified probit configurations

## Testing
- Not run (Julia executable unavailable in the container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918dea35360832599c17fde4a51d1a8)