### PR TITLE
Write percolator input TSV to temp directory

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/score_psms.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/score_psms.jl
@@ -99,6 +99,9 @@ function score_precursor_isotope_traces(
         # In-memory processing - load PSMs first
         best_psms = load_psms_for_lightgbm(second_pass_folder)
 
+        temp_folder = dirname(second_pass_folder)
+        write_input_psms_tsv(joinpath(temp_folder, "percolator_input_psms.tsv"), best_psms)
+
         # Add quantile-binned features before training
         features_to_bin = [:prec_mz, :refined_irt_pred, :irt_pred, :weight, :tic]
         add_quantile_binned_features!(best_psms, features_to_bin, n_quantile_bins)

--- a/src/utils/ML/percolatorSortOf.jl
+++ b/src/utils/ML/percolatorSortOf.jl
@@ -256,7 +256,7 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
                   print_importance::Bool = false,
                   show_progress::Bool = true,
                   verbose_logging::Bool = false)
-    
+
     # Apply random target-decoy pairing before ML training
     assign_random_target_decoy_pairs!(psms)
     #Faster if sorted first (handle missing pair_id values)
@@ -1015,6 +1015,22 @@ function dropVectorColumns!(df)
     end
     # 2) Drop those columns in place
     select!(df, Not(to_drop))
+end
+
+"""
+    write_input_psms_tsv(tsv_output_path::AbstractString, psms::DataFrame)
+
+Write the incoming PSM DataFrame to a TSV file for debugging.
+Vector columns are dropped to avoid serialization errors.
+"""
+function write_input_psms_tsv(tsv_output_path::AbstractString, psms::DataFrame)
+    mkpath(dirname(tsv_output_path))
+
+    psms_for_output = copy(psms)
+    dropVectorColumns!(psms_for_output)
+    CSV.write(tsv_output_path, psms_for_output; delim='\t')
+
+    return nothing
 end
 # DISABLED: OOM helper function - only used by sort_of_percolator_out_of_memory!
 #=


### PR DESCRIPTION
## Summary
- write percolator input PSMs to a temp_data TSV alongside other intermediate files
- remove optional TSV export flag and logging from percolator scoring routine

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928c0094e908325a20e2c26fabdaa4d)