### PR TITLE
Add local scan filtering to fragment index search

### DIFF
--- a/src/Routines/SearchDIA/CommonSearchUtils/queryFragmentIndex.jl
+++ b/src/Routines/SearchDIA/CommonSearchUtils/queryFragmentIndex.jl
@@ -336,9 +336,34 @@ function searchScan!(prec_id_to_score::Counter{UInt32, UInt8},
     return nothing#filterPrecursorMatches!(prec_id_to_score, min_score)
 end
 
-function filterPrecursorMatches!(prec_id_to_score::Counter{UInt32, UInt8}, min_score::UInt8)
+function filterPrecursorMatches!(prec_id_to_score::Counter{I, C}, min_score::C) where {I, C<:Unsigned}
     match_count = countFragMatches(prec_id_to_score, min_score)
     prec_count = getSize(prec_id_to_score) - 1
-    sortCounter!(prec_id_to_score);
+    sortCounter!(prec_id_to_score)
+    return match_count, prec_count
+end
+
+function filterPrecursorMatches!(smoothed_scores::Counter{I, C},
+                                 local_scores::Counter{I, C},
+                                 min_smoothed_score::C,
+                                 min_local_score::C) where {I, C<:Unsigned}
+    prec_count = getSize(smoothed_scores) - 1
+    match_count = 0
+
+    @inbounds @fastmath for idx in 1:prec_count
+        id = getID(smoothed_scores, idx)
+        smoothed_weighted = convert_frag_score(getCount(smoothed_scores, id))
+        local_weighted = convert_frag_score(getCount(local_scores, id))
+
+        if smoothed_weighted >= min_smoothed_score && local_weighted >= min_local_score
+            match_count += 1
+            smoothed_scores.ids[match_count] = id
+        end
+
+        smoothed_scores.counts[id] = zero(C)
+    end
+
+    smoothed_scores.matches = match_count
+    sortCounter!(smoothed_scores)
     return match_count, prec_count
 end

--- a/src/Routines/SearchDIA/LibrarySearch.jl
+++ b/src/Routines/SearchDIA/LibrarySearch.jl
@@ -38,6 +38,13 @@ function searchFragmentIndex(
     free_counters = Counter{UInt32, UInt8}[raw_counters...]
     smoothed_counter = Counter(UInt32, UInt8, counter_size)
 
+    @inline uses_smoothed_scores(::FragmentIndexSearchParameters) = true
+    @inline uses_smoothed_scores(::ParameterTuningSearchParameters) = false
+    @inline uses_smoothed_scores(::NceTuningSearchParameters) = false
+    @inline uses_smoothed_scores(::QuadTuningSearchParameters) = false
+
+    local_score_threshold(min_score::UInt8) = UInt8(max(Int(min_score) - 1, 0))
+
     acquire_counter!() = pop!(free_counters)
 
     function release_counter!(counter::Counter{UInt32, UInt8})
@@ -97,9 +104,20 @@ function searchFragmentIndex(
     end
 
     function finalize_scan!(target, left, right)
-        smooth_scores!(smoothed_counter, target, left, right)
-        filterPrecursorMatches!(smoothed_counter, getMinIndexSearchScore(params))
-        record_matches!(smoothed_counter, target.scan_idx)
+        min_score = getMinIndexSearchScore(params)
+        if uses_smoothed_scores(params)
+            smooth_scores!(smoothed_counter, target, left, right)
+            filterPrecursorMatches!(
+                smoothed_counter,
+                target.counter,
+                min_score,
+                local_score_threshold(min_score)
+            )
+            record_matches!(smoothed_counter, target.scan_idx)
+        else
+            filterPrecursorMatches!(target.counter, min_score)
+            record_matches!(target.counter, target.scan_idx)
+        end
         return nothing
     end
 


### PR DESCRIPTION
## Summary
- require fragment index matches to satisfy both smoothed scores and local scan scores with a reduced threshold
- skip smoothed scoring for parameter, NCE, and quad tuning searches so they rely on local weighted scores only
- generalize precursor match filtering utilities to support combined smoothed and local checks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940585f2ff083259b6e592dbc9736b8)