### PR TITLE
Skip regression searches without data

### DIFF
--- a/test/run_regressions.jl
+++ b/test/run_regressions.jl
@@ -8,6 +8,12 @@ param_dir = get(
 
 for path in readdir(param_dir; join=true)
     endswith(path, ".json") || continue
+    params_name, _ = splitext(basename(path))
+    data_path = joinpath(raw"C:\pioneer-runner\data", params_name)
+    if !isdir(data_path)
+        @info "Skipping SearchDIA due to missing data path" path data_path
+        continue
+    end
     @info "Running SearchDIA" path
     SearchDIA(path)
 end


### PR DESCRIPTION
## Summary
- compute the expected data folder for each regression params file and verify it exists before running SearchDIA
- skip searches with a missing C:\pioneer-runner\data/<params_name> directory while logging the skip reason

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945c818070c83259cef0d234cd83fbf)