### PR TITLE
Add consensus iRT anchors for RT window placement

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -546,7 +546,7 @@ function summarize_results!(
         
         if isempty(valid_psms_paths)
             @user_warn "No valid files for cross-run precursor analysis"
-            return Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_library_irt::Float32, mean_library_irt::Union{Missing, Float32}, var_library_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32}}()
+            return Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_library_irt::Float32, mean_library_irt::Union{Missing, Float32}, var_library_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32, library_irts::Vector{Float32}, irt_probs::Vector{Float32}}}()
         end
         
         # Get best precursors from valid files only

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
@@ -202,7 +202,8 @@ function get_best_precursors_accross_runs(
     end
 
     # Recompute statistics around consensus anchors
-    for (precursor_idx, stats) in prec_to_best_prob
+    for precursor_idx in keys(prec_to_best_prob)
+        stats = prec_to_best_prob[precursor_idx]
         irts = stats.library_irts
         probs = stats.irt_probs
         n = UInt16(length(irts))

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
@@ -35,10 +35,12 @@ Dictionary mapping precursor indices to NamedTuple containing:
 - `best_prob`: Highest probability score
 - `best_ms_file_idx`: File index with best match
 - `best_scan_idx`: Scan index of best match
-- `best_library_irt`: Library iRT value of best match
+- `best_library_irt`: Consensus library iRT anchor (weighted median across qualifying runs)
 - `mean_library_irt`: Mean library iRT across qualifying matches
 - `var_library_irt`: Variance in library iRT across qualifying matches
 - `n`: Number of qualifying matches
+- `library_irts`: Library iRTs from qualifying runs
+- `irt_probs`: Probabilities for qualifying runs (weights for consensus)
 - `mz`: Precursor m/z value
 
 # Process
@@ -61,7 +63,9 @@ function get_best_precursors_accross_runs(
                                                     mean_library_irt::Union{Missing, Float32},
                                                     var_library_irt::Union{Missing, Float32},
                                                     n::Union{Missing, UInt16},
-                                                    mz::Float32}},
+                                                    mz::Float32,
+                                                    library_irts::Vector{Float32},
+                                                    irt_probs::Vector{Float32}}},
         precursor_idxs::AbstractVector{UInt32},
         q_values::AbstractVector{Float16},
         probs::AbstractVector{Float32},
@@ -86,12 +90,14 @@ function get_best_precursors_accross_runs(
             mean_library_irt = passed_q_val ? library_irt : zero(Float32)
             var_library_irt = zero(Float32)
             mz = prec_mzs[precursor_idx]
+            library_irts = passed_q_val ? Float32[library_irt] : Float32[]
+            irt_probs = passed_q_val ? Float32[prob] : Float32[]
 
             #Has the precursor been encountered in a previous raw file?
             #Keep a running mean library_irt for instances below q-val threshold
             if haskey(prec_to_best_prob, precursor_idx)
                 # Update existing precursor entry
-                best_prob, best_ms_file_idx, best_scan_idx, best_library_irt, old_mean_library_irt, var_library_irt, old_n, mz = prec_to_best_prob[precursor_idx]
+                best_prob, best_ms_file_idx, best_scan_idx, best_library_irt, old_mean_library_irt, var_library_irt, old_n, mz, existing_library_irts, existing_irt_probs = prec_to_best_prob[precursor_idx]
 
                 # Update best match if current is better
                 if (best_prob < prob)
@@ -104,6 +110,8 @@ function get_best_precursors_accross_runs(
                 # Update running statistics
                 mean_library_irt += old_mean_library_irt
                 n += old_n
+                append!(library_irts, existing_library_irts)
+                append!(irt_probs, existing_irt_probs)
                 prec_to_best_prob[precursor_idx] = (
                                                 best_prob = best_prob,
                                                 best_ms_file_idx = best_ms_file_idx,
@@ -112,7 +120,9 @@ function get_best_precursors_accross_runs(
                                                 mean_library_irt = mean_library_irt,
                                                 var_library_irt = var_library_irt,
                                                 n = n,
-                                                mz = mz)
+                                                mz = mz,
+                                                library_irts = library_irts,
+                                                irt_probs = irt_probs)
             else
                 # Create new precursor entry
                 val = (best_prob = prob,
@@ -122,50 +132,10 @@ function get_best_precursors_accross_runs(
                         mean_library_irt = mean_library_irt,
                         var_library_irt = var_library_irt,
                         n = n,
-                        mz = mz)
+                        mz = mz,
+                        library_irts = library_irts,
+                        irt_probs = irt_probs)
                 insert!(prec_to_best_prob, precursor_idx, val)
-            end
-        end
-    end
-    function getVariance!(
-        prec_to_best_prob::Dictionary{UInt32, @NamedTuple{ best_prob::Float32,
-                                                    best_ms_file_idx::UInt32,
-                                                    best_scan_idx::UInt32,
-                                                    best_library_irt::Float32,
-                                                    mean_library_irt::Union{Missing, Float32},
-                                                    var_library_irt::Union{Missing, Float32},
-                                                    n::Union{Missing, UInt16},
-                                                    mz::Float32}},
-        precursor_idxs::AbstractVector{UInt32},
-        q_values::AbstractVector{Float16},
-        rts::AbstractVector{Float32},
-        rt_to_library_irt::RtConversionModel,
-        max_q_val::Float32)
-        for row in eachindex(precursor_idxs)
-            # Skip PSMs that don't pass q-value threshold
-            q_value = q_values[row]
-
-            # Get precursor info
-            precursor_idx = precursor_idxs[row]
-            library_irt = rt_to_library_irt(rts[row])
-
-            if q_value > max_q_val
-                continue
-            end
-            if haskey(prec_to_best_prob, precursor_idx)
-                # Update variance calculation
-                best_prob, best_ms_file_idx, best_scan_idx, best_library_irt, mean_library_irt, var_library_irt, n, mz = prec_to_best_prob[precursor_idx]
-                var_library_irt += (library_irt - mean_library_irt/n)^2
-                prec_to_best_prob[precursor_idx] = (
-                    best_prob = best_prob,
-                    best_ms_file_idx= best_ms_file_idx,
-                    best_scan_idx = best_scan_idx,
-                    best_library_irt = best_library_irt,
-                    mean_library_irt = mean_library_irt,
-                    var_library_irt = var_library_irt,
-                    n = n,
-                    mz = mz)
-
             end
         end
     end
@@ -177,7 +147,9 @@ function get_best_precursors_accross_runs(
                                                         mean_library_irt::Union{Missing, Float32},
                                                         var_library_irt::Union{Missing, Float32},
                                                         n::Union{Missing, UInt16},
-                                                        mz::Float32}}()
+                                                        mz::Float32,
+                                                        library_irts::Vector{Float32},
+                                                        irt_probs::Vector{Float32}}}()
 
     # First pass: collect best matches and mean library iRT
 
@@ -229,32 +201,29 @@ function get_best_precursors_accross_runs(
         end
     end
 
-    # Second pass: calculate library iRT variance for remaining precursors
-    for psms_path in psms_paths #For each data frame
-        psms = Arrow.Table(psms_path)
+    # Recompute statistics around consensus anchors
+    for (precursor_idx, stats) in prec_to_best_prob
+        irts = stats.library_irts
+        probs = stats.irt_probs
+        n = UInt16(length(irts))
+        consensus_val = consensus_irt(irts, probs)
+        consensus = isnothing(consensus_val) ? stats.best_library_irt : consensus_val
+        mean_library_irt = isempty(irts) ? missing : Float32(mean(irts))
+        var_library_irt = isempty(irts) ? missing : Float32(sum((irt .- consensus).^2))
 
-        # Get the original file index from the PSM data
-        if isempty(psms[:ms_file_idx])
-            continue  # Skip empty files
-        end
-        file_idx = first(psms[:ms_file_idx])  # All PSMs in a file should have the same ms_file_idx
-
-        # Check if RT model exists for this file
-        if !haskey(rt_to_library_irt, file_idx)
-            continue  # Skip files without RT models (already warned in first pass)
-        end
-
-        #One row for each precursor
-        getVariance!(
-            prec_to_best_prob,
-            psms[:precursor_idx],
-            psms[:q_value],
-            psms[:rt],
-            rt_to_library_irt[file_idx],
-            max_q_val
+        prec_to_best_prob[precursor_idx] = (
+            best_prob = stats.best_prob,
+            best_ms_file_idx = stats.best_ms_file_idx,
+            best_scan_idx = stats.best_scan_idx,
+            best_library_irt = consensus,
+            mean_library_irt = mean_library_irt,
+            var_library_irt = var_library_irt,
+            n = n,
+            mz = stats.mz,
+            library_irts = irts,
+            irt_probs = probs
         )
-    end 
+    end
 
-    
     return prec_to_best_prob #[(prob, idx) for (idx, prob) in sort(collect(top_probs), rev=true)]
 end

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
@@ -210,7 +210,7 @@ function get_best_precursors_accross_runs(
         consensus_val = consensus_irt(irts, probs)
         consensus = isnothing(consensus_val) ? stats.best_library_irt : consensus_val
         mean_library_irt = isempty(irts) ? missing : Float32(mean(irts))
-        var_library_irt = isempty(irts) ? missing : Float32(sum((irt .- consensus).^2))
+        var_library_irt = isempty(irts) ? missing : Float32(sum((irts .- consensus).^2))
 
         prec_to_best_prob[precursor_idx] = (
             best_prob = stats.best_prob,

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
@@ -756,13 +756,13 @@ end
 
 
 """
-    get_irt_errs(fwhms::Dictionary, prec_to_irt::Dictionary, params::FirstPassSearchParameters)
+    get_irt_errs(fwhms::Dictionary, prec_to_irt::PrecToIrtType, params::FirstPassSearchParameters)
 
 Calculates refined iRT error tolerances based on peak widths and cross-run variation.
 
 # Arguments
 - `fwhms`: Dictionary of FWHM statistics per file
-- `prec_to_irt`: Dictionary of precursor refined iRT data
+- `prec_to_irt`: Dictionary of precursor refined iRT data (including consensus fields)
 - `params`: Parameters including FWHM and iRT standard deviation multipliers
 
 # Returns
@@ -771,21 +771,12 @@ Dictionary mapping file indices to refined iRT tolerances, combining:
 - Cross-run refined iRT variation
 """
 function get_irt_errs(
-    fwhms::Dictionary{Int64, 
+    fwhms::Dictionary{Int64,
                         @NamedTuple{
                             median_fwhm::Float32,
                             mad_fwhm::Float32
                         }},
-    prec_to_irt::Dictionary{UInt32,
-    @NamedTuple{best_prob::Float32,
-                best_ms_file_idx::UInt32,
-                best_scan_idx::UInt32,
-                best_library_irt::Float32,
-                mean_library_irt::Union{Missing, Float32},
-                var_library_irt::Union{Missing, Float32},
-                n::Union{Missing, UInt16},
-                mz::Float32}}
-    ,
+    prec_to_irt::PrecToIrtType,
     params::FirstPassSearchParameters
 )
     #Get upper bound on peak fwhm. Use median + n*standard_deviation
@@ -796,12 +787,21 @@ function get_irt_errs(
     #Get variance in irt of apex accross runs. Only consider precursor identified below q-value threshold
     #in more than two runs .
     irt_std = nothing
-    variance_  = collect(skipmissing(map(x-> (x[:n] > 2) ? sqrt(x[:var_library_irt]/(x[:n] - 1)) : missing, prec_to_irt)))
+    variance_ = collect(
+        skipmissing(
+            map(x -> (x[:n] > 2 && !ismissing(x[:var_library_irt])) ? sqrt(x[:var_library_irt]/(x[:n] - 1)) : missing,
+                prec_to_irt)
+        )
+    )
     if !iszero(length(variance_))
         irt_std = median(variance_)
     else
         #This could happen if only two files are being searched
-        variance_  = collect(skipmissing(map(x-> (x[:n] == 2) ? sqrt(x[:var_library_irt]) : missing, prec_to_irt)))
+        variance_ = collect(
+            skipmissing(
+                map(x -> (x[:n] == 2 && !ismissing(x[:var_library_irt])) ? sqrt(x[:var_library_irt]) : missing, prec_to_irt)
+            )
+        )
         if iszero(length(variance_)) #only searching one file so 
             irt_std = 0.0f0
         else

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
@@ -617,10 +617,62 @@ end
 
 PrecToIrtType = Dictionary{UInt32,
     NamedTuple{
-        (:best_prob, :best_ms_file_idx, :best_scan_idx, :best_library_irt, :mean_library_irt, :var_library_irt, :n, :mz),
-        Tuple{Float32, UInt32, UInt32, Float32, Union{Missing, Float32}, Union{Missing, Float32}, Union{Missing, UInt16}, Float32}
+        (
+            :best_prob,
+            :best_ms_file_idx,
+            :best_scan_idx,
+            :best_library_irt,
+            :mean_library_irt,
+            :var_library_irt,
+            :n,
+            :mz,
+            :library_irts,
+            :irt_probs
+        ),
+        Tuple{
+            Float32,
+            UInt32,
+            UInt32,
+            Float32,
+            Union{Missing, Float32},
+            Union{Missing, Float32},
+            Union{Missing, UInt16},
+            Float32,
+            Vector{Float32},
+            Vector{Float32}
+        }
     }
 }
+
+"""
+    consensus_irt(irts::AbstractVector{Float32}, probs::Union{Nothing, AbstractVector{Float32}}=nothing)
+
+Calculate a consensus iRT using a weighted median of qualifying runs.
+
+Falls back to an unweighted median when weights are unavailable or invalid.
+"""
+function consensus_irt(
+    irts::AbstractVector{Float32},
+    probs::Union{Nothing, AbstractVector{Float32}} = nothing
+)
+    isempty(irts) && return nothing
+
+    valid_weights = !(probs === nothing) && (length(irts) == length(probs))
+    if valid_weights
+        order = sortperm(irts)
+        sorted_irts = irts[order]
+        sorted_weights = probs[order]
+        total_weight = sum(sorted_weights)
+        if total_weight > zero(Float32)
+            threshold = total_weight / 2
+            cumulative = cumsum(sorted_weights)
+            idx = findfirst(w -> w >= threshold, cumulative)
+            return Float32(sorted_irts[coalesce(idx, length(sorted_irts))])
+        end
+    end
+
+    return Float32(median(irts))
+end
 
 """
     create_rt_indices!(search_context::SearchContext, results::FirstPassSearchResults,

--- a/src/Routines/SearchDIA/SearchMethods/SearchTypes.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SearchTypes.jl
@@ -621,7 +621,10 @@ function setIrtRefinementModel!(s::SearchContext, model::Union{IrtRefinementMode
     s.irt_refinement_models[index] = model
 end
 
-function setPrecursorDict!(s::SearchContext, dict::Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_library_irt::Float32, mean_library_irt::Union{Missing, Float32}, var_library_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32}})
+function setPrecursorDict!(
+    s::SearchContext,
+    dict::Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_library_irt::Float32, mean_library_irt::Union{Missing, Float32}, var_library_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32, library_irts::Vector{Float32}, irt_probs::Vector{Float32}}}
+)
     s.precursor_dict[] = dict
 end
 setRtIndexPaths!(s::SearchContext, paths::Vector{String}) = (s.rt_index_paths[] = paths)

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -838,7 +838,7 @@ function add_features!(psms::DataFrame,
                                     ms_file_idx::Integer,
                                     rt_to_irt_interp::RtConversionModel,
                                     rt_to_refined_irt_interp::RtConversionModel,
-                                    prec_id_to_irt::Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_library_irt::Float32, mean_library_irt::Union{Missing, Float32}, var_library_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32}}
+                                    prec_id_to_irt::Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_library_irt::Float32, mean_library_irt::Union{Missing, Float32}, var_library_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32, library_irts::Vector{Float32}, irt_probs::Vector{Float32}}}
                                     )
 
     precursor_sequence = getSequence(getPrecursors(getSpecLib(search_context)))#[:sequence],


### PR DESCRIPTION
## Summary
- add a consensus iRT helper that computes weighted medians for qualifying runs
- use the consensus anchor when building precursor RT indices and second-pass windows
- retain cross-run variance tracking around the new anchor for downstream tolerance calculations

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925e46782848325872edac8f663c3a4)