### PR TITLE
Add MAD-trimmed cross-run iRT consensus

### DIFF
--- a/assets/example_config/defaultSearchParams.json
+++ b/assets/example_config/defaultSearchParams.json
@@ -83,6 +83,7 @@
             "max_prob_to_impute_irt": 0.75,
             "fwhm_nstd": 4,
             "irt_nstd": 4,
+            "irt_trim_mad_multiplier": 6,
             "plot_rt_alignment": false,
             "use_robust_fitting": true
         }

--- a/docs/src/user_guide/parameters.md
+++ b/docs/src/user_guide/parameters.md
@@ -83,6 +83,7 @@ Most parameters should not be changed, but the following may need adjustement.
 | `irt_mapping.max_prob_to_impute_irt` | Int | If probability of the psm is less then x in the first-pass search, then impute irt for the precursor with globably determined value from the other runs (default: 0.75) |
 | `irt_mapping.fwhm_nstd` | Float | Number of standard deviations of the fwhm to add to the retention time tolerance (default: 4) |
 | `irt_mapping.irt_nstd` | Int | Number of standard deviations of run-to-run irt tolerance to add to the retention time tolerance (default: 4) |
+| `irt_mapping.irt_trim_mad_multiplier` | Float | MAD multiplier used to trim outlier cross-run iRTs before forming the consensus anchor (default: 6) |
 
 ### Quantification Search Parameters
 

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -117,6 +117,7 @@ struct FirstPassSearchParameters{P<:PrecEstimation} <: FragmentIndexSearchParame
     max_prob_to_impute::Float32
     fwhm_nstd::Float32
     irt_nstd::Float32
+    irt_trim_mad_multiplier::Float32
     plot_rt_alignment::Bool
     use_robust_fitting::Bool
     prec_estimation::P
@@ -172,6 +173,7 @@ struct FirstPassSearchParameters{P<:PrecEstimation} <: FragmentIndexSearchParame
             Float32(irt_mapping_params.max_prob_to_impute_irt),  # Default max_prob_to_impute
             Float32(irt_mapping_params.fwhm_nstd),   # Default fwhm_nstd
             Float32(irt_mapping_params.irt_nstd),   # Default irt_nstd
+            Float32(get(irt_mapping_params, :irt_trim_mad_multiplier, 6.0)),
             Bool(hasproperty(irt_mapping_params, :plot_rt_alignment) ? irt_mapping_params.plot_rt_alignment : false),
             Bool(hasproperty(irt_mapping_params, :use_robust_fitting) ? irt_mapping_params.use_robust_fitting : true),
             prec_estimation
@@ -546,15 +548,16 @@ function summarize_results!(
         
         if isempty(valid_psms_paths)
             @user_warn "No valid files for cross-run precursor analysis"
-            return Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_library_irt::Float32, mean_library_irt::Union{Missing, Float32}, var_library_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32}}()
+            return Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_library_irt::Float32, consensus_library_irt::Float32, median_library_irt::Float32, mad_library_irt::Float32, n::UInt16, mz::Float32}}()
         end
-        
+
         # Get best precursors from valid files only
         return get_best_precursors_accross_runs(
             valid_psms_paths,
             getMz(getPrecursors(getSpecLib(search_context))),#[:mz],
             valid_rt_irt,
-            max_q_val=params.max_q_val_for_irt
+            max_q_val=params.max_q_val_for_irt,
+            mad_trim_multiplier=params.irt_trim_mad_multiplier
         )
     end
     # Map retention times
@@ -574,7 +577,7 @@ function summarize_results!(
         i = 1
         for (pid, val) in pairs(precursor_dict)
             i += 1
-            setPredIrt!(search_context, pid, getIrt(getPrecursors(getSpecLib(search_context)))[pid])
+            setPredIrt!(search_context, pid, val.consensus_library_irt)
             partner_pid = getPartnerPrecursorIdx(precursors)[pid]
             if ismissing(partner_pid)
                 continue
@@ -584,15 +587,15 @@ function summarize_results!(
             # Otherwise if the partner was ID'ed, it should keep its original predicted iRT
             if !haskey(precursor_dict, partner_pid)
                 insert!(precursor_dict, partner_pid, val)
-                setPredIrt!(search_context, partner_pid, getIrt(getPrecursors(getSpecLib(search_context)))[pid])
+                setPredIrt!(search_context, partner_pid, val.consensus_library_irt)
             else
-                setPredIrt!(search_context, partner_pid, getIrt(getPrecursors(getSpecLib(search_context)))[partner_pid])
+                setPredIrt!(search_context, partner_pid, precursor_dict[partner_pid].consensus_library_irt)
             end
-            
+
         end
     else
         for (pid, val) in pairs(precursor_dict)
-            setPredIrt!(search_context, pid, getIrt(getPrecursors(getSpecLib(search_context)))[pid])
+            setPredIrt!(search_context, pid, val.consensus_library_irt)
         end
     end
 

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-using Statistics: mean, median
-
 """
     get_best_precursors_accross_runs(psms_paths::Vector{String},
                                     prec_mzs::AbstractVector{Float32},

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
@@ -19,7 +19,8 @@
     get_best_precursors_accross_runs(psms_paths::Vector{String},
                                     prec_mzs::AbstractVector{Float32},
                                     rt_to_library_irt::Dict{Int64, RtConversionModel};
-                                    max_q_val::Float32=0.01f0)
+                                    max_q_val::Float32=0.01f0,
+                                    mad_trim_multiplier::Float32=6.0f0)
     -> Dictionary{UInt32, NamedTuple}
 
 Identify and collect best precursor matches across multiple runs for retention time calibration.
@@ -29,6 +30,7 @@ Identify and collect best precursor matches across multiple runs for retention t
 - `prec_mzs`: Vector of precursor m/z values
 - `rt_to_library_irt`: Dictionary mapping file indices to RT→library_iRT conversion models
 - `max_q_val`: Maximum q-value threshold for considering PSMs
+- `mad_trim_multiplier`: MAD multiplier used to trim outlier iRTs before consensus calculation
 
 # Returns
 Dictionary mapping precursor indices to NamedTuple containing:
@@ -36,31 +38,38 @@ Dictionary mapping precursor indices to NamedTuple containing:
 - `best_ms_file_idx`: File index with best match
 - `best_scan_idx`: Scan index of best match
 - `best_library_irt`: Library iRT value of best match
-- `mean_library_irt`: Mean library iRT across qualifying matches
-- `var_library_irt`: Variance in library iRT across qualifying matches
-- `n`: Number of qualifying matches
+- `consensus_library_irt`: Trimmed mean library iRT across qualifying matches
+- `median_library_irt`: Median library iRT across qualifying matches
+- `mad_library_irt`: Median absolute deviation of library iRT across qualifying matches
+- `n`: Number of retained matches after trimming
 - `mz`: Precursor m/z value
 
 # Process
-1. First pass: Collects best matches and calculates mean library iRT for each precursor across the runs
+1. First pass: Collects best matches and records library iRT observations for each precursor across the runs
 2. Filters to top N precursors by probability
-3. Second pass: Calculates library iRT variance for remaining precursors
+3. Calculates median/MAD statistics and trims outlier runs prior to consensus iRT calculation
 """
 function get_best_precursors_accross_runs(
                          psms_paths::Vector{String},
                          prec_mzs::AbstractVector{Float32},
                          rt_to_library_irt::Dict{Int64, RtConversionModel};
-                         max_q_val::Float32 = 0.01f0
+                         max_q_val::Float32 = 0.01f0,
+                         mad_trim_multiplier::Float32 = 6.0f0
                          )
+
+    using Statistics: mean, median
+
+    precursor_irt_values = Dictionary{UInt32, Vector{Float32}}()
 
     function readPSMs!(
         prec_to_best_prob::Dictionary{UInt32, @NamedTuple{ best_prob::Float32,
                                                     best_ms_file_idx::UInt32,
                                                     best_scan_idx::UInt32,
                                                     best_library_irt::Float32,
-                                                    mean_library_irt::Union{Missing, Float32},
-                                                    var_library_irt::Union{Missing, Float32},
-                                                    n::Union{Missing, UInt16},
+                                                    consensus_library_irt::Float32,
+                                                    median_library_irt::Float32,
+                                                    mad_library_irt::Float32,
+                                                    n::UInt16,
                                                     mz::Float32}},
         precursor_idxs::AbstractVector{UInt32},
         q_values::AbstractVector{Float16},
@@ -83,15 +92,12 @@ function get_best_precursors_accross_runs(
             # Initialize running statistics
             passed_q_val = (q_value <= max_q_val)
             n = passed_q_val ? one(UInt16) : zero(UInt16)
-            mean_library_irt = passed_q_val ? library_irt : zero(Float32)
-            var_library_irt = zero(Float32)
             mz = prec_mzs[precursor_idx]
 
             #Has the precursor been encountered in a previous raw file?
-            #Keep a running mean library_irt for instances below q-val threshold
             if haskey(prec_to_best_prob, precursor_idx)
                 # Update existing precursor entry
-                best_prob, best_ms_file_idx, best_scan_idx, best_library_irt, old_mean_library_irt, var_library_irt, old_n, mz = prec_to_best_prob[precursor_idx]
+                best_prob, best_ms_file_idx, best_scan_idx, best_library_irt, consensus_library_irt, median_library_irt, mad_library_irt, old_n, mz = prec_to_best_prob[precursor_idx]
 
                 # Update best match if current is better
                 if (best_prob < prob)
@@ -102,15 +108,15 @@ function get_best_precursors_accross_runs(
                 end
 
                 # Update running statistics
-                mean_library_irt += old_mean_library_irt
                 n += old_n
                 prec_to_best_prob[precursor_idx] = (
                                                 best_prob = best_prob,
                                                 best_ms_file_idx = best_ms_file_idx,
                                                 best_scan_idx = best_scan_idx,
                                                 best_library_irt = best_library_irt,
-                                                mean_library_irt = mean_library_irt,
-                                                var_library_irt = var_library_irt,
+                                                consensus_library_irt = consensus_library_irt,
+                                                median_library_irt = median_library_irt,
+                                                mad_library_irt = mad_library_irt,
                                                 n = n,
                                                 mz = mz)
             else
@@ -119,54 +125,72 @@ function get_best_precursors_accross_runs(
                         best_ms_file_idx = ms_file_idx,
                         best_scan_idx = scan_idx,
                         best_library_irt = library_irt,
-                        mean_library_irt = mean_library_irt,
-                        var_library_irt = var_library_irt,
+                        consensus_library_irt = library_irt,
+                        median_library_irt = library_irt,
+                        mad_library_irt = 0.0f0,
                         n = n,
                         mz = mz)
                 insert!(prec_to_best_prob, precursor_idx, val)
             end
+
+            if passed_q_val
+                push!(get!(precursor_irt_values, precursor_idx, Float32[]), library_irt)
+            end
         end
     end
-    function getVariance!(
+
+    function finalize_irt_statistics!(
         prec_to_best_prob::Dictionary{UInt32, @NamedTuple{ best_prob::Float32,
                                                     best_ms_file_idx::UInt32,
                                                     best_scan_idx::UInt32,
                                                     best_library_irt::Float32,
-                                                    mean_library_irt::Union{Missing, Float32},
-                                                    var_library_irt::Union{Missing, Float32},
-                                                    n::Union{Missing, UInt16},
+                                                    consensus_library_irt::Float32,
+                                                    median_library_irt::Float32,
+                                                    mad_library_irt::Float32,
+                                                    n::UInt16,
                                                     mz::Float32}},
-        precursor_idxs::AbstractVector{UInt32},
-        q_values::AbstractVector{Float16},
-        rts::AbstractVector{Float32},
-        rt_to_library_irt::RtConversionModel,
-        max_q_val::Float32)
-        for row in eachindex(precursor_idxs)
-            # Skip PSMs that don't pass q-value threshold
-            q_value = q_values[row]
-
-            # Get precursor info
-            precursor_idx = precursor_idxs[row]
-            library_irt = rt_to_library_irt(rts[row])
-
-            if q_value > max_q_val
+        precursor_irt_values::Dictionary{UInt32, Vector{Float32}},
+        mad_trim_multiplier::Float32)
+        for (precursor_idx, val) in prec_to_best_prob
+            irts = get(precursor_irt_values, precursor_idx, Float32[])
+            if isempty(irts)
+                prec_to_best_prob[precursor_idx] = (
+                    best_prob = val.best_prob,
+                    best_ms_file_idx = val.best_ms_file_idx,
+                    best_scan_idx = val.best_scan_idx,
+                    best_library_irt = val.best_library_irt,
+                    consensus_library_irt = val.consensus_library_irt,
+                    median_library_irt = val.median_library_irt,
+                    mad_library_irt = val.mad_library_irt,
+                    n = zero(UInt16),
+                    mz = val.mz
+                )
                 continue
             end
-            if haskey(prec_to_best_prob, precursor_idx)
-                # Update variance calculation
-                best_prob, best_ms_file_idx, best_scan_idx, best_library_irt, mean_library_irt, var_library_irt, n, mz = prec_to_best_prob[precursor_idx]
-                var_library_irt += (library_irt - mean_library_irt/n)^2
-                prec_to_best_prob[precursor_idx] = (
-                    best_prob = best_prob,
-                    best_ms_file_idx= best_ms_file_idx,
-                    best_scan_idx = best_scan_idx,
-                    best_library_irt = best_library_irt,
-                    mean_library_irt = mean_library_irt,
-                    var_library_irt = var_library_irt,
-                    n = n,
-                    mz = mz)
 
+            med = median(irts)
+            abs_dev = abs.(irts .- med)
+            mad_val = median(abs_dev)
+            trimmed_irts = if mad_val == 0f0
+                irts
+            else
+                filter(x -> abs(x - med) <= mad_trim_multiplier * mad_val, irts)
             end
+            trimmed_median = median(trimmed_irts)
+            trimmed_mean = mean(trimmed_irts)
+            consensus_irt = length(trimmed_irts) == 1 ? trimmed_irts[1] : trimmed_mean
+
+            prec_to_best_prob[precursor_idx] = (
+                best_prob = val.best_prob,
+                best_ms_file_idx = val.best_ms_file_idx,
+                best_scan_idx = val.best_scan_idx,
+                best_library_irt = val.best_library_irt,
+                consensus_library_irt = Float32(consensus_irt),
+                median_library_irt = Float32(trimmed_median),
+                mad_library_irt = Float32(mad_val),
+                n = UInt16(length(trimmed_irts)),
+                mz = val.mz
+            )
         end
     end
     # Initialize dictionary to store best precursor matches
@@ -174,9 +198,10 @@ function get_best_precursors_accross_runs(
                                                         best_ms_file_idx::UInt32,
                                                         best_scan_idx::UInt32,
                                                         best_library_irt::Float32,
-                                                        mean_library_irt::Union{Missing, Float32},
-                                                        var_library_irt::Union{Missing, Float32},
-                                                        n::Union{Missing, UInt16},
+                                                        consensus_library_irt::Float32,
+                                                        median_library_irt::Float32,
+                                                        mad_library_irt::Float32,
+                                                        n::UInt16,
                                                         mz::Float32}}()
 
     # First pass: collect best matches and mean library iRT
@@ -229,32 +254,8 @@ function get_best_precursors_accross_runs(
         end
     end
 
-    # Second pass: calculate library iRT variance for remaining precursors
-    for psms_path in psms_paths #For each data frame
-        psms = Arrow.Table(psms_path)
+    # Calculate trimmed consensus statistics
+    finalize_irt_statistics!(prec_to_best_prob, precursor_irt_values, mad_trim_multiplier)
 
-        # Get the original file index from the PSM data
-        if isempty(psms[:ms_file_idx])
-            continue  # Skip empty files
-        end
-        file_idx = first(psms[:ms_file_idx])  # All PSMs in a file should have the same ms_file_idx
-
-        # Check if RT model exists for this file
-        if !haskey(rt_to_library_irt, file_idx)
-            continue  # Skip files without RT models (already warned in first pass)
-        end
-
-        #One row for each precursor
-        getVariance!(
-            prec_to_best_prob,
-            psms[:precursor_idx],
-            psms[:q_value],
-            psms[:rt],
-            rt_to_library_irt[file_idx],
-            max_q_val
-        )
-    end 
-
-    
     return prec_to_best_prob #[(prob, idx) for (idx, prob) in sort(collect(top_probs), rev=true)]
 end

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
@@ -49,6 +49,8 @@ Dictionary mapping precursor indices to NamedTuple containing:
 2. Filters to top N precursors by probability
 3. Calculates median/MAD statistics and trims outlier runs prior to consensus iRT calculation
 """
+using Statistics: mean, median
+
 function get_best_precursors_accross_runs(
                          psms_paths::Vector{String},
                          prec_mzs::AbstractVector{Float32},
@@ -56,8 +58,6 @@ function get_best_precursors_accross_runs(
                          max_q_val::Float32 = 0.01f0,
                          mad_trim_multiplier::Float32 = 6.0f0
                          )
-
-    using Statistics: mean, median
 
     precursor_irt_values = Dictionary{UInt32, Vector{Float32}}()
 

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+using Statistics: mean, median
+
 """
     get_best_precursors_accross_runs(psms_paths::Vector{String},
                                     prec_mzs::AbstractVector{Float32},
@@ -49,7 +51,6 @@ Dictionary mapping precursor indices to NamedTuple containing:
 2. Filters to top N precursors by probability
 3. Calculates median/MAD statistics and trims outlier runs prior to consensus iRT calculation
 """
-using Statistics: mean, median
 
 function get_best_precursors_accross_runs(
                          psms_paths::Vector{String},

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
@@ -150,7 +150,7 @@ function get_best_precursors_accross_runs(
                                                     mz::Float32}},
         precursor_irt_values::Dictionary{UInt32, Vector{Float32}},
         mad_trim_multiplier::Float32)
-        for (precursor_idx, val) in prec_to_best_prob
+        for (precursor_idx, val) in pairs(prec_to_best_prob)
             irts = get(precursor_irt_values, precursor_idx, Float32[])
             if isempty(irts)
                 prec_to_best_prob[precursor_idx] = (

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
@@ -617,8 +617,8 @@ end
 
 PrecToIrtType = Dictionary{UInt32,
     NamedTuple{
-        (:best_prob, :best_ms_file_idx, :best_scan_idx, :best_library_irt, :mean_library_irt, :var_library_irt, :n, :mz),
-        Tuple{Float32, UInt32, UInt32, Float32, Union{Missing, Float32}, Union{Missing, Float32}, Union{Missing, UInt16}, Float32}
+        (:best_prob, :best_ms_file_idx, :best_scan_idx, :best_library_irt, :consensus_library_irt, :median_library_irt, :mad_library_irt, :n, :mz),
+        Tuple{Float32, UInt32, UInt32, Float32, Float32, Float32, Float32, UInt16, Float32}
     }
 }
 
@@ -655,7 +655,7 @@ function create_rt_indices!(
     setIrtErrors!(search_context, irt_errs)
 
     # Create precursor to library iRT mapping
-    prec_to_irt = map(x -> (irt=x[:best_library_irt], mz=x[:mz]),
+    prec_to_irt = map(x -> (irt=x[:consensus_library_irt], mz=x[:mz]),
                       precursor_dict)
 
     # Set up indices folder
@@ -716,7 +716,7 @@ Calculates refined iRT error tolerances based on peak widths and cross-run varia
 # Returns
 Dictionary mapping file indices to refined iRT tolerances, combining:
 - Peak width variation (FWHM + n*MAD)
-- Cross-run refined iRT variation
+- Cross-run refined iRT variation estimated by median MAD across precursors
 """
 function get_irt_errs(
     fwhms::Dictionary{Int64, 
@@ -729,9 +729,10 @@ function get_irt_errs(
                 best_ms_file_idx::UInt32,
                 best_scan_idx::UInt32,
                 best_library_irt::Float32,
-                mean_library_irt::Union{Missing, Float32},
-                var_library_irt::Union{Missing, Float32},
-                n::Union{Missing, UInt16},
+                consensus_library_irt::Float32,
+                median_library_irt::Float32,
+                mad_library_irt::Float32,
+                n::UInt16,
                 mz::Float32}}
     ,
     params::FirstPassSearchParameters
@@ -741,22 +742,15 @@ function get_irt_errs(
     #n is a user-defined paramter.
     fwhms = map(x->x[:median_fwhm] + params.fwhm_nstd*x[:mad_fwhm],
     fwhms)
-    #Get variance in irt of apex accross runs. Only consider precursor identified below q-value threshold
-    #in more than two runs .
+    #Get median absolute deviation in iRT across runs (after trimming)
     irt_std = nothing
-    variance_  = collect(skipmissing(map(x-> (x[:n] > 2) ? sqrt(x[:var_library_irt]/(x[:n] - 1)) : missing, prec_to_irt)))
-    if !iszero(length(variance_))
-        irt_std = median(variance_)
+    mad_vals = collect(skipmissing(map(x -> (x[:n] > 1) ? x[:mad_library_irt] : missing, prec_to_irt)))
+    if !iszero(length(mad_vals))
+        irt_std = median(mad_vals)
     else
-        #This could happen if only two files are being searched
-        variance_  = collect(skipmissing(map(x-> (x[:n] == 2) ? sqrt(x[:var_library_irt]) : missing, prec_to_irt)))
-        if iszero(length(variance_)) #only searching one file so 
-            irt_std = 0.0f0
-        else
-            irt_std = median(variance_)
-        end
+        irt_std = 0.0f0
     end
-    #Number of standard deviations to cover
+    #Number of MADs to cover
     irt_std *= params.irt_nstd
     #dictionary maping file name to irt tolerance.
     return map(x->Float32((x+irt_std))::Float32, fwhms)::Dictionary{Int64, Float32}

--- a/src/Routines/SearchDIA/SearchMethods/SearchTypes.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SearchTypes.jl
@@ -621,7 +621,7 @@ function setIrtRefinementModel!(s::SearchContext, model::Union{IrtRefinementMode
     s.irt_refinement_models[index] = model
 end
 
-function setPrecursorDict!(s::SearchContext, dict::Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_library_irt::Float32, mean_library_irt::Union{Missing, Float32}, var_library_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32}})
+function setPrecursorDict!(s::SearchContext, dict::Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_library_irt::Float32, consensus_library_irt::Float32, median_library_irt::Float32, mad_library_irt::Float32, n::UInt16, mz::Float32}})
     s.precursor_dict[] = dict
 end
 setRtIndexPaths!(s::SearchContext, paths::Vector{String}) = (s.rt_index_paths[] = paths)

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -838,7 +838,7 @@ function add_features!(psms::DataFrame,
                                     ms_file_idx::Integer,
                                     rt_to_irt_interp::RtConversionModel,
                                     rt_to_refined_irt_interp::RtConversionModel,
-                                    prec_id_to_irt::Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_library_irt::Float32, mean_library_irt::Union{Missing, Float32}, var_library_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32}}
+                                    prec_id_to_irt::Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_library_irt::Float32, consensus_library_irt::Float32, median_library_irt::Float32, mad_library_irt::Float32, n::UInt16, mz::Float32}}
                                     )
 
     precursor_sequence = getSequence(getPrecursors(getSpecLib(search_context)))#[:sequence],
@@ -930,10 +930,10 @@ function add_features!(psms::DataFrame,
                 end
 
                 # Difference between observed and best library iRT from other runs
-                refined_irt_diff[i] = abs(refined_irt_obs[i] - 
-                refinement_model(precursor_sequence[prec_idx], prec_id_to_irt[prec_idx].best_library_irt))
-                
-                irt_diff[i] = abs(irt_obs[i] - prec_id_to_irt[prec_idx].best_library_irt)
+                refined_irt_diff[i] = abs(refined_irt_obs[i] -
+                refinement_model(precursor_sequence[prec_idx], prec_id_to_irt[prec_idx].consensus_library_irt))
+
+                irt_diff[i] = abs(irt_obs[i] - prec_id_to_irt[prec_idx].consensus_library_irt)
 
                 # MS1-level iRT difference
                 if !ms1_missing[i]


### PR DESCRIPTION
## Summary
- compute per-precursor median/MAD of library iRTs, trim outliers with a configurable MAD multiplier, and derive consensus values
- use the consensus iRTs for RT index construction and second-pass feature deltas
- document the new trimming parameter and expose it in the default configuration

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925f074853083258a0c88bb383805be)