### PR TITLE
Use pioneer binary in regression workflow

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -8,6 +8,7 @@ jobs:
   regression:
     name: Julia ${{ matrix.version }} regression sweep
     runs-on: [self-hosted, pioneer-regression]
+    timeout-minutes: 7200
     strategy:
       matrix:
         version: ['1.11']

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -43,17 +43,31 @@ jobs:
       - name: Run SearchDIA for all parameter files
         env:
           PIONEER_PARAMS_DIR: ${{ github.workspace }}/pioneer-regression-configs/params
-        shell: pwsh
+        shell: bash
         run: |
-          $paramsDir = $env:PIONEER_PARAMS_DIR
-          if (-not (Test-Path $paramsDir)) {
-            throw "Parameters directory not found: $paramsDir"
-          }
+          set -euo pipefail
+          params_dir="${PIONEER_PARAMS_DIR:-}"
+          if [[ -z "$params_dir" ]]; then
+            echo "PIONEER_PARAMS_DIR is not set."
+            exit 1
+          fi
 
-          Get-ChildItem -Path $paramsDir -Filter *.json | ForEach-Object {
-            Write-Host "Running pioneer search for $($_.FullName)"
-            pioneer search $_.FullName
-          }
+          if [[ ! -d "$params_dir" ]]; then
+            echo "Parameters directory not found: $params_dir"
+            exit 1
+          fi
+
+          shopt -s nullglob
+          param_files=("$params_dir"/*.json)
+          if (( ${#param_files[@]} == 0 )); then
+            echo "No parameter files found in $params_dir"
+            exit 1
+          fi
+
+          for param_file in "${param_files[@]}"; do
+            echo "Running pioneer search for ${param_file}"
+            pioneer search "$param_file"
+          done
 
       - name: Summarize regression results
         env:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -40,6 +40,11 @@ jobs:
       - name: Instantiate project
         run: julia --threads auto --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.build()'
 
+      - name: Add pioneer to PATH
+        shell: powershell
+        run: |
+          "C:\Program Files\Pioneer" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
       - name: Run SearchDIA for all parameter files
         env:
           PIONEER_PARAMS_DIR: ${{ github.workspace }}/pioneer-regression-configs/params

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -43,7 +43,17 @@ jobs:
       - name: Run SearchDIA for all parameter files
         env:
           PIONEER_PARAMS_DIR: ${{ github.workspace }}/pioneer-regression-configs/params
-        run: julia --threads auto --project=. test/run_regressions.jl
+        shell: pwsh
+        run: |
+          $paramsDir = $env:PIONEER_PARAMS_DIR
+          if (-not (Test-Path $paramsDir)) {
+            throw "Parameters directory not found: $paramsDir"
+          }
+
+          Get-ChildItem -Path $paramsDir -Filter *.json | ForEach-Object {
+            Write-Host "Running pioneer search for $($_.FullName)"
+            pioneer search $_.FullName
+          }
 
       - name: Summarize regression results
         env:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -43,31 +43,31 @@ jobs:
       - name: Run SearchDIA for all parameter files
         env:
           PIONEER_PARAMS_DIR: ${{ github.workspace }}/pioneer-regression-configs/params
-        shell: bash
+        shell: powershell
         run: |
-          set -euo pipefail
-          params_dir="${PIONEER_PARAMS_DIR:-}"
-          if [[ -z "$params_dir" ]]; then
-            echo "PIONEER_PARAMS_DIR is not set."
-            exit 1
-          fi
+          $ErrorActionPreference = "Stop"
+          $paramsDir = $env:PIONEER_PARAMS_DIR
 
-          if [[ ! -d "$params_dir" ]]; then
-            echo "Parameters directory not found: $params_dir"
+          if (-not $paramsDir) {
+            Write-Error "PIONEER_PARAMS_DIR is not set."
             exit 1
-          fi
+          }
 
-          shopt -s nullglob
-          param_files=("$params_dir"/*.json)
-          if (( ${#param_files[@]} == 0 )); then
-            echo "No parameter files found in $params_dir"
+          if (-not (Test-Path $paramsDir)) {
+            Write-Error "Parameters directory not found: $paramsDir"
             exit 1
-          fi
+          }
 
-          for param_file in "${param_files[@]}"; do
-            echo "Running pioneer search for ${param_file}"
-            pioneer search "$param_file"
-          done
+          $paramFiles = Get-ChildItem -Path $paramsDir -Filter *.json
+          if (-not $paramFiles) {
+            Write-Error "No parameter files found in $paramsDir"
+            exit 1
+          }
+
+          foreach ($paramFile in $paramFiles) {
+            Write-Host "Running pioneer search for $($paramFile.FullName)"
+            pioneer search $paramFile.FullName
+          }
 
       - name: Summarize regression results
         env:


### PR DESCRIPTION
## Summary
- switch the regression workflow to run `pioneer search` for each parameter file instead of using the Julia REPL
- add a parameters directory existence check before kicking off the regression searches

## Testing
- not run (workflow-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943e865ab64832587587a8ef2bad383)