### PR TITLE
Add peptide tracking logs during spectral library build

### DIFF
--- a/src/Routines/BuildSpecLib.jl
+++ b/src/Routines/BuildSpecLib.jl
@@ -307,6 +307,10 @@ function BuildSpecLib(params_path::String)
                     :mods => :structural_mods
                 ])
 
+                target_peptide = "ENALDRAEQAEADK"
+                peptide_hits = count(==(target_peptide), precursors_table.sequence)
+                println("   [PeptideTracker] Processed precursors_table occurrences of $target_peptide: $peptide_hits")
+
                 # Convert types
                 precursors_table[!, :missed_cleavages] = UInt8.(precursors_table[!, :missed_cleavages])
                 precursors_table[!, :prec_charge] = UInt8.(precursors_table[!, :prec_charge])

--- a/src/Routines/BuildSpecLib/chronologer/chronologer_prep.jl
+++ b/src/Routines/BuildSpecLib/chronologer/chronologer_prep.jl
@@ -318,10 +318,30 @@ multiple modification variants.
 """
 function add_mods(
     fasta_peptides::Vector{FastaEntry},
-    fixed_mod_names::Vector{NamedTuple{(:p, :r), Tuple{Regex, String}}}, 
+    fixed_mod_names::Vector{NamedTuple{(:p, :r), Tuple{Regex, String}}},
     var_mod_names::Vector{NamedTuple{(:p, :r), Tuple{Regex, String}}},
     max_var_mods::Int)
 
+
+    target_peptide = "ENALDRAEQAEADK"
+
+    format_mods(mods::Vector{PeptideMod}) = isempty(mods) ? "<none>" :
+        join("$(getModName(m))@$(getPosition(m))$(getAA(m))" for m in mods, ", ")
+
+    function log_target_mods(stage::String; fixed_mods::Vector{PeptideMod}, var_sites::Vector{NamedTuple{(:regex_match, :name), Tuple{RegexMatch, String}}}, combination_idx::Union{Nothing, Int}=nothing, combination_total::Union{Nothing, Int}=nothing, applied_mods::Union{Nothing, Vector{PeptideMod}}=nothing)
+        println("[PeptideTracker] add_mods: $stage")
+        println("    Fixed mods: $(format_mods(fixed_mods))")
+        if !isnothing(combination_total)
+            println("    Variable mod combinations: $(combination_total)")
+        end
+        if !isempty(var_sites)
+            site_strings = join("$(match.regex_match.offset)$(match.regex_match.match)=>$(match.name)" for match in var_sites, "; ")
+            println("    Variable mod sites: $(site_strings)")
+        end
+        if !isnothing(combination_idx) && !isnothing(applied_mods)
+            println("    Emitting combination $(combination_idx)/$(combination_total): $(format_mods(applied_mods))")
+        end
+    end
 
     fasta_mods = Vector{FastaEntry}()
     # NOTE: base_pep_id will be preserved from original peptides (not made unique per modification)
@@ -340,18 +360,37 @@ function add_mods(
 
         #Get each instance of a variable mod
         var_mod_matches = matchVarMods(sequence, var_mod_names)
-        #Count number of unique variable mod combinations 
+        #Count number of unique variable mod combinations
         n_var_mod_combinations = countVarModCombinations(var_mod_matches, max_var_mods)
-        
+
+        if sequence == target_peptide
+            log_target_mods(
+                "target sequence identified",
+                fixed_mods = fixed_mods_vector,
+                var_sites = var_mod_matches,
+                combination_total = n_var_mod_combinations,
+            )
+        end
+
         var_mods = Vector{Vector{PeptideMod}}(undef, n_var_mod_combinations)
-        #Build modification strings for all combinations of variable mods 
+        #Build modification strings for all combinations of variable mods
         fillVarModStrings!(var_mods,
                             var_mod_matches,
                             fixed_mods_vector,
                             max_var_mods
                             )
 
-        for var_mod in var_mods
+        for (i, var_mod) in enumerate(var_mods)
+            if sequence == target_peptide
+                log_target_mods(
+                    "target variant generated",
+                    fixed_mods = fixed_mods_vector,
+                    var_sites = var_mod_matches,
+                    combination_idx = i,
+                    combination_total = n_var_mod_combinations,
+                    applied_mods = var_mod,
+                )
+            end
             # NOTE: Preserve original base_pep_id to maintain link with entrapment sequences
             push!(fasta_mods,
                 FastaEntry(

--- a/src/Routines/BuildSpecLib/chronologer/chronologer_prep.jl
+++ b/src/Routines/BuildSpecLib/chronologer/chronologer_prep.jl
@@ -86,6 +86,16 @@ function prepare_chronologer_input(
     chronologer_out_path::String,
     proteins_out_path::String)
 
+    target_peptide = "ENALDRAEQAEADK"
+
+    log_peptide_presence(stage::String, sequences::AbstractVector{<:AbstractString}) = begin
+        count_hits = count(==(target_peptide), sequences)
+        println("[PeptideTracker] $stage: $target_peptide occurrences = $count_hits")
+    end
+
+    log_peptide_presence(stage::String, entries::Vector{FastaEntry}) =
+        log_peptide_presence(stage, get_sequence.(entries))
+
     # Parse parameters into structured format
     _params = (
         fasta_digest_params = Dict{String, Any}(k => v for (k, v) in params["fasta_digest_params"]),
@@ -167,6 +177,8 @@ function prepare_chronologer_input(
         )
     end
 
+    log_peptide_presence("After digestion", fasta_entries)
+
     protein_df = build_protein_df(protein_entries)
     Arrow.write(proteins_out_path, protein_df)
 
@@ -176,13 +188,15 @@ function prepare_chronologer_input(
 
     # Step 1: Combine shared peptides (I/L equivalence)
     fasta_entries = combine_shared_peptides(fasta_entries)
-    
+
     # Step 2: Add modifications (creates peptide variants before entrapment)
     fasta_entries = add_mods(
-        fasta_entries, 
-        fixed_mods, 
+        fasta_entries,
+        fixed_mods,
         var_mods,
         _params.fasta_digest_params["max_var_mods"])
+
+    log_peptide_presence("After adding modifications", fasta_entries)
 
     # Step 3: Assign base_pep_id for peptide tracking (after modifications)
     pep_entries_processed = assign_base_pep_ids!(fasta_entries)
@@ -195,6 +209,8 @@ function prepare_chronologer_input(
         entrapment_method = entrapment_method
     )
 
+    log_peptide_presence("After entrapment sequence generation", fasta_entries)
+
     # Step 5: Assign base_target_id values for entrapment grouping
     assign_base_target_ids!(fasta_entries)
 
@@ -202,14 +218,17 @@ function prepare_chronologer_input(
     if _params.fasta_digest_params["add_decoys"]
         decoy_method = get(_params.fasta_digest_params, "decoy_method", "shuffle")
         fasta_entries = add_decoy_sequences_grouped(fasta_entries; decoy_method=decoy_method)
+        log_peptide_presence("After decoy generation", fasta_entries)
     end
-        
+
     # Step 7: Add charges (creates precursor variants)
     fasta_entries = add_charge(
         fasta_entries,
         _params.fasta_digest_params["min_charge"],
         _params.fasta_digest_params["max_charge"]
     )
+
+    log_peptide_presence("After charge state expansion", fasta_entries)
 
     # Build UniSpec input dataframe
     fasta_df = build_fasta_df(
@@ -238,6 +257,8 @@ function prepare_chronologer_input(
 
     # Filter by mass rang
     filter!(x -> (x.mz >= prec_mz_min) & (x.mz <= prec_mz_max), fasta_df)
+
+    log_peptide_presence("After m/z filtering", fasta_df[!, :sequence])
 
     # Apply charge-specific target-decoy pairing AFTER all filtering is complete
     # This ensures partner_precursor_idx values are valid row indices


### PR DESCRIPTION
## Summary
- add helper logging to track occurrences of peptide ENALDRAEQAEADK during digestion and precursor preparation
- report the same peptide count after processing the precursor table in the prediction workflow

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d8963fda88325a2ec0092d61f9063)