### PR TITLE
Smooth fragment scores across neighboring scans

### DIFF
--- a/src/Routines/SearchDIA/CommonSearchUtils/queryFragmentIndex.jl
+++ b/src/Routines/SearchDIA/CommonSearchUtils/queryFragmentIndex.jl
@@ -203,12 +203,12 @@ function searchFragmentBin!(prec_id_to_score::Counter{UInt32, UInt8},
         end
     end
         
-    function addFragmentMatches!(prec_id_to_score::Counter{UInt32, UInt8}, 
+    function addFragmentMatches!(prec_id_to_score::Counter{UInt32, UInt8},
                                     fragments::AbstractArray{IndexFragment},
                                     matched_frag_range::UnitRange{UInt32})
         @inline @inbounds for i in matched_frag_range
             frag = fragments[i]
-            inc!(prec_id_to_score, getPrecID(frag), getScore(frag))
+            or_inc!(prec_id_to_score, getPrecID(frag), getScore(frag))
         end
     end
     

--- a/src/Routines/SearchDIA/LibrarySearch.jl
+++ b/src/Routines/SearchDIA/LibrarySearch.jl
@@ -31,13 +31,89 @@ function searchFragmentIndex(
     prec_id = 0
     precursors_passed_scoring = Vector{UInt32}(undef, 250000)
     rt_bin_idx = 1
+
+    base_counter = getPrecursorScores(search_data)
+    counter_size = length(base_counter.counts)
+    raw_counters = Counter{UInt32, UInt8}[base_counter, Counter(UInt32, UInt8, counter_size), Counter(UInt32, UInt8, counter_size)]
+    free_counters = Counter{UInt32, UInt8}[raw_counters...]
+    smoothed_counter = Counter(UInt32, UInt8, counter_size)
+
+    acquire_counter!() = pop!(free_counters)
+
+    function release_counter!(counter::Counter{UInt32, UInt8})
+        reset!(counter)
+        push!(free_counters, counter)
+        return nothing
+    end
+
+    @inline function normalize_float(val)
+        return ismissing(val) ? val : Float32(val)
+    end
+
+    @inline function same_isolation_window(center_a, width_a, center_b, width_b)
+        return !(ismissing(center_a) || ismissing(width_a) || ismissing(center_b) || ismissing(width_b)) &&
+               center_a == center_b && width_a == width_b
+    end
+
+    function add_scores!(dest::Counter{UInt32, UInt8}, source::Counter{UInt32, UInt8})
+        @inbounds @fastmath for i in 1:(getSize(source) - 1)
+            id = getID(source, i)
+            or_inc!(dest, id, getCount(source, id))
+        end
+        return nothing
+    end
+
+    function smooth_scores!(dest::Counter{UInt32, UInt8}, target, left, right)
+        reset!(dest)
+        if left !== nothing && same_isolation_window(target.center_mz, target.isolation_width, left.center_mz, left.isolation_width)
+            add_scores!(dest, left.counter)
+        end
+        add_scores!(dest, target.counter)
+        if right !== nothing && same_isolation_window(target.center_mz, target.isolation_width, right.center_mz, right.isolation_width)
+            add_scores!(dest, right.counter)
+        end
+        return nothing
+    end
+
+    function record_matches!(counter::Counter{UInt32, UInt8}, scan_idx::Int64)
+        if getID(counter, 1) > 0
+            start_idx = prec_id + 1
+            n = 1
+            while n <= counter.matches
+                prec_id += 1
+                if prec_id > length(precursors_passed_scoring)
+                    append!(precursors_passed_scoring,
+                            Vector{eltype(precursors_passed_scoring)}(undef, length(precursors_passed_scoring))
+                            )
+                end
+                precursors_passed_scoring[prec_id] = getID(counter, n)
+                n += 1
+            end
+            scan_to_prec_idx[scan_idx] = start_idx:prec_id#stop_idx
+        else
+            scan_to_prec_idx[scan_idx] = missing
+        end
+        return nothing
+    end
+
+    function finalize_scan!(target, left, right)
+        smooth_scores!(smoothed_counter, target, left, right)
+        filterPrecursorMatches!(smoothed_counter, getMinIndexSearchScore(params))
+        record_matches!(smoothed_counter, target.scan_idx)
+        return nothing
+    end
+
+    prev_scan = nothing
+    curr_scan = nothing
+
     for scan_idx in thread_task
-        #if scan_idx % 50 != 0
-        #    continue
-        #end
-        # Skip invalid indices
         (scan_idx <= 0 || scan_idx > length(spectra)) && continue
         getMsOrder(spectra, scan_idx) ∉ getSpecOrder(params) && continue
+
+        raw_counter = acquire_counter!()
+
+        center_mz = normalize_float(getCenterMz(spectra, scan_idx))
+        isolation_width = normalize_float(getIsolationWidthMz(spectra, scan_idx))
 
         # Update RT bin index based on iRT window
         irt_lo, irt_hi = getRTWindow(rt_to_irt_spline(getRetentionTime(spectra, scan_idx)), irt_tol)
@@ -47,10 +123,10 @@ function searchFragmentIndex(
         while rt_bin_idx > 1 && getLow(getRTBin(frag_index, rt_bin_idx)) > irt_lo
             rt_bin_idx -= 1
         end
-        
+
         # Fragment index search for matching precursors
         searchScan!(
-            getPrecursorScores(search_data),
+            raw_counter,
             getRTBins(frag_index),
             getFragBins(frag_index),
             getFragments(frag_index),
@@ -59,32 +135,34 @@ function searchFragmentIndex(
             rt_bin_idx,
             irt_hi,
             mem,
-            getQuadTransmissionFunction(qtm, getCenterMz(spectra, scan_idx), getIsolationWidthMz(spectra, scan_idx)),
+            getQuadTransmissionFunction(qtm, center_mz, isolation_width),
             getIsotopeErrBounds(params)
         )
 
-        # Filter precursor matches based on score
-        match_count, prec_count = filterPrecursorMatches!(getPrecursorScores(search_data), getMinIndexSearchScore(params))
+        new_scan = (;
+            counter = raw_counter,
+            center_mz = center_mz,
+            isolation_width = isolation_width,
+            scan_idx = scan_idx,
+        )
 
-        if getID(getPrecursorScores(search_data), 1)>0
-            start_idx = prec_id + 1
-            n = 1
-            while n <= getPrecursorScores(search_data).matches
-                prec_id += 1
-                if prec_id > length(precursors_passed_scoring)
-                    append!(precursors_passed_scoring, 
-                            Vector{eltype(precursors_passed_scoring)}(undef, length(precursors_passed_scoring))
-                            )
-                end
-                precursors_passed_scoring[prec_id] = getID(getPrecursorScores(search_data), n)
-                n += 1
+        if curr_scan !== nothing
+            finalize_scan!(curr_scan, prev_scan, new_scan)
+            if prev_scan !== nothing
+                release_counter!(prev_scan.counter)
             end
-            scan_to_prec_idx[scan_idx] = start_idx:prec_id#stop_idx
-        else
-            scan_to_prec_idx[scan_idx] = missing
         end
 
-        reset!(getPrecursorScores(search_data))
+        prev_scan = curr_scan
+        curr_scan = new_scan
+    end
+
+    if curr_scan !== nothing
+        finalize_scan!(curr_scan, prev_scan, nothing)
+        if prev_scan !== nothing
+            release_counter!(prev_scan.counter)
+        end
+        release_counter!(curr_scan.counter)
     end
 
     return precursors_passed_scoring[1:prec_id]

--- a/src/structs/Counter.jl
+++ b/src/structs/Counter.jl
@@ -36,7 +36,7 @@ function update!(c::Counter{I,C}, id::I, pred_intensity::C) where {I,C<:Unsigned
 end
 
 function reset!(c::Counter{I,C}, id::I) where {I,C<:Unsigned}
-    c.counts[id] = zero(T);
+    c.counts[id] = zero(C);
     return nothing
 end
 #=
@@ -51,14 +51,35 @@ function inc!(c::Counter{I,C}, id::I, pred_intensity::C) where {I,C<:Unsigned}
     return nothing
 end
 =#
-function inc!(c::Counter{I,C}, id::I, pred_intensity::C) where {I,C<:Unsigned} 
-    @inbounds @fastmath begin 
+function inc!(c::Counter{I,C}, id::I, pred_intensity::C) where {I,C<:Unsigned}
+    @inbounds @fastmath begin
         no_previous_encounter = c.counts[id]===zero(C)
         c.ids[c.size] = id
         c.size += no_previous_encounter
         c.counts[id] += pred_intensity;
     end
     return nothing
+end
+
+function or_inc!(c::Counter{I,C}, id::I, frag_score::C) where {I,C<:Unsigned}
+    @inbounds @fastmath begin
+        prev_score = c.counts[id]
+        no_previous_encounter = prev_score === zero(C)
+        c.ids[c.size] = id
+        c.size += no_previous_encounter
+        c.counts[id] = prev_score | frag_score
+    end
+    return nothing
+end
+
+const FRAG_SCORE_WEIGHTS = UInt8[1, 1, 2, 2, 4, 4, 8]
+
+@inline function convert_frag_score(score::C) where {C<:Unsigned}
+    weighted_score = zero(C)
+    @inbounds @fastmath for (idx, weight) in pairs(FRAG_SCORE_WEIGHTS)
+        weighted_score += ((score >> (idx - 1)) & one(C)) * weight
+    end
+    return weighted_score
 end
 
 import Base.sort!
@@ -75,7 +96,7 @@ end
 function reset!(c::Counter{I,C}) where {I,C<:Unsigned}
     #for i in 1:(getSize(c) - 1)
     @turbo for i in 1:(getSize(c) - 1)
-        c.counts[c.ids[i]] = zero(T);
+        c.counts[c.ids[i]] = zero(C);
         c.ids[i] = zero(I)
     end
     c.size, c.matches = 1, 0
@@ -85,11 +106,12 @@ end
 function countFragMatches(c::Counter{I,C}, min_count::C) where {I,C<:Unsigned}
     @inbounds for i in 1:(getSize(c) - 1)
         id = c.ids[i]
-        if getCount(c, id)>=min_count
+        weighted_score = convert_frag_score(getCount(c, id))
+        if weighted_score >= min_count
                 c.ids[c.matches + 1] = c.ids[i]
                 c.matches += 1
         end
-        c.counts[id] = zero(Float32);
+        c.counts[id] = zero(C);
     end
     return 0#c.matches
 end


### PR DESCRIPTION
## Summary
- reuse a pool of counters to retain raw fragment bitmasks across scans and smooth scores with neighboring scans sharing an isolation window
- apply weighted filtering on the smoothed fragment masks when recording precursor matches per scan
- correct counter reset logic to zero values using the counter element type

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f03d2e6b48325a71629697b04e31d)