### PR TITLE
Refactor regression metrics grouping output

### DIFF
--- a/test/regression/metrics_pipeline.jl
+++ b/test/regression/metrics_pipeline.jl
@@ -162,6 +162,8 @@ function compute_dataset_metrics(
     need_three_proteome = ("fold_change" in requested_groups) || ("three_proteome" in requested_groups)
     need_table_metrics = need_identification || need_cv || need_keap1 || need_ftr || need_three_proteome
 
+    dataset_three_proteome_designs = need_three_proteome ? three_proteome_designs : nothing
+
     precursor_id_metrics = nothing
     protein_id_metrics = nothing
     keap1_precursor_metrics = nothing
@@ -225,7 +227,7 @@ function compute_dataset_metrics(
             cv_groups = run_groups_for_dataset(
                 experimental_design,
                 dataset_name;
-                three_proteome_designs = three_proteome_designs,
+                three_proteome_designs = dataset_three_proteome_designs,
             )
             precursor_wide_metrics, protein_wide_metrics, precursor_cv_metrics, protein_cv_metrics =
                 cv_metrics(
@@ -262,7 +264,7 @@ function compute_dataset_metrics(
         end
 
         if need_three_proteome
-            design_entry = three_proteome_design_entry(three_proteome_designs, dataset_name)
+            design_entry = three_proteome_design_entry(dataset_three_proteome_designs, dataset_name)
             fold_change_metrics = fold_change_metrics_block(
                 precursors_wide,
                 protein_groups_wide,

--- a/test/regression/metrics_pipeline.jl
+++ b/test/regression/metrics_pipeline.jl
@@ -288,7 +288,7 @@ function compute_dataset_metrics(
 
     metrics = Dict{String, Any}()
 
-    identification_metrics = Dict{String, Any}()
+    identification_metrics_block = Dict{String, Any}()
 
     if need_identification
         precursors_identification = Dict{String, Any}()
@@ -297,8 +297,8 @@ function compute_dataset_metrics(
         precursor_id_metrics !== nothing && merge!(precursors_identification, precursor_id_metrics)
         protein_id_metrics !== nothing && merge!(protein_identification, protein_id_metrics)
 
-        !isempty(precursors_identification) && (identification_metrics["precursors"] = precursors_identification)
-        !isempty(protein_identification) && (identification_metrics["protein_groups"] = protein_identification)
+        !isempty(precursors_identification) && (identification_metrics_block["precursors"] = precursors_identification)
+        !isempty(protein_identification) && (identification_metrics_block["protein_groups"] = protein_identification)
     end
 
     cv_metrics_block = Dict{String, Any}()
@@ -323,7 +323,7 @@ function compute_dataset_metrics(
         !isempty(protein_cv_block) && (cv_metrics_block["protein_groups"] = protein_cv_block)
     end
 
-    !isempty(identification_metrics) && (metrics["identification"] = identification_metrics)
+    !isempty(identification_metrics_block) && (metrics["identification"] = identification_metrics_block)
     !isempty(cv_metrics_block) && (metrics["cv"] = cv_metrics_block)
     if need_keap1
         keap1_metrics_block = Dict{String, Any}()

--- a/test/regression/three_proteome_metrics.jl
+++ b/test/regression/three_proteome_metrics.jl
@@ -259,7 +259,6 @@ function fold_change_metrics_for_table(
             end
 
             pair_metrics[string(lowercase(species), "_median_deviation")] = deviation
-            pair_metrics[string(lowercase(species), "_entries")] = length(values)
         end
 
         isempty(pair_metrics) || (metrics[pair_label] = pair_metrics)


### PR DESCRIPTION
## Summary
- restructure regression metrics JSON to group metrics by metric category for clearer organization
- drop run count and CV run metrics and remove fold-change entry counts
- add dedicated groupings for KEAP1 and CV metrics while preserving key completeness and variability values

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945ae104a008325bcf9db232a3f14e0)