### PR TITLE
Smooth and convert aggregated fragment scores for filtering

### DIFF
--- a/src/Routines/SearchDIA/CommonSearchUtils/queryFragmentIndex.jl
+++ b/src/Routines/SearchDIA/CommonSearchUtils/queryFragmentIndex.jl
@@ -203,12 +203,12 @@ function searchFragmentBin!(prec_id_to_score::Counter{UInt32, UInt8},
         end
     end
         
-    function addFragmentMatches!(prec_id_to_score::Counter{UInt32, UInt8}, 
+    function addFragmentMatches!(prec_id_to_score::Counter{UInt32, UInt8},
                                     fragments::AbstractArray{IndexFragment},
                                     matched_frag_range::UnitRange{UInt32})
         @inline @inbounds for i in matched_frag_range
             frag = fragments[i]
-            inc!(prec_id_to_score, getPrecID(frag), getScore(frag))
+            or_inc!(prec_id_to_score, getPrecID(frag), getScore(frag))
         end
     end
     

--- a/src/Routines/SearchDIA/CommonSearchUtils/queryFragmentIndex.jl
+++ b/src/Routines/SearchDIA/CommonSearchUtils/queryFragmentIndex.jl
@@ -336,9 +336,12 @@ function searchScan!(prec_id_to_score::Counter{UInt32, UInt8},
     return nothing#filterPrecursorMatches!(prec_id_to_score, min_score)
 end
 
-function filterPrecursorMatches!(prec_id_to_score::Counter{UInt32, UInt8}, min_score::UInt8)
-    match_count = countFragMatches(prec_id_to_score, min_score)
-    prec_count = getSize(prec_id_to_score) - 1
-    sortCounter!(prec_id_to_score);
+function filterPrecursorMatches!(smoothed_scores::Counter{UInt32, UInt8},
+                                 current_scores::Counter{UInt32, UInt8},
+                                 min_score::UInt8)
+    current_min_score = min_score <= one(UInt8) ? zero(UInt8) : min_score - one(UInt8)
+    match_count = countFragMatches(smoothed_scores, min_score, current_scores, current_min_score)
+    prec_count = getSize(smoothed_scores) - 1
+    sortCounter!(smoothed_scores);
     return match_count, prec_count
 end

--- a/src/Routines/SearchDIA/LibrarySearch.jl
+++ b/src/Routines/SearchDIA/LibrarySearch.jl
@@ -31,60 +31,127 @@ function searchFragmentIndex(
     prec_id = 0
     precursors_passed_scoring = Vector{UInt32}(undef, 250000)
     rt_bin_idx = 1
-    for scan_idx in thread_task
-        #if scan_idx % 50 != 0
-        #    continue
-        #end
-        # Skip invalid indices
-        (scan_idx <= 0 || scan_idx > length(spectra)) && continue
-        getMsOrder(spectra, scan_idx) ∉ getSpecOrder(params) && continue
+    counter_pool = (
+        getPrecursorScores(search_data),
+        Counter(UInt32, UInt8, length(getPrecursorScores(search_data).counts)),
+        Counter(UInt32, UInt8, length(getPrecursorScores(search_data).counts)),
+    )
+    smoothed_scores = Counter(UInt32, UInt8, length(getPrecursorScores(search_data).counts))
+    counter_index = Ref(1)
 
-        # Update RT bin index based on iRT window
-        irt_lo, irt_hi = getRTWindow(rt_to_irt_spline(getRetentionTime(spectra, scan_idx)), irt_tol)
-        while rt_bin_idx < length(getRTBins(frag_index)) && getHigh(getRTBin(frag_index, rt_bin_idx)) < irt_lo
-            rt_bin_idx += 1
+    function next_counter()
+        counter_index[] = counter_index[] % length(counter_pool) + 1
+        return counter_pool[counter_index[]]
+    end
+
+    function get_available_counter(prev_counter, curr_counter)
+        available = next_counter()
+        while available === prev_counter || available === curr_counter
+            available = next_counter()
         end
-        while rt_bin_idx > 1 && getLow(getRTBin(frag_index, rt_bin_idx)) > irt_lo
-            rt_bin_idx -= 1
+        return available
+    end
+
+    task_pos = Ref(1)
+    rt_bin_idx_ref = Ref(rt_bin_idx)
+
+    function next_valid_scan!(counter)
+        while task_pos[] <= length(thread_task)
+            scan_idx = thread_task[task_pos[]]
+            task_pos[] += 1
+
+            (scan_idx <= 0 || scan_idx > length(spectra)) && continue
+            getMsOrder(spectra, scan_idx) ∉ getSpecOrder(params) && continue
+
+            irt_lo, irt_hi = getRTWindow(rt_to_irt_spline(getRetentionTime(spectra, scan_idx)), irt_tol)
+            while rt_bin_idx_ref[] < length(getRTBins(frag_index)) && getHigh(getRTBin(frag_index, rt_bin_idx_ref[])) < irt_lo
+                rt_bin_idx_ref[] += 1
+            end
+            while rt_bin_idx_ref[] > 1 && getLow(getRTBin(frag_index, rt_bin_idx_ref[])) > irt_lo
+                rt_bin_idx_ref[] -= 1
+            end
+
+            reset!(counter)
+            searchScan!(
+                counter,
+                getRTBins(frag_index),
+                getFragBins(frag_index),
+                getFragments(frag_index),
+                getMzArray(spectra, scan_idx),
+                getIntensityArray(spectra, scan_idx),
+                rt_bin_idx_ref[],
+                irt_hi,
+                mem,
+                getQuadTransmissionFunction(qtm, getCenterMz(spectra, scan_idx), getIsolationWidthMz(spectra, scan_idx)),
+                getIsotopeErrBounds(params)
+            )
+
+            return (scan_idx, (getCenterMz(spectra, scan_idx), getIsolationWidthMz(spectra, scan_idx)))
         end
-        
-        # Fragment index search for matching precursors
-        searchScan!(
-            getPrecursorScores(search_data),
-            getRTBins(frag_index),
-            getFragBins(frag_index),
-            getFragments(frag_index),
-            getMzArray(spectra, scan_idx),
-            getIntensityArray(spectra, scan_idx),
-            rt_bin_idx,
-            irt_hi,
-            mem,
-            getQuadTransmissionFunction(qtm, getCenterMz(spectra, scan_idx), getIsolationWidthMz(spectra, scan_idx)),
-            getIsotopeErrBounds(params)
-        )
 
-        # Filter precursor matches based on score
-        match_count, prec_count = filterPrecursorMatches!(getPrecursorScores(search_data), getMinIndexSearchScore(params))
+        return nothing
+    end
 
-        if getID(getPrecursorScores(search_data), 1)>0
+    function smooth_scores!(dest, curr_counter, curr_iso, prev_counter, prev_iso, next_counter, next_iso)
+        reset!(dest)
+        if prev_iso !== nothing && prev_iso == curr_iso
+            or_merge!(dest, prev_counter)
+        end
+        or_merge!(dest, curr_counter)
+        if next_iso !== nothing && next_iso == curr_iso
+            or_merge!(dest, next_counter)
+        end
+        return nothing
+    end
+
+    prev_info = nothing
+    curr_counter = counter_pool[1]
+    curr_info = next_valid_scan!(curr_counter)
+    curr_info === nothing && return precursors_passed_scoring[1:prec_id]
+    next_counter_ref = get_available_counter(nothing, curr_counter)
+    next_info = next_valid_scan!(next_counter_ref)
+    next_counter = next_counter_ref
+
+    prev_counter = counter_pool[3]
+    while curr_info !== nothing
+        curr_scan_idx, curr_iso = curr_info
+        prev_iso = prev_info === nothing ? nothing : last(prev_info)
+        next_iso = next_info === nothing ? nothing : last(next_info)
+
+        smooth_scores!(smoothed_scores, curr_counter, curr_iso, prev_counter, prev_iso, next_counter, next_iso)
+
+        match_count, prec_count = filterPrecursorMatches!(smoothed_scores, getMinIndexSearchScore(params))
+
+        if getID(smoothed_scores, 1) > 0
             start_idx = prec_id + 1
             n = 1
-            while n <= getPrecursorScores(search_data).matches
+            while n <= smoothed_scores.matches
                 prec_id += 1
                 if prec_id > length(precursors_passed_scoring)
-                    append!(precursors_passed_scoring, 
+                    append!(precursors_passed_scoring,
                             Vector{eltype(precursors_passed_scoring)}(undef, length(precursors_passed_scoring))
                             )
                 end
-                precursors_passed_scoring[prec_id] = getID(getPrecursorScores(search_data), n)
+                precursors_passed_scoring[prec_id] = getID(smoothed_scores, n)
                 n += 1
             end
-            scan_to_prec_idx[scan_idx] = start_idx:prec_id#stop_idx
+            scan_to_prec_idx[curr_scan_idx] = start_idx:prec_id#stop_idx
         else
-            scan_to_prec_idx[scan_idx] = missing
+            scan_to_prec_idx[curr_scan_idx] = missing
         end
 
-        reset!(getPrecursorScores(search_data))
+        reset!(smoothed_scores)
+
+        prev_info = curr_info
+        prev_counter = curr_counter
+        curr_info = next_info
+        curr_counter = next_counter
+
+        curr_info === nothing && break
+
+        next_counter_candidate = get_available_counter(prev_counter, curr_counter)
+        next_info = next_valid_scan!(next_counter_candidate)
+        next_counter = next_counter_candidate
     end
 
     return precursors_passed_scoring[1:prec_id]

--- a/src/Routines/SearchDIA/LibrarySearch.jl
+++ b/src/Routines/SearchDIA/LibrarySearch.jl
@@ -120,7 +120,11 @@ function searchFragmentIndex(
 
         smooth_scores!(smoothed_scores, curr_counter, curr_iso, prev_counter, prev_iso, next_counter, next_iso)
 
-        match_count, prec_count = filterPrecursorMatches!(smoothed_scores, getMinIndexSearchScore(params))
+        match_count, prec_count = filterPrecursorMatches!(
+            smoothed_scores,
+            curr_counter,
+            getMinIndexSearchScore(params),
+        )
 
         if getID(smoothed_scores, 1) > 0
             start_idx = prec_id + 1

--- a/src/structs/Counter.jl
+++ b/src/structs/Counter.jl
@@ -51,14 +51,43 @@ function inc!(c::Counter{I,C}, id::I, pred_intensity::C) where {I,C<:Unsigned}
     return nothing
 end
 =#
-function inc!(c::Counter{I,C}, id::I, pred_intensity::C) where {I,C<:Unsigned} 
-    @inbounds @fastmath begin 
+function inc!(c::Counter{I,C}, id::I, pred_intensity::C) where {I,C<:Unsigned}
+    @inbounds @fastmath begin
         no_previous_encounter = c.counts[id]===zero(C)
         c.ids[c.size] = id
         c.size += no_previous_encounter
         c.counts[id] += pred_intensity;
     end
     return nothing
+end
+
+function or_inc!(c::Counter{I,C}, id::I, frag_score::C) where {I,C<:Unsigned}
+    @inbounds @fastmath begin
+        prev_score = c.counts[id]
+        no_previous_encounter = prev_score === zero(C)
+        c.ids[c.size] = id
+        c.size += no_previous_encounter
+        c.counts[id] = prev_score | frag_score
+    end
+    return nothing
+end
+
+function or_merge!(dest::Counter{I,C}, source::Counter{I,C}) where {I,C<:Unsigned}
+    @inbounds @fastmath for i in 1:(getSize(source) - 1)
+        id = source.ids[i]
+        or_inc!(dest, id, source.counts[id])
+    end
+    return nothing
+end
+
+const FRAG_SCORE_WEIGHTS = UInt8[1, 1, 2, 2, 4, 4, 8]
+
+@inline function convert_frag_score(score::C) where {C<:Unsigned}
+    weighted_score = zero(C)
+    @inbounds @fastmath for (idx, weight) in pairs(FRAG_SCORE_WEIGHTS)
+        weighted_score += ((score >> (idx - 1)) & one(C)) * weight
+    end
+    return weighted_score
 end
 
 import Base.sort!
@@ -85,11 +114,12 @@ end
 function countFragMatches(c::Counter{I,C}, min_count::C) where {I,C<:Unsigned}
     @inbounds for i in 1:(getSize(c) - 1)
         id = c.ids[i]
-        if getCount(c, id)>=min_count
+        weighted_score = convert_frag_score(getCount(c, id))
+        if weighted_score >= min_count
                 c.ids[c.matches + 1] = c.ids[i]
                 c.matches += 1
         end
-        c.counts[id] = zero(Float32);
+        c.counts[id] = zero(C);
     end
     return 0#c.matches
 end

--- a/src/structs/Counter.jl
+++ b/src/structs/Counter.jl
@@ -112,14 +112,35 @@ function reset!(c::Counter{I,C}) where {I,C<:Unsigned}
 end
 
 function countFragMatches(c::Counter{I,C}, min_count::C) where {I,C<:Unsigned}
+    c.matches = 0
     @inbounds for i in 1:(getSize(c) - 1)
         id = c.ids[i]
         weighted_score = convert_frag_score(getCount(c, id))
         if weighted_score >= min_count
-                c.ids[c.matches + 1] = c.ids[i]
-                c.matches += 1
+            c.ids[c.matches + 1] = c.ids[i]
+            c.matches += 1
         end
-        c.counts[id] = zero(C);
     end
     return 0#c.matches
+end
+
+function countFragMatches(
+    smoothed::Counter{I,C},
+    smoothed_min::C,
+    current::Counter{I,C},
+    current_min::C,
+)
+    smoothed.matches = 0
+    @inbounds for i in 1:(getSize(smoothed) - 1)
+        id = smoothed.ids[i]
+        smoothed_score = convert_frag_score(getCount(smoothed, id))
+        if smoothed_score >= smoothed_min
+            current_score = convert_frag_score(getCount(current, id))
+            if current_score >= current_min
+                smoothed.ids[smoothed.matches + 1] = id
+                smoothed.matches += 1
+            end
+        end
+    end
+    return 0
 end


### PR DESCRIPTION
## Summary
- add a converter to translate bitwise fragment scores into weighted totals
- apply the weighted conversion when filtering precursor matches and clear counters with the correct type
- smooth fragment evidence by OR-combining neighboring scans from the same isolation window before scoring filters

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f03d2e6b48325a71629697b04e31d)