### PR TITLE
Adjust second pass precursor centering using refined iRT offset

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -597,7 +597,7 @@ function summarize_results!(
         
         if isempty(valid_psms_paths)
             @user_warn "No valid files for cross-run precursor analysis"
-            return Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_library_irt::Float32, mean_library_irt::Union{Missing, Float32}, var_library_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32}}()
+            return Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_library_irt::Float32, best_refined_irt::Float32, irt_offset::Float32, mean_library_irt::Union{Missing, Float32}, var_library_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32}}()
         end
         
         # Get best precursors from valid files only

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/getBestPrecursorsAccrossRuns.jl
@@ -36,6 +36,8 @@ Dictionary mapping precursor indices to NamedTuple containing:
 - `best_ms_file_idx`: File index with best match
 - `best_scan_idx`: Scan index of best match
 - `best_library_irt`: Library iRT value of best match
+- `best_refined_irt`: Refined predicted iRT of best match
+- `irt_offset`: Difference between observed iRT and refined prediction
 - `mean_library_irt`: Mean library iRT across qualifying matches
 - `var_library_irt`: Variance in library iRT across qualifying matches
 - `n`: Number of qualifying matches
@@ -58,6 +60,8 @@ function get_best_precursors_accross_runs(
                                                     best_ms_file_idx::UInt32,
                                                     best_scan_idx::UInt32,
                                                     best_library_irt::Float32,
+                                                    best_refined_irt::Float32,
+                                                    irt_offset::Float32,
                                                     mean_library_irt::Union{Missing, Float32},
                                                     var_library_irt::Union{Missing, Float32},
                                                     n::Union{Missing, UInt16},
@@ -66,6 +70,7 @@ function get_best_precursors_accross_runs(
         q_values::AbstractVector{Float16},
         probs::AbstractVector{Float32},
         rts::AbstractVector{Float32},
+        refined_irts::AbstractVector{Float32},
         scan_idxs::AbstractVector{UInt32},
         ms_file_idxs::AbstractVector{UInt32},
         rt_to_library_irt::RtConversionModel,
@@ -77,8 +82,10 @@ function get_best_precursors_accross_runs(
             precursor_idx = precursor_idxs[row]
             prob = probs[row]
             library_irt = rt_to_library_irt(rts[row])
+            refined_pred_irt = refined_irts[row]
             scan_idx = UInt32(scan_idxs[row])
             ms_file_idx = UInt32(ms_file_idxs[row])
+            irt_offset = library_irt - refined_pred_irt
 
             # Initialize running statistics
             passed_q_val = (q_value <= max_q_val)
@@ -91,7 +98,7 @@ function get_best_precursors_accross_runs(
             #Keep a running mean library_irt for instances below q-val threshold
             if haskey(prec_to_best_prob, precursor_idx)
                 # Update existing precursor entry
-                best_prob, best_ms_file_idx, best_scan_idx, best_library_irt, old_mean_library_irt, var_library_irt, old_n, mz = prec_to_best_prob[precursor_idx]
+                best_prob, best_ms_file_idx, best_scan_idx, best_library_irt, best_refined_irt, best_irt_offset, old_mean_library_irt, var_library_irt, old_n, mz = prec_to_best_prob[precursor_idx]
 
                 # Update best match if current is better
                 if (best_prob < prob)
@@ -99,6 +106,8 @@ function get_best_precursors_accross_runs(
                     best_library_irt = library_irt
                     best_scan_idx = scan_idx
                     best_ms_file_idx = ms_file_idx
+                    best_refined_irt = refined_pred_irt
+                    best_irt_offset = irt_offset
                 end
 
                 # Update running statistics
@@ -109,6 +118,8 @@ function get_best_precursors_accross_runs(
                                                 best_ms_file_idx = best_ms_file_idx,
                                                 best_scan_idx = best_scan_idx,
                                                 best_library_irt = best_library_irt,
+                                                best_refined_irt = best_refined_irt,
+                                                irt_offset = best_irt_offset,
                                                 mean_library_irt = mean_library_irt,
                                                 var_library_irt = var_library_irt,
                                                 n = n,
@@ -119,6 +130,8 @@ function get_best_precursors_accross_runs(
                         best_ms_file_idx = ms_file_idx,
                         best_scan_idx = scan_idx,
                         best_library_irt = library_irt,
+                        best_refined_irt = refined_pred_irt,
+                        irt_offset = irt_offset,
                         mean_library_irt = mean_library_irt,
                         var_library_irt = var_library_irt,
                         n = n,
@@ -132,6 +145,8 @@ function get_best_precursors_accross_runs(
                                                     best_ms_file_idx::UInt32,
                                                     best_scan_idx::UInt32,
                                                     best_library_irt::Float32,
+                                                    best_refined_irt::Float32,
+                                                    irt_offset::Float32,
                                                     mean_library_irt::Union{Missing, Float32},
                                                     var_library_irt::Union{Missing, Float32},
                                                     n::Union{Missing, UInt16},
@@ -154,13 +169,15 @@ function get_best_precursors_accross_runs(
             end
             if haskey(prec_to_best_prob, precursor_idx)
                 # Update variance calculation
-                best_prob, best_ms_file_idx, best_scan_idx, best_library_irt, mean_library_irt, var_library_irt, n, mz = prec_to_best_prob[precursor_idx]
+                best_prob, best_ms_file_idx, best_scan_idx, best_library_irt, best_refined_irt, irt_offset, mean_library_irt, var_library_irt, n, mz = prec_to_best_prob[precursor_idx]
                 var_library_irt += (library_irt - mean_library_irt/n)^2
                 prec_to_best_prob[precursor_idx] = (
                     best_prob = best_prob,
                     best_ms_file_idx= best_ms_file_idx,
                     best_scan_idx = best_scan_idx,
                     best_library_irt = best_library_irt,
+                    best_refined_irt = best_refined_irt,
+                    irt_offset = irt_offset,
                     mean_library_irt = mean_library_irt,
                     var_library_irt = var_library_irt,
                     n = n,
@@ -174,6 +191,8 @@ function get_best_precursors_accross_runs(
                                                         best_ms_file_idx::UInt32,
                                                         best_scan_idx::UInt32,
                                                         best_library_irt::Float32,
+                                                        best_refined_irt::Float32,
+                                                        irt_offset::Float32,
                                                         mean_library_irt::Union{Missing, Float32},
                                                         var_library_irt::Union{Missing, Float32},
                                                         n::Union{Missing, UInt16},
@@ -205,6 +224,7 @@ function get_best_precursors_accross_runs(
             psms[:q_value],
             psms[:prob],
             psms[:rt],
+            psms[:refined_irt],
             psms[:scan_idx],
             psms[:ms_file_idx],
             rt_to_library_irt[file_idx],

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
@@ -718,13 +718,13 @@ end
 
 
 """
-    get_irt_errs(fwhms::Dictionary, prec_to_irt::Dictionary, params::FirstPassSearchParameters)
+    get_irt_errs(fwhms::Dictionary, prec_to_irt::PrecToIrtType, params::FirstPassSearchParameters)
 
 Calculates refined iRT error tolerances based on peak widths and cross-run variation.
 
 # Arguments
 - `fwhms`: Dictionary of FWHM statistics per file
-- `prec_to_irt`: Dictionary of precursor refined iRT data
+- `prec_to_irt`: Dictionary of precursor refined iRT data (see `PrecToIrtType`)
 - `params`: Parameters including FWHM and iRT standard deviation multipliers
 
 # Returns
@@ -733,21 +733,12 @@ Dictionary mapping file indices to refined iRT tolerances, combining:
 - Cross-run refined iRT variation
 """
 function get_irt_errs(
-    fwhms::Dictionary{Int64, 
+    fwhms::Dictionary{Int64,
                         @NamedTuple{
                             median_fwhm::Float32,
                             mad_fwhm::Float32
                         }},
-    prec_to_irt::Dictionary{UInt32,
-    @NamedTuple{best_prob::Float32,
-                best_ms_file_idx::UInt32,
-                best_scan_idx::UInt32,
-                best_library_irt::Float32,
-                mean_library_irt::Union{Missing, Float32},
-                var_library_irt::Union{Missing, Float32},
-                n::Union{Missing, UInt16},
-                mz::Float32}}
-    ,
+    prec_to_irt::PrecToIrtType,
     params::FirstPassSearchParameters
 )
     #Get upper bound on peak fwhm. Use median + n*standard_deviation

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
@@ -631,8 +631,8 @@ end
 
 PrecToIrtType = Dictionary{UInt32,
     NamedTuple{
-        (:best_prob, :best_ms_file_idx, :best_scan_idx, :best_library_irt, :mean_library_irt, :var_library_irt, :n, :mz),
-        Tuple{Float32, UInt32, UInt32, Float32, Union{Missing, Float32}, Union{Missing, Float32}, Union{Missing, UInt16}, Float32}
+        (:best_prob, :best_ms_file_idx, :best_scan_idx, :best_library_irt, :best_refined_irt, :irt_offset, :mean_library_irt, :var_library_irt, :n, :mz),
+        Tuple{Float32, UInt32, UInt32, Float32, Float32, Float32, Union{Missing, Float32}, Union{Missing, Float32}, Union{Missing, UInt16}, Float32}
     }
 }
 
@@ -669,7 +669,7 @@ function create_rt_indices!(
     setIrtErrors!(search_context, irt_errs)
 
     # Create precursor to library iRT mapping
-    prec_to_irt = map(x -> (irt=x[:best_library_irt], mz=x[:mz]),
+    prec_to_irt = map(x -> (irt = x[:best_refined_irt] + x[:irt_offset], mz = x[:mz]),
                       precursor_dict)
 
     # Set up indices folder

--- a/src/Routines/SearchDIA/SearchMethods/SearchTypes.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SearchTypes.jl
@@ -621,7 +621,7 @@ function setIrtRefinementModel!(s::SearchContext, model::Union{IrtRefinementMode
     s.irt_refinement_models[index] = model
 end
 
-function setPrecursorDict!(s::SearchContext, dict::Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_library_irt::Float32, mean_library_irt::Union{Missing, Float32}, var_library_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32}})
+function setPrecursorDict!(s::SearchContext, dict::Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_library_irt::Float32, best_refined_irt::Float32, irt_offset::Float32, mean_library_irt::Union{Missing, Float32}, var_library_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32}})
     s.precursor_dict[] = dict
 end
 setRtIndexPaths!(s::SearchContext, paths::Vector{String}) = (s.rt_index_paths[] = paths)

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -838,7 +838,7 @@ function add_features!(psms::DataFrame,
                                     ms_file_idx::Integer,
                                     rt_to_irt_interp::RtConversionModel,
                                     rt_to_refined_irt_interp::RtConversionModel,
-                                    prec_id_to_irt::Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_library_irt::Float32, mean_library_irt::Union{Missing, Float32}, var_library_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32}}
+                                    prec_id_to_irt::Dictionary{UInt32, @NamedTuple{best_prob::Float32, best_ms_file_idx::UInt32, best_scan_idx::UInt32, best_library_irt::Float32, best_refined_irt::Float32, irt_offset::Float32, mean_library_irt::Union{Missing, Float32}, var_library_irt::Union{Missing, Float32}, n::Union{Missing, UInt16}, mz::Float32}}
                                     )
 
     precursor_sequence = getSequence(getPrecursors(getSpecLib(search_context)))#[:sequence],
@@ -929,14 +929,11 @@ function add_features!(psms::DataFrame,
                     library_irt
                 end
 
-                # Difference between observed and best library iRT from other runs
-                refined_irt_diff[i] = abs(refined_irt_obs[i] - refinement_model(
-                    precursor_sequence[prec_idx],
-                    structural_mods[prec_idx],
-                    prec_id_to_irt[prec_idx].best_library_irt
-                ))
-                
-                irt_diff[i] = abs(irt_obs[i] - prec_id_to_irt[prec_idx].best_library_irt)
+                target_refined_irt = prec_id_to_irt[prec_idx].best_refined_irt
+                target_library_irt = target_refined_irt + prec_id_to_irt[prec_idx].irt_offset
+
+                refined_irt_diff[i] = abs(refined_irt_obs[i] - target_refined_irt)
+                irt_diff[i] = abs(irt_obs[i] - target_library_irt)
 
                 # MS1-level iRT difference
                 if !ms1_missing[i]


### PR DESCRIPTION
## Summary
- track refined predicted iRT and per-precursor iRT offsets when collecting best PSMs
- propagate the expanded precursor dictionary to search context
- center second-pass RT indices using refined iRT plus the learned offset

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cd25521888325a427b2e8a78f396f)