### PR TITLE
Update MBR global probability aggregation

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/score_psms.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/score_psms.jl
@@ -360,6 +360,7 @@ function train_lightgbm_model_in_memory(
             :MBR_log2_explained_ratio,
             :MBR_rv_coefficient,
             :MBR_best_irt_diff,
+            :MBR_global_prob,
             :MBR_is_missing
         ])
     end

--- a/src/utils/ML/percolatorSortOf.jl
+++ b/src/utils/ML/percolatorSortOf.jl
@@ -861,8 +861,15 @@ function update_mbr_features!(psms_train::AbstractDataFrame,
 end
 
 function compute_mbr_global_prob!(psms::AbstractDataFrame, sqrt_n_runs::Int)
-    transform!(groupby(psms, [:precursor_idx, :isotopes_captured]),
-               :trace_prob => (p -> logodds(p, sqrt_n_runs)) => :MBR_global_prob)
+    for sub_psms in groupby(psms, [:precursor_idx, :isotopes_captured])
+        ms_files = sub_psms.ms_file_idx
+        probs = sub_psms.trace_prob
+
+        for run in unique(ms_files)
+            other_probs = probs[ms_files .!= run]
+            sub_psms.MBR_global_prob[ms_files .== run] .= logodds(other_probs, sqrt_n_runs)
+        end
+    end
 
     return psms
 end

--- a/src/utils/ML/percolatorSortOf.jl
+++ b/src/utils/ML/percolatorSortOf.jl
@@ -849,8 +849,22 @@ function update_mbr_features!(psms_train::AbstractDataFrame,
         summarize_precursors!(psms_train, q_cutoff = max_q_value_lightgbm_rescore)
     end
     if itr == mbr_start_iter - 1
+        sqrt_n_runs = begin
+            n_runs = length(unique(vcat(psms_train.ms_file_idx, psms_test.ms_file_idx)))
+            max(1, floor(Int, sqrt(n_runs)))
+        end
+
+        compute_mbr_global_prob!(psms_train, sqrt_n_runs)
+        compute_mbr_global_prob!(psms_test, sqrt_n_runs)
         prob_test[test_fold_idxs] = psms_test.trace_prob
     end
+end
+
+function compute_mbr_global_prob!(psms::AbstractDataFrame, sqrt_n_runs::Int)
+    transform!(groupby(psms, [:precursor_idx, :isotopes_captured]),
+               :trace_prob => (p -> logodds(p, sqrt_n_runs)) => :MBR_global_prob)
+
+    return psms
 end
 
 function summarize_precursors!(psms::AbstractDataFrame; q_cutoff::Float32 = 0.01f0)
@@ -960,6 +974,7 @@ function initialize_prob_group_features!(
         psms[!, :MBR_rv_coefficient]            = zeros(Float32, n)
         psms[!, :MBR_is_best_decoy]             = trues(n)
         psms[!, :MBR_num_runs]                  = zeros(Int32, n)
+        psms[!, :MBR_global_prob]               = zeros(Float32, n)
         psms[!, :MBR_transfer_candidate]        = falses(n)
         psms[!, :MBR_is_missing]                = falses(n)
     end


### PR DESCRIPTION
## Summary
- compute `MBR_global_prob` per precursor and isotope combination using log-odds aggregation of trace-level probabilities after the second iteration
- continue exposing the `MBR_global_prob` feature in the LightGBM MBR feature set for downstream training

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cf959417c8325b68ec9ff670ed586)