### PR TITLE
Add logging for duplicate fragment matches

### DIFF
--- a/src/Routines/SearchDIA/CommonSearchUtils/queryFragmentIndex.jl
+++ b/src/Routines/SearchDIA/CommonSearchUtils/queryFragmentIndex.jl
@@ -215,10 +215,10 @@ function searchFragmentBin!(prec_id_to_score::Counter{UInt32, UInt8},
         #range that matches the precursor tolerance. 
         if window_start === window_stop
             if (getPrecMZ(fragments[window_start])>window_max)
-                return nothing
+                return 0, 0
             end
             if getPrecMZ(fragments[window_stop])<window_min
-                return nothing
+                return 0, 0
             end
         end
     end
@@ -262,8 +262,6 @@ function queryFragment!(prec_id_to_score::Counter{UInt32, UInt8},
         frag_mz_max,
         UInt32(2048) #step size
     )
-    single_increment = 0
-    double_increment = 0
     #First frag_bin matching fragment tolerance
     frag_bin_idx = findFirstFragmentBin(
                                     frag_bins,
@@ -271,10 +269,12 @@ function queryFragment!(prec_id_to_score::Counter{UInt32, UInt8},
                                     upper_bound_guess,
                                     frag_mz_min
                                     )
-    @inbounds @fastmath begin 
+    single_increment = 0
+    double_increment = 0
+    @inbounds @fastmath begin
         #No fragment bins contain the fragment m/z
         if iszero(frag_bin_idx)
-            return lower_bound_guess, upper_bound_guess
+            return lower_bound_guess, upper_bound_guess, single_increment, double_increment
         end
 
         #Search subsequent frag bins until no more bins or untill a bin is outside the fragment tolerance

--- a/src/Routines/SearchDIA/CommonSearchUtils/queryFragmentIndex.jl
+++ b/src/Routines/SearchDIA/CommonSearchUtils/queryFragmentIndex.jl
@@ -155,11 +155,31 @@ Search a fragment bin for matches within precursor mass window.
 
 Updates prec_id_to_score in place with new matches.
 """
-function searchFragmentBin!(prec_id_to_score::Counter{UInt32, UInt8}, 
+function tally_fragment_matches!(fragment_match_counts::Dict{UInt32, UInt8},
+                                    matched_frag_range::UnitRange{UInt32})
+    single_increment = 0
+    double_increment = 0
+
+    @inbounds for frag_idx in matched_frag_range
+        prev_count = get(fragment_match_counts, frag_idx, zero(UInt8))
+        if iszero(prev_count)
+            single_increment += 1
+        elseif prev_count === one(UInt8)
+            single_increment -= 1
+            double_increment += 1
+        end
+        fragment_match_counts[frag_idx] = prev_count + one(UInt8)
+    end
+
+    return single_increment, double_increment
+end
+
+function searchFragmentBin!(prec_id_to_score::Counter{UInt32, UInt8},
                             fragments::AbstractArray{IndexFragment},
                             frag_id_range::UnitRange{UInt32},
-                            window_min::Float32, 
-                            window_max::Float32)
+                            window_min::Float32,
+                            window_max::Float32,
+                            fragment_match_counts::Dict{UInt32, UInt8})
 
     #Index of first and last fragments to search 
     lo, hi = first(frag_id_range), last(frag_id_range)
@@ -203,7 +223,7 @@ function searchFragmentBin!(prec_id_to_score::Counter{UInt32, UInt8},
         end
     end
         
-    function addFragmentMatches!(prec_id_to_score::Counter{UInt32, UInt8}, 
+    function addFragmentMatches!(prec_id_to_score::Counter{UInt32, UInt8},
                                     fragments::AbstractArray{IndexFragment},
                                     matched_frag_range::UnitRange{UInt32})
         @inline @inbounds for i in matched_frag_range
@@ -212,24 +232,27 @@ function searchFragmentBin!(prec_id_to_score::Counter{UInt32, UInt8},
         end
     end
     
-    #For each fragment matching the query, 
-    #award its score to its parent ion. 
-    @inline addFragmentMatches!(prec_id_to_score, fragments, window_start:window_stop)
-    return nothing
+    #For each fragment matching the query,
+    #award its score to its parent ion.
+    matched_frag_range = window_start:window_stop
+    single_increment, double_increment = tally_fragment_matches!(fragment_match_counts, matched_frag_range)
+    @inline addFragmentMatches!(prec_id_to_score, fragments, matched_frag_range)
+    return single_increment, double_increment
 
 end
 
-function queryFragment!(prec_id_to_score::Counter{UInt32, UInt8}, 
+function queryFragment!(prec_id_to_score::Counter{UInt32, UInt8},
                         frag_bin_max_idx::UInt32,
                         lower_bound_guess::UInt32,
                         upper_bound_guess::UInt32,
                         frag_bins::AbstractArray{FragIndexBin},
                         fragments::AbstractArray{IndexFragment},
-                        frag_mz_min::Float32, 
-                        frag_mz_max::Float32, 
+                        frag_mz_min::Float32,
+                        frag_mz_max::Float32,
                         prec_mz_min::Float32,
-                        prec_mz_max::Float32)# where {T,U<:AbstractFloat}
-    #Get new lower and upper bounds for the fragment bin search if necessary 
+                        prec_mz_max::Float32,
+                        fragment_match_counts::Dict{UInt32, UInt8})# where {T,U<:AbstractFloat}
+    #Get new lower and upper bounds for the fragment bin search if necessary
     lower_bound_guess, upper_bound_guess = exponentialFragmentBinSearch(
         frag_bins,
         frag_bin_max_idx,
@@ -239,9 +262,11 @@ function queryFragment!(prec_id_to_score::Counter{UInt32, UInt8},
         frag_mz_max,
         UInt32(2048) #step size
     )
+    single_increment = 0
+    double_increment = 0
     #First frag_bin matching fragment tolerance
     frag_bin_idx = findFirstFragmentBin(
-                                    frag_bins, 
+                                    frag_bins,
                                     lower_bound_guess,
                                     upper_bound_guess,
                                     frag_mz_min
@@ -266,26 +291,29 @@ function queryFragment!(prec_id_to_score::Counter{UInt32, UInt8},
                         break
                     end
                 end
-                #Range of fragment ions that could match the observed fragment tolerance 
+                #Range of fragment ions that could match the observed fragment tolerance
                 frag_id_range = getSubBinRange(frag_bin)
                 #Search the fragment range for fragments with precursors in the precursor tolerance
-                searchFragmentBin!(prec_id_to_score, 
-                                    fragments,
-                                    frag_id_range, 
-                                    prec_mz_min, 
-                                    prec_mz_max
-                                )
-                #Advance to the next fragment bin 
+                frag_single_increment, frag_double_increment = searchFragmentBin!(prec_id_to_score,
+                                                                                    fragments,
+                                                                                    frag_id_range,
+                                                                                    prec_mz_min,
+                                                                                    prec_mz_max,
+                                                                                    fragment_match_counts
+                                                                                )
+                single_increment += frag_single_increment
+                double_increment += frag_double_increment
+                #Advance to the next fragment bin
                 frag_bin_idx += 1
             end
         end
     end
 
     #Only reach this point if frag_bin exceeds length(frag_index)
-    return lower_bound_guess, upper_bound_guess
+    return lower_bound_guess, upper_bound_guess, single_increment, double_increment
 end
 
-function searchScan!(prec_id_to_score::Counter{UInt32, UInt8}, 
+function searchScan!(prec_id_to_score::Counter{UInt32, UInt8},
                     rt_bins::AbstractArray{FragIndexBin},
                     frag_bins::AbstractArray{FragIndexBin},
                     fragments::AbstractArray{IndexFragment},
@@ -300,6 +328,10 @@ function searchScan!(prec_id_to_score::Counter{UInt32, UInt8},
     prec_min = U(getPrecMinBound(quad_transmission_func) - NEUTRON*first(isotope_err_bounds)/2)
     prec_max = U(getPrecMaxBound(quad_transmission_func) + NEUTRON*last(isotope_err_bounds)/2)
 
+    fragment_match_counts = Dict{UInt32, UInt8}()
+    single_match_count = 0
+    double_match_count = 0
+
     #@inbounds @fastmath while getLow(rt_bins[rt_bin_idx]) < irt_high
     while getLow(rt_bins[rt_bin_idx]) < irt_high
         #BinRanges
@@ -313,17 +345,20 @@ function searchScan!(prec_id_to_score::Counter{UInt32, UInt8},
             frag_min, frag_max = getMzBoundsReverse(mass_err_model, corrected_mz)
             #For every precursor that could have produced the observed ion
             #award to it the corresponding score
-            lower_bound_guess, upper_bound_guess = queryFragment!(prec_id_to_score, 
-                                            max_frag_bin,
-                                            lower_bound_guess,
-                                            upper_bound_guess,
-                                            frag_bins,
-                                            fragments,
-                                            frag_min, 
-                                            frag_max, 
-                                            prec_min, 
-                                            prec_max
-                                        )
+            lower_bound_guess, upper_bound_guess, single_increment, double_increment = queryFragment!(prec_id_to_score,
+                                                                                            max_frag_bin,
+                                                                                            lower_bound_guess,
+                                                                                            upper_bound_guess,
+                                                                                            frag_bins,
+                                                                                            fragments,
+                                                                                            frag_min,
+                                                                                            frag_max,
+                                                                                            prec_min,
+                                                                                            prec_max,
+                                                                                            fragment_match_counts
+                                                                                        )
+            single_match_count += single_increment
+            double_match_count += double_increment
         end
 
         rt_bin_idx += 1
@@ -333,7 +368,7 @@ function searchScan!(prec_id_to_score::Counter{UInt32, UInt8},
         end 
     end
 
-    return nothing#filterPrecursorMatches!(prec_id_to_score, min_score)
+    return single_match_count, double_match_count#filterPrecursorMatches!(prec_id_to_score, min_score)
 end
 
 function filterPrecursorMatches!(prec_id_to_score::Counter{UInt32, UInt8}, min_score::UInt8)

--- a/src/Routines/SearchDIA/LibrarySearch.jl
+++ b/src/Routines/SearchDIA/LibrarySearch.jl
@@ -31,6 +31,8 @@ function searchFragmentIndex(
     prec_id = 0
     precursors_passed_scoring = Vector{UInt32}(undef, 250000)
     rt_bin_idx = 1
+    single_match_count = 0
+    double_match_count = 0
     for scan_idx in thread_task
         #if scan_idx % 50 != 0
         #    continue
@@ -47,9 +49,9 @@ function searchFragmentIndex(
         while rt_bin_idx > 1 && getLow(getRTBin(frag_index, rt_bin_idx)) > irt_lo
             rt_bin_idx -= 1
         end
-        
+
         # Fragment index search for matching precursors
-        searchScan!(
+        single_increment, double_increment = searchScan!(
             getPrecursorScores(search_data),
             getRTBins(frag_index),
             getFragBins(frag_index),
@@ -62,6 +64,8 @@ function searchFragmentIndex(
             getQuadTransmissionFunction(qtm, getCenterMz(spectra, scan_idx), getIsolationWidthMz(spectra, scan_idx)),
             getIsotopeErrBounds(params)
         )
+        single_match_count += single_increment
+        double_match_count += double_increment
 
         # Filter precursor matches based on score
         match_count, prec_count = filterPrecursorMatches!(getPrecursorScores(search_data), getMinIndexSearchScore(params))
@@ -87,7 +91,11 @@ function searchFragmentIndex(
         reset!(getPrecursorScores(search_data))
     end
 
-    return precursors_passed_scoring[1:prec_id]
+    return (
+        precursors = precursors_passed_scoring[1:prec_id],
+        single_match_count = single_match_count,
+        double_match_count = double_match_count
+    )
 end
 
 function getPSMS(
@@ -301,7 +309,19 @@ function LibrarySearch(
         end
     end
     
-    precursors_passed_scoring = fetch.(tasks)
+    fragment_search_results = fetch.(tasks)
+    precursors_passed_scoring = Vector{Vector{UInt32}}(undef, length(search_data))
+    single_match_count = 0
+    double_match_count = 0
+
+    for (result, thread_task) in zip(fragment_search_results, thread_tasks)
+        thread_id = first(thread_task)
+        precursors_passed_scoring[thread_id] = result.precursors
+        single_match_count += result.single_match_count
+        double_match_count += result.double_match_count
+    end
+
+    @info "Fragment match tally after first-pass search" ms_file_idx single_match_count double_match_count
 
     tasks = map(thread_tasks) do thread_task
         Threads.@spawn begin 
@@ -385,7 +405,19 @@ function LibrarySearchNceTuning(
         end
     end
 
-    precursors_passed_scoring = fetch.(tasks)
+    fragment_search_results = fetch.(tasks)
+    precursors_passed_scoring = Vector{Vector{UInt32}}(undef, length(search_data))
+    single_match_count = 0
+    double_match_count = 0
+
+    for (result, thread_task) in zip(fragment_search_results, thread_tasks)
+        thread_id = first(thread_task)
+        precursors_passed_scoring[thread_id] = result.precursors
+        single_match_count += result.single_match_count
+        double_match_count += result.double_match_count
+    end
+
+    @info "Fragment match tally after first-pass search" ms_file_idx single_match_count double_match_count
 
     # For each NCE value, run getPSMS using the same fragment index results
     all_results = map(nce_grid) do nce


### PR DESCRIPTION
## Summary
- track fragment match counts during queryFragmentIndex searches to detect duplicate fragment contributions per scan
- aggregate duplicate and single fragment match counts across threads and log totals after the first-pass search for each file

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ed4a9f3d08325ad5065b6d206f29d)