### PR TITLE
Weight fragment index scores using spline intensities

### DIFF
--- a/src/Routines/BuildSpecLib.jl
+++ b/src/Routines/BuildSpecLib.jl
@@ -248,30 +248,60 @@ function BuildSpecLib(params_path::String)
                 # Load tables
                 precursors_table = Arrow.Table(precursors_arrow_path)
                 fragments_table = Arrow.Table(raw_fragments_arrow_path)
-                #Record the spline knots 
-                try
-                    spl_knots = copy(fragments_table[:knot_vector][1])
-                    jldsave(
-                        joinpath(lib_dir, "spline_knots.jld2");
-                        spl_knots
-                    )
-                    ion_dictionary = get_altimeter_ion_dict(asset_path("ion_dictionary.txt"))
 
-                    parse_altimeter_fragments(
-                        precursors_table,
-                        fragments_table,
-                        frag_annotation_type,
-                        ion_dictionary,
-                        10000,
-                        asset_path("immonium.txt"),
-                        lib_dir,
-                        Dict{String, Int8}(),
-                        iso_mod_to_mass,
-                        koina_model_type
-                    )
+                # Record the spline knots if they were produced by fragment predictions
+                has_knot_vector = hasproperty(fragments_table, :knot_vector)
+                @info "Fragment prediction includes knot_vector column" has_knot_vector
 
-                catch
-                    #println("No spline knots. static library")
+                if has_knot_vector
+                    try
+                        knot_column = fragments_table[:knot_vector]
+                        @info "Attempting to persist spline knots for fragment scoring" knot_entries=length(knot_column)
+                        spl_knots = copy(knot_column[1])
+                        jldsave(
+                            joinpath(lib_dir, "spline_knots.jld2");
+                            spl_knots
+                        )
+                        @info "Saved spline knots for fragment scoring" output_path=joinpath(lib_dir, "spline_knots.jld2") knot_count=length(spl_knots)
+
+                        ion_dictionary = get_altimeter_ion_dict(asset_path("ion_dictionary.txt"))
+
+                        parse_altimeter_fragments(
+                            precursors_table,
+                            fragments_table,
+                            frag_annotation_type,
+                            ion_dictionary,
+                            10000,
+                            asset_path("immonium.txt"),
+                            lib_dir,
+                            Dict{String, Int8}(),
+                            iso_mod_to_mass,
+                            koina_model_type
+                        )
+
+                    catch e
+                        @warn "Failed to extract or save spline knots; using static fragment parsing" exception=(e, catch_backtrace())
+
+                        # Process ion annotations
+                        ion_annotation_set = get_ion_annotation_set(fragments_table[:annotation])
+                        frag_name_to_idx = Dict(ion => UInt16(i) for (i, ion) in enumerate(ion_annotation_set))
+
+                        ion_annotation_dict = parse_koina_fragments(
+                            precursors_table,
+                            fragments_table,
+                            frag_annotation_type,
+                            ion_annotation_set,
+                            frag_name_to_idx,
+                            10000,
+                            asset_path("immonium.txt"),
+                            lib_dir,
+                            Dict{String, Int8}(),
+                            iso_mod_to_mass,
+                            koina_model_type
+                        )
+                    end
+                else
+                    @info "No knot_vector column; skipping spline knots save (static library or non-spline predictions)"
 
                     # Process ion annotations
                     ion_annotation_set = get_ion_annotation_set(fragments_table[:annotation])

--- a/src/Routines/BuildSpecLib/build/build_poin_lib.jl
+++ b/src/Routines/BuildSpecLib/build/build_poin_lib.jl
@@ -714,6 +714,9 @@ function getSimpleFrags(
         end
 
         rank_scores = get_rank_scores(filtered_frag_indices)
+        if use_spline_scores && pid % 100_000 == 0
+            @info "Spline fragment weights sample" pid rank_scores
+        end
         for (local_rank, frag_idx) in enumerate(filtered_frag_indices)
             simple_frag_idx += 1
             simple_frags[simple_frag_idx] = SimpleFrag(

--- a/src/Routines/BuildSpecLib/build/build_poin_lib.jl
+++ b/src/Routines/BuildSpecLib/build/build_poin_lib.jl
@@ -99,6 +99,11 @@ function buildPionLib(spec_lib_path::String,
     catch
         nothing
     end
+    if isnothing(spline_knots)
+        @info "No spline knots found; using fixed fragment rank weights" spec_lib_path
+    else
+        @info "Loaded spline knots for spline-scored fragment indexing" spec_lib_path knot_count=length(spline_knots)
+    end
 
     #Simple fragments that go into the fragment index
     #println("Get index fragments...")
@@ -642,16 +647,23 @@ function getSimpleFrags(
     simple_frags = Vector{SimpleFrag{Float32}}(undef, n_precursors*max_rank_index)
     simple_frag_idx = 0
     knots_tuple = isnothing(spline_knots) ? nothing : Tuple(Float32.(spline_knots))
+    coeff_count = isnothing(frag_coefficients) ? 0 : length(frag_coefficients)
     use_spline_scores = !isnothing(frag_coefficients) && !isnothing(knots_tuple)
+
+    if use_spline_scores
+        @info "Spline fragment scoring enabled" coeff_count knots_count=length(knots_tuple) spline_degree spline_nce
+    else
+        @info "Spline fragment scoring disabled; falling back to fixed rank weights" has_coefficients=!isnothing(frag_coefficients) coeff_count has_knots=!isnothing(knots_tuple)
+    end
 
     function get_rank_scores(filtered_frag_indices::Vector{UInt32})
         rank_limit = length(filtered_frag_indices)
         if rank_limit == 0
-            return UInt8[]
+            return UInt8[], false
         end
 
         if !use_spline_scores
-            return rank_to_score[1:rank_limit]
+            return rank_to_score[1:rank_limit], false
         end
 
         intensities = Vector{Float32}(undef, rank_limit)
@@ -665,7 +677,7 @@ function getSimpleFrags(
         end
 
         if total_intensity == 0
-            return rank_to_score[1:rank_limit]
+            return rank_to_score[1:rank_limit], false
         end
 
         total_score = sum(rank_to_score[1:rank_limit])
@@ -674,8 +686,10 @@ function getSimpleFrags(
             proportional_score = intensities[i] / total_intensity * total_score
             scores[i] = UInt8(clamp(round(proportional_score), one(UInt8), typemax(UInt8)))
         end
-        return scores
+        return scores, true
     end
+
+    zero_intensity_fallbacks = 0
 
     for pid in range(one(UInt32), n_precursors)
         prec_mz = precursor_mz[pid]
@@ -713,9 +727,16 @@ function getSimpleFrags(
             end
         end
 
-        rank_scores = get_rank_scores(filtered_frag_indices)
-        if use_spline_scores && pid % 100_000 == 0
-            @info "Spline fragment weights sample" pid rank_scores
+        rank_scores, used_spline_rank = get_rank_scores(filtered_frag_indices)
+        if use_spline_scores && !used_spline_rank && !isempty(filtered_frag_indices)
+            zero_intensity_fallbacks += 1
+            if zero_intensity_fallbacks <= 5 || pid % 100_000 == 0
+                @warn "Spline scoring fell back to fixed rank weights" pid rank_limit=length(filtered_frag_indices)
+            end
+        end
+
+        if pid % 100_000 == 0
+            @info "Fragment scoring sample" pid use_spline_scores used_spline_rank rank_scores rank_limit=length(filtered_frag_indices)
         end
         for (local_rank, frag_idx) in enumerate(filtered_frag_indices)
             simple_frag_idx += 1
@@ -728,6 +749,10 @@ function getSimpleFrags(
                 rank_scores[local_rank]
             )
         end
+    end
+
+    if use_spline_scores && zero_intensity_fallbacks > 0
+        @info "Total spline scoring fallbacks to fixed weights" zero_intensity_fallbacks
     end
     return simple_frags[1:simple_frag_idx]
 end

--- a/src/Routines/BuildSpecLib/build/build_poin_lib.jl
+++ b/src/Routines/BuildSpecLib/build/build_poin_lib.jl
@@ -94,7 +94,13 @@ function buildPionLib(spec_lib_path::String,
         return nothing
     end
 
-    #Simple fragments that go into the fragment index 
+    spline_knots = try
+        JLD2.load(joinpath(spec_lib_path, "spline_knots.jld2"))["spl_knots"]
+    catch
+        nothing
+    end
+
+    #Simple fragments that go into the fragment index
     #println("Get index fragments...")
     simple_frags = getSimpleFrags(
         fragments_table[:mz],
@@ -120,7 +126,10 @@ function buildPionLib(spec_lib_path::String,
         include_neutral_diff,
         max_frag_charge,
         frag_bounds,
-        rank_to_score
+        rank_to_score;
+        frag_coefficients = fragments_table[:coefficients],
+        spline_knots = spline_knots,
+        spline_degree = 3,
     );
 
     #println("Build fragment index...")
@@ -617,7 +626,11 @@ function getSimpleFrags(
     include_neutral_diff::Bool,
     max_frag_charge::UInt8,
     frag_bounds::FragBoundModel,
-    rank_to_score::Vector{UInt8},
+    rank_to_score::Vector{UInt8};
+    frag_coefficients=nothing,
+    spline_knots=nothing,
+    spline_degree::Int=3,
+    spline_nce::Float32=25f0,
     )
     if (length(prec_to_frag_idx) - 1) != (length(precursor_mz))
         #println("mistake")
@@ -628,10 +641,47 @@ function getSimpleFrags(
     n_precursors = UInt32(length(precursor_mz))
     simple_frags = Vector{SimpleFrag{Float32}}(undef, n_precursors*max_rank_index)
     simple_frag_idx = 0
+    knots_tuple = isnothing(spline_knots) ? nothing : Tuple(Float32.(spline_knots))
+    use_spline_scores = !isnothing(frag_coefficients) && !isnothing(knots_tuple)
+
+    function get_rank_scores(filtered_frag_indices::Vector{UInt32})
+        rank_limit = length(filtered_frag_indices)
+        if rank_limit == 0
+            return UInt8[]
+        end
+
+        if !use_spline_scores
+            return rank_to_score[1:rank_limit]
+        end
+
+        intensities = Vector{Float32}(undef, rank_limit)
+        total_intensity = zero(Float32)
+        for (local_idx, frag_idx) in enumerate(filtered_frag_indices)
+            coef = frag_coefficients[frag_idx]
+            intensity = Float32(splevl(spline_nce, knots_tuple, coef, spline_degree))
+            intensity = max(intensity, zero(Float32))
+            intensities[local_idx] = intensity
+            total_intensity += intensity
+        end
+
+        if total_intensity == 0
+            return rank_to_score[1:rank_limit]
+        end
+
+        total_score = sum(rank_to_score[1:rank_limit])
+        scores = Vector{UInt8}(undef, rank_limit)
+        for i in 1:rank_limit
+            proportional_score = intensities[i] / total_intensity * total_score
+            scores[i] = UInt8(clamp(round(proportional_score), one(UInt8), typemax(UInt8)))
+        end
+        return scores
+    end
+
     for pid in range(one(UInt32), n_precursors)
         prec_mz = precursor_mz[pid]
         frag_start_idx, frag_stop_idx = prec_to_frag_idx[pid], prec_to_frag_idx[pid+1] - 1
-        rank = 1
+        filtered_frag_indices = UInt32[]
+
         for frag_idx in range(frag_start_idx, frag_stop_idx)
             if fragFilter(
                     frag_is_y[frag_idx],
@@ -656,6 +706,15 @@ function getSimpleFrags(
                     max_frag_charge)==false
                 continue
             end
+
+            push!(filtered_frag_indices, UInt32(frag_idx))
+            if length(filtered_frag_indices) >= max_rank_index
+                break
+            end
+        end
+
+        rank_scores = get_rank_scores(filtered_frag_indices)
+        for (local_rank, frag_idx) in enumerate(filtered_frag_indices)
             simple_frag_idx += 1
             simple_frags[simple_frag_idx] = SimpleFrag(
                 frag_mz[frag_idx],
@@ -663,14 +722,9 @@ function getSimpleFrags(
                 precursor_mz[pid],
                 precursor_irt[pid],
                 precursor_charge[pid],
-                rank_to_score[rank]
+                rank_scores[local_rank]
             )
-            rank += 1
-            if rank > max_rank_index
-                break
-            end
         end
-
     end
     return simple_frags[1:simple_frag_idx]
 end

--- a/test/UnitTests/BuildPionLibTest.jl
+++ b/test/UnitTests/BuildPionLibTest.jl
@@ -913,11 +913,53 @@ end
         
         # Should only return 3 fragments due to rank limit
         @test length(rank_limited_frags) == 3
-        
+
         # Test scores are assigned in decreasing order
         @test getScore(rank_limited_frags[1]) == 10
         @test getScore(rank_limited_frags[2]) == 9
         @test getScore(rank_limited_frags[3]) == 8
+
+        @testset "spline-weighted scores" begin
+            frag_coefficients = NTuple{2, Float32}[(10.0f0, 2.0f0), (2.0f0, 2.0f0),
+                                                  (1.0f0, 5.0f0), (4.0f0, 1.0f0)]
+            spline_knots = (0.0f0, 0.0f0, 50.0f0, 50.0f0)
+
+            proportional_frags = getSimpleFrags(
+                frag_mz,
+                frag_is_y,
+                frag_is_b,
+                frag_is_p,
+                frag_index,
+                frag_charge,
+                frag_isotope,
+                frag_internal,
+                frag_immonium,
+                frag_neutral_diff,
+                precursor_mz,
+                precursor_irt,
+                precursor_charge,
+                prec_to_frag_idx,
+                y_start,
+                b_start,
+                include_p,
+                include_isotope,
+                include_immonium,
+                include_internal,
+                include_neutral_diff,
+                max_frag_charge,
+                frag_bounds,
+                rank_to_score;
+                frag_coefficients=frag_coefficients,
+                spline_knots=spline_knots,
+                spline_degree=1,
+                spline_nce=25f0,
+            )
+
+            @test getScore(proportional_frags[1]) == UInt8(14)
+            @test getScore(proportional_frags[2]) == UInt8(5)
+            @test getScore(proportional_frags[3]) == UInt8(10)
+            @test getScore(proportional_frags[4]) == UInt8(9)
+        end
     end
     
     #==========================================================================


### PR DESCRIPTION
## Summary
- compute per-precursor fragment index scores from spline-evaluated intensities at NCE 25
- load spline knots when available to enable intensity-proportional scoring while preserving fragment order
- add coverage to ensure spline-weighted fragment index scoring is calculated correctly

## Testing
- `julia --project -e 'using Pkg; Pkg.test(; test_args=["UnitTests/BuildPionLibTest.jl"])'` *(fails: registry fetch blocked by proxy 403 during Arrow clone)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940c35497908325a26970e0a4b4491c)