### PR TITLE
Update FTR regression design handling

### DIFF
--- a/test/regression/regression_metrics.jl
+++ b/test/regression/regression_metrics.jl
@@ -12,7 +12,7 @@ include("ftr_metrics.jl")
 include("metrics_pipeline.jl")
 using .RegressionMetricsHelpers: condition_columns, count_nonyeast_ids, count_species_ids, count_total_ids, count_yeast_ids, gene_names_column, mean_for_columns, quant_column_names_from_proteins, select_quant_columns, species_column, unique_species_value
 using .EntrapmentMetrics: compute_entrapment_metrics
-using .ThreeProteomeMetrics: experimental_design_for_dataset, fold_change_metrics_for_table, gene_counts_metrics_by_run, load_experimental_design, load_three_proteome_designs, normalize_metric_label, run_groups_for_dataset, three_proteome_design_entry
+using .ThreeProteomeMetrics: experimental_design_entry, experimental_design_for_dataset, fold_change_metrics_for_table, gene_counts_metrics_by_run, load_experimental_design, load_three_proteome_designs, normalize_metric_label, run_groups_for_dataset, three_proteome_design_entry
 
 const DEFAULT_METRIC_GROUPS = ["identification", "CV", "eFDR", "runtime"]
 

--- a/test/regression/three_proteome_metrics.jl
+++ b/test/regression/three_proteome_metrics.jl
@@ -405,7 +405,8 @@ function three_proteome_design_entry(
     nothing
 end
 
-export load_experimental_design, normalize_metric_label, experimental_design_for_dataset, run_groups_for_dataset
+export load_experimental_design, normalize_metric_label, experimental_design_for_dataset, run_groups_for_dataset,
+       experimental_design_entry
 export gene_counts_metrics_by_run, fold_change_metrics_for_table
 export load_three_proteome_designs, three_proteome_design_entry
 


### PR DESCRIPTION
## Summary
- allow false transfer rate metrics to read the human-only condition name from experimental design metadata
- export the experimental design accessor so FTR metrics can interpret dataset-specific configuration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946981c9c408325a3aa7894b94a06e9)