### PR TITLE
Add refined iRT error rescore for first-pass PSMs

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -119,6 +119,7 @@ struct FirstPassSearchParameters{P<:PrecEstimation} <: FragmentIndexSearchParame
     irt_nstd::Float32
     plot_rt_alignment::Bool
     use_robust_fitting::Bool
+    rescore_with_refined_irt_error::Bool
     prec_estimation::P
 
     function FirstPassSearchParameters(params::PioneerParameters)
@@ -174,6 +175,8 @@ struct FirstPassSearchParameters{P<:PrecEstimation} <: FragmentIndexSearchParame
             Float32(irt_mapping_params.irt_nstd),   # Default irt_nstd
             Bool(hasproperty(irt_mapping_params, :plot_rt_alignment) ? irt_mapping_params.plot_rt_alignment : false),
             Bool(hasproperty(irt_mapping_params, :use_robust_fitting) ? irt_mapping_params.use_robust_fitting : true),
+            Bool(hasproperty(irt_mapping_params, :rescore_with_refined_irt_error) ?
+                irt_mapping_params.rescore_with_refined_irt_error : true),
             prec_estimation
         )
     end
@@ -313,20 +316,7 @@ function process_file!(
         psms::DataFrame,
         params::FirstPassSearchParameters,
         search_context::SearchContext)
-        column_names = [
-            :spectral_contrast, :city_block, :entropy_score, :scribe, :percent_theoretical_ignored,
-            :charge2, :poisson, :irt_error, 
-            :missed_cleavage, 
-            :Mox,
-            #:charge, Only works with charge 2 if at least 3 charge states presence. otherwise singular error
-            #:b_count, might be good for non-tryptic enzymes
-            :TIC, :y_count, :err_norm, :spectrum_peak_count, :intercept
-        ]
-
-        # Avoid singular error if no peaks were ignored
-        if maximum(psms.percent_theoretical_ignored) == 0
-            deleteat!(column_names, findfirst(==(:percent_theoretical_ignored), column_names))
-        end
+        column_names = get_first_pass_score_columns(psms)
 
 
         # Select scoring columns
@@ -359,9 +349,12 @@ function process_file!(
             )
         end
         # Process scores
-       
-        select!(psms, [:ms_file_idx, :score, :precursor_idx, :scan_idx,
-            :q_value, :log2_summed_intensity, :irt, :rt, :irt_predicted, :target])
+        keep_columns = unique(vcat(
+            column_names,
+            [:ms_file_idx, :score, :precursor_idx, :scan_idx, :q_value, :log2_summed_intensity,
+             :irt, :rt, :irt_predicted, :target, :irt_error, :scan_count]
+        ))
+        select!(psms, keep_columns)
         get_probs!(psms, psms[!,:score])
     end
 
@@ -491,10 +484,15 @@ function process_search_results!(
     parsed_fname = getParsedFileName(search_context, ms_file_idx)
     temp_path = joinpath(getDataOutDir(search_context), "temp_data", "first_pass_psms", parsed_fname * ".arrow")
     psms[!, :ms_file_idx] .= UInt32(ms_file_idx)
+    scored_columns = get_first_pass_score_columns(psms)
+    persisted_columns = unique(vcat(
+        scored_columns,
+        [:ms_file_idx, :scan_idx, :precursor_idx, :rt, :irt_predicted, :q_value,
+         :score, :prob, :scan_count, :target, :irt_error]
+    ))
     Arrow.write(
         temp_path,
-        select!(psms, [:ms_file_idx, :scan_idx, :precursor_idx, :rt,
-            :irt_predicted, :q_value, :score, :prob, :scan_count])
+        select(psms, persisted_columns)
     )
     setFirstPassPsms!(getMSData(search_context), ms_file_idx, temp_path)
 
@@ -559,6 +557,8 @@ function summarize_results!(
     end
     # Map retention times
     map_retention_times!(search_context, results, params)
+    # Optional rescore using refined iRT errors before selecting precursors
+    rescore_psms_with_refined_irt_error!(search_context, params)
     # Process precursors
     precursor_dict = get_best_precursors_accross_runs!(search_context, results, params)
 

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
@@ -121,6 +121,25 @@ function add_main_search_columns!(psms::DataFrame,
     psms[!,:intercept] = ones(Float16, N)
 end
 
+function get_first_pass_score_columns(psms::DataFrame)
+    column_names = [
+        :spectral_contrast, :city_block, :entropy_score, :scribe, :percent_theoretical_ignored,
+        :charge2, :poisson, :irt_error,
+        :missed_cleavage,
+        :Mox,
+        #:charge, Only works with charge 2 if at least 3 charge states presence. otherwise singular error
+        #:b_count, might be good for non-tryptic enzymes
+        :TIC, :y_count, :err_norm, :spectrum_peak_count, :intercept
+    ]
+
+    # Avoid singular error if no peaks were ignored
+    if :percent_theoretical_ignored in names(psms) && maximum(psms.percent_theoretical_ignored) == 0
+        deleteat!(column_names, findfirst(==(:percent_theoretical_ignored), column_names))
+    end
+
+    return column_names
+end
+
 """
     score_main_search_psms!(psms::DataFrame, column_names::Vector{Symbol};
                            n_train_rounds::Int64=2,
@@ -555,6 +574,65 @@ function map_retention_times!(
             setRefinedIrtToRtMap!(search_context, IdentityModel(), failed_idx)
             setIrtRefinementModel!(search_context, nothing, failed_idx)
         end
+    end
+
+    return nothing
+end
+
+"""
+    rescore_psms_with_refined_irt_error!(search_context::SearchContext,
+                                         params::FirstPassSearchParameters)
+
+Recompute iRT error using refined predictions and rescore first-pass PSMs.
+
+Runs only when refinement models and refined RT splines are available for a file
+and the feature-level rescore is enabled via parameters.
+"""
+function rescore_psms_with_refined_irt_error!(
+    search_context::SearchContext,
+    params::FirstPassSearchParameters
+)
+    params.rescore_with_refined_irt_error || return
+
+    psms_paths = getFirstPassPsms(getMSData(search_context))
+    rt_to_refined_irt = getRtToRefinedIrtMap(search_context)
+    refinement_models = getIrtRefinementModels(search_context)
+    fdr_scale_factor = getLibraryFdrScaleFactor(search_context)
+
+    for ms_file_idx in get_valid_file_indices(search_context)
+        if is_file_failed(search_context, ms_file_idx)
+            continue
+        end
+
+        refinement_model = get(refinement_models, ms_file_idx, nothing)
+        rt_model = get(rt_to_refined_irt, ms_file_idx, IdentityModel())
+
+        # Require a usable refinement model and refined RT spline
+        if isnothing(refinement_model) || !(refinement_model.use_refinement) || rt_model isa IdentityModel
+            continue
+        end
+
+        psms_path = psms_paths[ms_file_idx]
+        psms = DataFrame(Arrow.Table(psms_path))
+        if isempty(psms) || !haskey(psms, :refined_irt)
+            continue
+        end
+
+        # Update iRT error using refined predictions
+        psms[!, :irt_error] = Float16.(abs.(rt_model.(Float32.(psms[!, :rt])) .- Float32.(psms[!, :refined_irt])))
+
+        column_names = get_first_pass_score_columns(psms)
+        score_main_search_psms!(
+            psms,
+            column_names;
+            n_train_rounds=params.n_train_rounds_probit,
+            max_iter_per_round=params.max_iter_probit,
+            max_q_value=Float64(params.max_q_value_probit_rescore),
+            fdr_scale_factor=fdr_scale_factor
+        )
+        get_probs!(psms, psms[!, :score])
+
+        Arrow.write(psms_path, psms)
     end
 
     return nothing


### PR DESCRIPTION
## Summary
- persist scoring features for first-pass PSMs so refined iRT errors can be recomputed
- add an optional refined-iRT rescore step before precursor selection when refinement models are available
- gate the rescore with a new parameter and shared helper for first-pass scoring columns

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69261b73639c832594f1f37516129614)