### PR TITLE
Add cluster SSH bootstrap to regression workflow

### DIFF
--- a/.github/workflows/build_app_linux.yml
+++ b/.github/workflows/build_app_linux.yml
@@ -25,7 +25,7 @@ jobs:
             format('call-{0}-{1}-{2}', github.run_id, github.run_attempt, matrix.identifier) ||
             format('{0}-{1}-{2}', github.workflow, github.ref_name, matrix.identifier) }}
       cancel-in-progress: true
-    runs-on: [self-hosted, Linux]
+    runs-on: [self-hosted, Linux, pioneer-compile]
     env:
       JULIA_NUM_THREADS: auto
     outputs:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -17,6 +17,44 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Configure SSH for cluster access
+        env:
+          CLUSTER_SSH_KEY: ${{ secrets.CLUSTER_SSH_KEY }}
+          CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
+        run: |
+          set -euo pipefail
+          install -m 700 -d ~/.ssh
+          echo "$CLUSTER_SSH_KEY" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          # Preload host key to avoid interactive prompt
+          ssh-keyscan -H "$CLUSTER_HOST" >> ~/.ssh/known_hosts
+
+      - name: Checkout regression configs on cluster
+        env:
+          CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
+          CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
+          CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
+        run: |
+          set -euo pipefail
+          # Guard the SSH session to avoid hanging forever if the cluster is unreachable
+          timeout 5m ssh \
+            -o BatchMode=yes \
+            -o ServerAliveInterval=60 \
+            -o ServerAliveCountMax=3 \
+            "${CLUSTER_USERNAME}@${CLUSTER_HOST}" <<'EOF'
+          set -euo pipefail
+          RUN_ROOT="${CLUSTER_RUN_ROOT:-$HOME/pioneer-regressions}"
+          mkdir -p "$RUN_ROOT"
+          cd "$RUN_ROOT"
+
+          if [ -d regression-configs/.git ]; then
+            git -C regression-configs fetch --all
+            git -C regression-configs reset --hard origin/main
+          else
+            git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs
+          fi
+          EOF
+
       - name: Checkout regression parameter configs
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -400,79 +400,61 @@ jobs:
             done
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Clean run workspace on shared storage
+      - name: Submit cluster cleanup job
         if: always()
         env:
-          CLUSTER_RUN_DIR_MOUNT: ${{ env.CLUSTER_RUN_DIR_MOUNT }}
+          CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
+          CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
+          CLUSTER_RUN_DIR: ${{ env.CLUSTER_RUN_DIR }}
+          CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
+          CLEANUP_JOB_SCRIPT: ${{ vars.CLEANUP_JOB_SCRIPT }}
         shell: bash
         run: |
           set -euo pipefail
 
-          run_dir="${CLUSTER_RUN_DIR_MOUNT:?CLUSTER_RUN_DIR_MOUNT not set}"
-          results_dir="$run_dir/results"
+          remote_run_root="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
+          remote_run_dir="${CLUSTER_RUN_DIR:-${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}"
+          cleanup_script_path="${remote_run_dir}/${CLEANUP_JOB_SCRIPT:-regression-configs/job_scripts/cleanup.bsub}"
 
-          case "$run_dir" in
-            /mnt/ris/Active/Automation/Pioneer/run-*) ;;
+          case "$remote_run_dir" in
+            /storage1/fs1/d.goldfarb/Active/Automation/Pioneer/run-*) ;;
             *)
-              echo "Refusing to clean unexpected run directory: $run_dir" >&2
+              echo "Refusing to submit cleanup for unexpected run directory: $remote_run_dir" >&2
               exit 1
               ;;
           esac
 
-          if [ ! -d "$run_dir" ]; then
-            echo "Run directory $run_dir does not exist; skipping cleanup"
-            exit 0
-          fi
+          ssh_options=(
+            -o BatchMode=yes
+            -o ServerAliveInterval=60
+            -o ServerAliveCountMax=3
+            -o ConnectTimeout=30
+          )
 
-          if [ ! -d "$results_dir" ]; then
-            echo "Results directory not found at $results_dir; skipping cleanup"
-            exit 0
-          fi
+          cleanup_submit="$(timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+            "RUN_DIR='${remote_run_dir}' CLEANUP_SCRIPT='${cleanup_script_path}' bash -s" <<'EOF'
+              set -eu
 
-          shopt -s dotglob nullglob
-          entries=()
-
-          for entry in "$run_dir"/* "$run_dir"/.*; do
-            base="$(basename "$entry")"
-            if [ "$base" = "." ] || [ "$base" = ".." ]; then
-              continue
-            fi
-
-            if [ "$entry" = "$results_dir" ]; then
-              continue
-            fi
-
-            entries+=("$entry")
-          done
-
-          failed=()
-
-          for entry in "${entries[@]}"; do
-            removed=0
-            for attempt in $(seq 1 5); do
-              if rm -rf -- "$entry"; then
-                echo "Removed $entry (attempt $attempt)"
-                removed=1
-                break
+              if [ ! -f "$CLEANUP_SCRIPT" ]; then
+                echo "Missing cleanup job script: $CLEANUP_SCRIPT" >&2
+                exit 1
               fi
 
-              echo "Removal failed for $entry (attempt $attempt); retrying in 5s" >&2
-              sleep 5
-            done
+              submit_out=$(RUN_DIR="$RUN_DIR" bsub < "$CLEANUP_SCRIPT")
+              printf '%s' "$submit_out"
+          EOF
+          )"
 
-            if [ "$removed" -ne 1 ]; then
-              if [ -e "$entry" ]; then
-                failed+=("$entry")
-              else
-                echo "$entry no longer exists after retries; continuing"
-              fi
-            fi
-          done
+          cleanup_job_id=$(printf '%s\n' "$cleanup_submit" | sed -n 's/Job <\([0-9]\+\)>.*$/\1/p' | head -n 1)
 
-          if [ "${#failed[@]}" -gt 0 ]; then
-            echo "Failed to remove the following entries:" >&2
-            printf '  %s\n' "${failed[@]}" >&2
+          if [ -z "$cleanup_job_id" ]; then
+            echo "Failed to parse cleanup job ID from submission output:" >&2
+            printf '%s\n' "$cleanup_submit" >&2
             exit 1
           fi
 
-          echo "Cleanup complete; preserved results at $results_dir" | tee -a "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Cleanup job submission"
+            echo "- Run directory: $remote_run_dir"
+            echo "- Cleanup job ID: $cleanup_job_id"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -127,11 +127,6 @@ jobs:
               exit 1
             fi
 
-            if ! command -v jq >/dev/null 2>&1; then
-              echo "jq is required on the cluster to adjust param files" >&2
-              exit 1
-            fi
-
             setup_submit=$(PIONEER_DIR="$PIONEER_DIR" bsub < "$SETUP_SCRIPT")
             setup_job_id=$(printf '%s\n' "$setup_submit" | sed -n 's/Job <\([0-9]\+\)>.*$/\1/p' | head -n 1)
 
@@ -155,7 +150,18 @@ jobs:
               adjusted_path="$ADJUSTED_PARAMS_DIR/$rel_path"
               mkdir -p "$(dirname "$adjusted_path")"
 
-              jq --arg suffix "$RUN_ID_SUFFIX" '.results = (.results | rtrimstr("/") + "/" + $suffix)' "$param_file" > "$adjusted_path"
+              results_path=$(sed -n 's/.*"results"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' "$param_file" | head -n 1)
+
+              if [ -z "$results_path" ]; then
+                echo "Failed to locate results path in $param_file" >&2
+                exit 1
+              fi
+
+              base_results=${results_path%/}
+              adjusted_results="${base_results}/${RUN_ID_SUFFIX}"
+              escaped_results=$(printf '%s\n' "$adjusted_results" | sed 's/[&/]/\\&/g')
+
+              sed -E "s|(\"results\"[[:space:]]*:[[:space:]]*\")([^"]+)(\")|\\1${escaped_results}\\3|" "$param_file" > "$adjusted_path"
 
               PIONEER_DIR="$PIONEER_DIR" PARAM_FILE="$adjusted_path" bsub -w "ended($setup_job_id)" < "$JOB_SCRIPT"
             done

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -135,44 +135,6 @@ jobs:
             fi
           EOF
 
-      - name: Show regression job script content
-        env:
-          CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
-          CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
-          CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
-          CLUSTER_RUN_DIR: ${{ env.CLUSTER_RUN_DIR }}
-          REGRESSION_JOB_SCRIPT: ${{ vars.REGRESSION_JOB_SCRIPT }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
-          remote_run_dir="${CLUSTER_RUN_DIR:-${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}"
-          job_script_path="${remote_run_dir}/${REGRESSION_JOB_SCRIPT:-regression-configs/job_scripts/search_dia.bsub}"
-
-          ssh_options=(
-            -o BatchMode=yes
-            -o ServerAliveInterval=60
-            -o ServerAliveCountMax=3
-            -o ConnectTimeout=30
-          )
-
-          timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-            "JOB_SCRIPT='${job_script_path}' sh -s" <<'EOF' >> "$GITHUB_STEP_SUMMARY"
-            set -eu
-
-            if [ ! -f "$JOB_SCRIPT" ]; then
-              echo "Job script not found: $JOB_SCRIPT" >&2
-              exit 1
-            fi
-
-            echo "### Submitted job script"
-            echo "Path: $JOB_SCRIPT"
-            echo '```bash'
-            cat "$JOB_SCRIPT"
-            echo '```'
-          EOF
-
       - name: Cleanup regression configs on cluster
         if: ${{ always() }}
         env:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -44,18 +44,18 @@ jobs:
           remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
 
           remote_script=$(cat <<'EOF'
-set -eu
-mkdir -p "$RUN_ROOT"
-cd "$RUN_ROOT"
+          set -eu
+          mkdir -p "$RUN_ROOT"
+          cd "$RUN_ROOT"
 
-if [ -d regression-configs/.git ]; then
-  git -C regression-configs fetch --all
-  git -C regression-configs reset --hard origin/main
-else
-  git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs
-fi
-EOF
-)
+          if [ -d regression-configs/.git ]; then
+            git -C regression-configs fetch --all
+            git -C regression-configs reset --hard origin/main
+          else
+            git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs
+          fi
+          EOF
+          )
 
           ssh_options=(
             -o BatchMode=yes

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -82,7 +82,6 @@ jobs:
             git -C "$PIONEER_DIR" checkout --force "$TARGET_SHA"
 
             mkdir -p "$DEPOT_DIR"
-            JULIA_DEPOT_PATH="$DEPOT_DIR" julia --project="$PIONEER_DIR" -e 'using Pkg; Pkg.instantiate()'
           EOF
 
       - name: Submit regression search jobs on cluster
@@ -113,7 +112,7 @@ jobs:
           )
 
           timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-            "RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' PARAMS_DIR='${params_dir}' JOB_SCRIPT='${job_script_path}' sh -s" <<'EOF'
+            "RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' PARAMS_DIR='${params_dir}' DEPOT_DIR='${depot_dir}' JOB_SCRIPT='${job_script_path}' sh -s" <<'EOF'
             set -eu
 
             if [ ! -f "$JOB_SCRIPT" ]; then

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -33,18 +33,22 @@ jobs:
           # Preload host key to avoid interactive prompt
           ssh-keyscan -H "$CLUSTER_HOST" >> ~/.ssh/known_hosts
 
-      - name: Checkout regression configs on cluster
+      - name: Prepare cluster workspace (configs and Pioneer)
         env:
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
           CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
+          GITHUB_SHA: ${{ github.sha }}
         shell: bash
         run: |
           set -euo pipefail
 
           remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
           remote_run_dir="${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          pioneer_dir="${remote_run_dir}/pioneer"
+
           echo "CLUSTER_RUN_DIR=${remote_run_dir}" >> "$GITHUB_ENV"
+          echo "CLUSTER_PIONEER_DIR=${pioneer_dir}" >> "$GITHUB_ENV"
 
           ssh_options=(
             -o BatchMode=yes
@@ -53,7 +57,7 @@ jobs:
             -o ConnectTimeout=30
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' sh -s" <<'EOF'
+          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' TARGET_SHA='${GITHUB_SHA}' sh -s" <<'EOF'
             set -eu
             mkdir -p "$RUN_DIR"
             cd "$RUN_DIR"
@@ -64,35 +68,6 @@ jobs:
             else
               git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs
             fi
-          EOF
-
-      - name: Checkout Pioneer code on cluster
-        env:
-          CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
-          CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
-          CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
-          CLUSTER_RUN_DIR: ${{ env.CLUSTER_RUN_DIR }}
-          GITHUB_SHA: ${{ github.sha }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
-          remote_run_dir="${CLUSTER_RUN_DIR:-${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}"
-          pioneer_dir="${remote_run_dir}/pioneer"
-          echo "CLUSTER_PIONEER_DIR=${pioneer_dir}" >> "$GITHUB_ENV"
-
-          ssh_options=(
-            -o BatchMode=yes
-            -o ServerAliveInterval=60
-            -o ServerAliveCountMax=3
-            -o ConnectTimeout=30
-          )
-
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' TARGET_SHA='${GITHUB_SHA}' sh -s" <<'EOF'
-            set -eu
-            mkdir -p "$RUN_DIR"
-            cd "$RUN_DIR"
 
             if [ -d "$PIONEER_DIR/.git" ]; then
               git -C "$PIONEER_DIR" fetch --all --tags

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -21,6 +21,7 @@ jobs:
         env:
           CLUSTER_SSH_KEY: ${{ secrets.CLUSTER_SSH_KEY }}
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
+        shell: bash
         run: |
           set -euo pipefail
           install -m 700 -d ~/.ssh
@@ -34,6 +35,7 @@ jobs:
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
           CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
+        shell: bash
         run: |
           set -euo pipefail
           # Guard the SSH session to avoid hanging forever if the cluster is unreachable

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -45,8 +45,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
-          remote_run_dir="${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          remote_run_root="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
+          run_suffix="run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          remote_run_dir="${remote_run_root}/${run_suffix}"
+          mount_run_root="/mnt/ris/Active/Automation/Pioneer"
+          mount_run_dir="${mount_run_root}/${run_suffix}"
           pioneer_dir="${remote_run_dir}/pioneer"
           entrapment_dir="${remote_run_dir}/PioneerEntrapment.jl"
           depot_dir="${remote_run_dir}/julia-depot"
@@ -59,6 +62,7 @@ jobs:
           fi
 
           echo "CLUSTER_RUN_DIR=${remote_run_dir}" >> "$GITHUB_ENV"
+          echo "CLUSTER_RUN_DIR_MOUNT=${mount_run_dir}" >> "$GITHUB_ENV"
           echo "CLUSTER_PIONEER_DIR=${pioneer_dir}" >> "$GITHUB_ENV"
           echo "CLUSTER_ENTRAPMENT_DIR=${entrapment_dir}" >> "$GITHUB_ENV"
           echo "CLUSTER_DEPOT_DIR=${depot_dir}" >> "$GITHUB_ENV"
@@ -116,6 +120,7 @@ jobs:
 
           remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
           remote_run_dir="${CLUSTER_RUN_DIR:-${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}"
+          mount_run_dir="${CLUSTER_RUN_DIR_MOUNT:-/mnt/ris/Active/Automation/Pioneer/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}"
           pioneer_dir="${CLUSTER_PIONEER_DIR:-${remote_run_dir}/pioneer}"
           entrapment_dir="${CLUSTER_ENTRAPMENT_DIR:-${remote_run_dir}/PioneerEntrapment.jl}"
           params_dir="${remote_run_dir}/regression-configs/params"
@@ -275,12 +280,12 @@ jobs:
 
       - name: Wait for regression outputs on shared storage
         env:
-          CLUSTER_RUN_DIR: ${{ env.CLUSTER_RUN_DIR }}
+          CLUSTER_RUN_DIR_MOUNT: ${{ env.CLUSTER_RUN_DIR_MOUNT }}
         shell: bash
         run: |
           set -euo pipefail
 
-          run_dir="${CLUSTER_RUN_DIR:?CLUSTER_RUN_DIR not set}"
+          run_dir="${CLUSTER_RUN_DIR_MOUNT:?CLUSTER_RUN_DIR_MOUNT not set}"
           manifest_path="$run_dir/job-ids/expected_results.txt"
           results_root="$run_dir/results"
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -45,10 +45,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          remote_run_root="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
+          remote_run_root_raw="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
+          remote_run_root="${remote_run_root_raw%/}"
           run_suffix="run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           remote_run_dir="${remote_run_root}/${run_suffix}"
-          mount_run_root="/mnt/ris/Active/Automation/Pioneer"
+          mount_run_root_raw="/mnt/ris/Active/Automation/Pioneer"
+          mount_run_root="${mount_run_root_raw%/}"
           mount_run_dir="${mount_run_root}/${run_suffix}"
           pioneer_dir="${remote_run_dir}/pioneer"
           entrapment_dir="${remote_run_dir}/PioneerEntrapment.jl"

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -40,6 +40,7 @@ jobs:
           CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          CLUSTER_ENTRAPMENT_REPO: ${{ secrets.CLUSTER_ENTRAPMENT_REPO }}
         shell: bash
         run: |
           set -euo pipefail
@@ -47,11 +48,19 @@ jobs:
           remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
           remote_run_dir="${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           pioneer_dir="${remote_run_dir}/pioneer"
+          entrapment_dir="${remote_run_dir}/PioneerEntrapment.jl"
           depot_dir="${remote_run_dir}/julia-depot"
           pioneer_repo="https://github.com/${GITHUB_REPOSITORY}"
+          entrapment_repo="${CLUSTER_ENTRAPMENT_REPO:-nwamsley1/PioneerEntrapment.jl}"
+          entrapment_repo_url="$entrapment_repo"
+
+          if [[ "$entrapment_repo" != http* ]]; then
+            entrapment_repo_url="https://github.com/${entrapment_repo}"
+          fi
 
           echo "CLUSTER_RUN_DIR=${remote_run_dir}" >> "$GITHUB_ENV"
           echo "CLUSTER_PIONEER_DIR=${pioneer_dir}" >> "$GITHUB_ENV"
+          echo "CLUSTER_ENTRAPMENT_DIR=${entrapment_dir}" >> "$GITHUB_ENV"
           echo "CLUSTER_DEPOT_DIR=${depot_dir}" >> "$GITHUB_ENV"
 
           ssh_options=(
@@ -61,7 +70,7 @@ jobs:
             -o ConnectTimeout=30
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' DEPOT_DIR='${depot_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${GITHUB_SHA}' sh -s" <<'EOF'
+          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' DEPOT_DIR='${depot_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${GITHUB_SHA}' ENTRAPMENT_DIR='${entrapment_dir}' ENTRAPMENT_REPO_URL='${entrapment_repo_url}' bash -s" <<'EOF'
             set -eu
             mkdir -p "$RUN_DIR"
             cd "$RUN_DIR"
@@ -81,6 +90,12 @@ jobs:
 
             git -C "$PIONEER_DIR" checkout --force "$TARGET_SHA"
 
+            if [ -d "$ENTRAPMENT_DIR/.git" ]; then
+              git -C "$ENTRAPMENT_DIR" fetch --all --tags
+            else
+              git clone "$ENTRAPMENT_REPO_URL" "$ENTRAPMENT_DIR"
+            fi
+
             mkdir -p "$DEPOT_DIR"
           EOF
 
@@ -91,8 +106,10 @@ jobs:
           CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
           CLUSTER_RUN_DIR: ${{ env.CLUSTER_RUN_DIR }}
           CLUSTER_PIONEER_DIR: ${{ env.CLUSTER_PIONEER_DIR }}
+          CLUSTER_ENTRAPMENT_DIR: ${{ env.CLUSTER_ENTRAPMENT_DIR }}
           REGRESSION_JOB_SCRIPT: ${{ vars.REGRESSION_JOB_SCRIPT }}
           SETUP_JOB_SCRIPT: ${{ vars.SETUP_JOB_SCRIPT }}
+          METRICS_JOB_SCRIPT: ${{ vars.METRICS_JOB_SCRIPT }}
         shell: bash
         run: |
           set -euo pipefail
@@ -100,9 +117,11 @@ jobs:
           remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
           remote_run_dir="${CLUSTER_RUN_DIR:-${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}"
           pioneer_dir="${CLUSTER_PIONEER_DIR:-${remote_run_dir}/pioneer}"
+          entrapment_dir="${CLUSTER_ENTRAPMENT_DIR:-${remote_run_dir}/PioneerEntrapment.jl}"
           params_dir="${remote_run_dir}/regression-configs/params"
           job_script_path="${remote_run_dir}/${REGRESSION_JOB_SCRIPT:-regression-configs/job_scripts/search_dia.bsub}"
           setup_script_path="${remote_run_dir}/${SETUP_JOB_SCRIPT:-regression-configs/job_scripts/setup.bsub}"
+          metrics_script_path="${remote_run_dir}/${METRICS_JOB_SCRIPT:-regression-configs/job_scripts/metrics.bsub}"
           adjusted_params_dir="${remote_run_dir}/adjusted-params"
           run_suffix="run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
 
@@ -114,7 +133,7 @@ jobs:
           )
 
           timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-            "RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' PARAMS_DIR='${params_dir}' JOB_SCRIPT='${job_script_path}' SETUP_SCRIPT='${setup_script_path}' ADJUSTED_PARAMS_DIR='${adjusted_params_dir}' RUN_ID_SUFFIX='${run_suffix}' sh -s" <<'EOF'
+            "RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' ENTRAPMENT_DIR='${entrapment_dir}' PARAMS_DIR='${params_dir}' JOB_SCRIPT='${job_script_path}' SETUP_SCRIPT='${setup_script_path}' METRICS_SCRIPT='${metrics_script_path}' ADJUSTED_PARAMS_DIR='${adjusted_params_dir}' RUN_ID_SUFFIX='${run_suffix}' bash -s" <<'EOF'
             set -eu
 
             if [ ! -f "$SETUP_SCRIPT" ]; then
@@ -124,6 +143,11 @@ jobs:
 
             if [ ! -f "$JOB_SCRIPT" ]; then
               echo "Missing job script: $JOB_SCRIPT" >&2
+              exit 1
+            fi
+
+            if [ ! -f "$METRICS_SCRIPT" ]; then
+              echo "Missing metrics job script: $METRICS_SCRIPT" >&2
               exit 1
             fi
 
@@ -144,9 +168,12 @@ jobs:
             fi
 
             mkdir -p "$ADJUSTED_PARAMS_DIR"
+            job_id_dir="$RUN_DIR/job-ids"
+            mkdir -p "$job_id_dir"
 
             printf '%s\n' "$param_list" | while IFS= read -r param_file; do
               rel_path="${param_file#${PARAMS_DIR}/}"
+              dataset_name="${rel_path%%/*}"
               adjusted_path="$ADJUSTED_PARAMS_DIR/$rel_path"
               mkdir -p "$(dirname "$adjusted_path")"
 
@@ -163,66 +190,73 @@ jobs:
 
               sed "s|\"results\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"results\": \"${escaped_results}\"|" "$param_file" > "$adjusted_path"
 
-              PIONEER_DIR="$PIONEER_DIR" PARAM_FILE="$adjusted_path" bsub -w "ended($setup_job_id)" < "$JOB_SCRIPT"
+              search_submit=$(PIONEER_DIR="$PIONEER_DIR" PARAM_FILE="$adjusted_path" bsub -w "ended($setup_job_id)" < "$JOB_SCRIPT")
+              search_job_id=$(printf '%s\n' "$search_submit" | sed -n 's/Job <\([0-9]\+\)>.*$/\1/p' | head -n 1)
+
+              if [ -z "$search_job_id" ]; then
+                echo "Failed to parse search job ID from submission output:" >&2
+                printf '%s\n' "$search_submit" >&2
+                exit 1
+              fi
+
+              echo "$search_job_id" >> "$job_id_dir/${dataset_name}.search"
+            done
+
+            dataset_dirs=$(find "$PARAMS_DIR" -mindepth 1 -maxdepth 1 -type d -print)
+
+            if [ -z "$dataset_dirs" ]; then
+              echo "No dataset directories found under $PARAMS_DIR" >&2
+              exit 1
+            fi
+
+            printf '%s\n' "$dataset_dirs" | while IFS= read -r dataset_dir; do
+              dataset_name="$(basename "$dataset_dir")"
+              job_list_file="$job_id_dir/${dataset_name}.search"
+              metrics_file="$dataset_dir/metrics.json"
+              exp_design_file="$dataset_dir/experimental_design.json"
+
+              if [ ! -f "$exp_design_file" ]; then
+                exp_design_file=""
+              fi
+
+              if [ ! -f "$metrics_file" ]; then
+                echo "Skipping dataset $dataset_name: missing metrics.json" >&2
+                continue
+              fi
+
+              if [ ! -s "$job_list_file" ]; then
+                echo "Skipping dataset $dataset_name: no search job IDs recorded" >&2
+                continue
+              fi
+
+              dep_expr=""
+              while IFS= read -r job_id; do
+                [ -n "$job_id" ] || continue
+                if [ -n "$dep_expr" ]; then
+                  dep_expr="$dep_expr && "
+                fi
+                dep_expr="${dep_expr}ended(${job_id})"
+              done < "$job_list_file"
+
+              if [ -z "$dep_expr" ]; then
+                echo "Skipping dataset $dataset_name: unable to build dependency expression" >&2
+                continue
+              fi
+
+              param_dataset_dir="$ADJUSTED_PARAMS_DIR/$dataset_name"
+              if [ ! -d "$param_dataset_dir" ]; then
+                echo "Skipping dataset $dataset_name: adjusted params directory missing at $param_dataset_dir" >&2
+                continue
+              fi
+
+              metrics_submit=$(PIONEER_DIR="$PIONEER_DIR" PIONEER_ENTRAPMENT_DIR="$ENTRAPMENT_DIR" PARAMS_DIR="$param_dataset_dir" METRICS_FILE="$metrics_file" EXPERIMENTAL_DESIGN_FILE="$exp_design_file" RUN_ID_SUFFIX="$RUN_ID_SUFFIX" bsub -w "$dep_expr" < "$METRICS_SCRIPT")
+
+              metrics_job_id=$(printf '%s\n' "$metrics_submit" | sed -n 's/Job <\([0-9]\+\)>.*$/\1/p' | head -n 1)
+
+              if [ -z "$metrics_job_id" ]; then
+                echo "Failed to parse metrics job ID for dataset $dataset_name:" >&2
+                printf '%s\n' "$metrics_submit" >&2
+                exit 1
+              fi
             done
           EOF
-
-      - name: Cleanup regression configs on cluster
-        if: ${{ false }}
-        env:
-          CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
-          CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
-          CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
-          CLUSTER_RUN_DIR: ${{ env.CLUSTER_RUN_DIR }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
-          remote_run_dir="${CLUSTER_RUN_DIR:-${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}"
-
-          ssh_options=(
-            -o BatchMode=yes
-            -o ServerAliveInterval=60
-            -o ServerAliveCountMax=3
-            -o ConnectTimeout=30
-          )
-
-          timeout 180 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_DIR='${remote_run_dir}' sh -s" <<'EOF'
-            set -eu
-            rm -rf "$RUN_DIR"
-          EOF
-
-      - name: Checkout regression parameter configs
-        if: ${{ false }}
-        uses: actions/checkout@v5
-        with:
-          repository: GoldfarbLab/pioneer-regression-configs
-          path: pioneer-regression-configs
-
-      - name: Checkout Entrapment analyses utilities
-        if: ${{ false }}
-        uses: actions/checkout@v5
-        with:
-          repository: nwamsley1/PioneerEntrapment.jl
-          path: PioneerEntrapment.jl
-
-      - name: Setup Julia
-        if: ${{ false }}
-        uses: julia-actions/setup-julia@v2
-        with:
-          version: ${{ matrix.version }}
-          arch: x64
-
-      - name: Run SearchDIA for all parameter files
-        if: ${{ false }}
-        env:
-          PIONEER_PARAMS_DIR: ${{ github.workspace }}/pioneer-regression-configs/params
-        run: julia --threads auto --project=. test/run_regressions.jl
-
-      - name: Summarize regression results
-        if: ${{ false }}
-        env:
-          ENTRAPMENT_ANALYSES_PATH: ${{ github.workspace }}/PioneerEntrapment.jl
-          PIONEER_RESULTS_DIR: /pioneer-runner/results/current
-        run: julia --threads auto --project=. test/regression/regression_metrics.jl

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -103,6 +103,8 @@ jobs:
           params_dir="${remote_run_dir}/regression-configs/params"
           job_script_path="${remote_run_dir}/${REGRESSION_JOB_SCRIPT:-regression-configs/job_scripts/search_dia.bsub}"
           setup_script_path="${remote_run_dir}/${SETUP_JOB_SCRIPT:-regression-configs/job_scripts/setup.bsub}"
+          adjusted_params_dir="${remote_run_dir}/adjusted-params"
+          run_suffix="run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
 
           ssh_options=(
             -o BatchMode=yes
@@ -112,7 +114,7 @@ jobs:
           )
 
           timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-            "RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' PARAMS_DIR='${params_dir}' JOB_SCRIPT='${job_script_path}' SETUP_SCRIPT='${setup_script_path}' sh -s" <<'EOF'
+            "RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' PARAMS_DIR='${params_dir}' JOB_SCRIPT='${job_script_path}' SETUP_SCRIPT='${setup_script_path}' ADJUSTED_PARAMS_DIR='${adjusted_params_dir}' RUN_ID_SUFFIX='${run_suffix}' sh -s" <<'EOF'
             set -eu
 
             if [ ! -f "$SETUP_SCRIPT" ]; then
@@ -122,6 +124,11 @@ jobs:
 
             if [ ! -f "$JOB_SCRIPT" ]; then
               echo "Missing job script: $JOB_SCRIPT" >&2
+              exit 1
+            fi
+
+            if ! command -v jq >/dev/null 2>&1; then
+              echo "jq is required on the cluster to adjust param files" >&2
               exit 1
             fi
 
@@ -141,8 +148,16 @@ jobs:
               exit 1
             fi
 
+            mkdir -p "$ADJUSTED_PARAMS_DIR"
+
             printf '%s\n' "$param_list" | while IFS= read -r param_file; do
-              PIONEER_DIR="$PIONEER_DIR" PARAM_FILE="$param_file" bsub -w "ended($setup_job_id)" < "$JOB_SCRIPT"
+              rel_path="${param_file#${PARAMS_DIR}/}"
+              adjusted_path="$ADJUSTED_PARAMS_DIR/$rel_path"
+              mkdir -p "$(dirname "$adjusted_path")"
+
+              jq --arg suffix "$RUN_ID_SUFFIX" '.results = (.results | rtrimstr("/") + "/" + $suffix)' "$param_file" > "$adjusted_path"
+
+              PIONEER_DIR="$PIONEER_DIR" PARAM_FILE="$adjusted_path" bsub -w "ended($setup_job_id)" < "$JOB_SCRIPT"
             done
           EOF
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -151,7 +151,7 @@ jobs:
               exit 1
             fi
 
-            setup_submit=$(PIONEER_DIR="$PIONEER_DIR" bsub < "$SETUP_SCRIPT")
+            setup_submit=$(PIONEER_DIR="$PIONEER_DIR" PIONEER_ENTRAPMENT_DIR="$ENTRAPMENT_DIR" bsub < "$SETUP_SCRIPT")
             setup_job_id=$(printf '%s\n' "$setup_submit" | sed -n 's/Job <\([0-9]\+\)>.*$/\1/p' | head -n 1)
 
             if [ -z "$setup_job_id" ]; then

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -102,7 +102,7 @@ jobs:
           pioneer_dir="${CLUSTER_PIONEER_DIR:-${remote_run_dir}/pioneer}"
           params_dir="${remote_run_dir}/regression-configs/params"
           job_script_path="${remote_run_dir}/${REGRESSION_JOB_SCRIPT:-regression-configs/job_scripts/search_dia.bsub}"
-          setup_script_path="${remote_run_dir}/${SETUP_JOB_SCRIPT:-regression-configs/job_scripts/setup_pioneer_env.lsf}"
+          setup_script_path="${remote_run_dir}/${SETUP_JOB_SCRIPT:-regression-configs/job_scripts/setup.bsub}"
 
           ssh_options=(
             -o BatchMode=yes

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -180,7 +180,7 @@ jobs:
 
             printf '%s\n' "$param_list" | while IFS= read -r param_file; do
               rel_path="${param_file#${PARAMS_DIR}/}"
-              dataset_name="${rel_path%%/*}"
+              dataset_dir_name="${rel_path%%/*}"
               search_name="$(basename "${rel_path%.*}")"
               adjusted_path="$ADJUSTED_PARAMS_DIR/$rel_path"
               mkdir -p "$(dirname "$adjusted_path")"
@@ -194,6 +194,7 @@ jobs:
 
               base_results=${results_path%/}
               adjusted_results="${base_results}/${RUN_ID_SUFFIX}"
+              dataset_name="$(basename "$(dirname "$adjusted_results")")"
               escaped_results=$(printf '%s\n' "$adjusted_results" | sed 's/[&/]/\\&/g')
 
               sed "s|\"results\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"results\": \"${escaped_results}\"|" "$param_file" > "$adjusted_path"
@@ -209,7 +210,7 @@ jobs:
                 exit 1
               fi
 
-              echo "$search_job_id" >> "$job_id_dir/${dataset_name}.search"
+              echo "$search_job_id" >> "$job_id_dir/${dataset_dir_name}.search"
             done
 
             dataset_dirs=$(find "$PARAMS_DIR" -mindepth 1 -maxdepth 1 -type d -print)

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -183,14 +183,6 @@ jobs:
           version: ${{ matrix.version }}
           arch: x64
 
-      - name: Instantiate PioneerEntrapment project
-        if: ${{ false }}
-        run: julia --threads auto --project=PioneerEntrapment.jl -e 'using Pkg; Pkg.instantiate()'
-
-      - name: Instantiate project
-        if: ${{ false }}
-        run: julia --threads auto --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.build()'
-
       - name: Run SearchDIA for all parameter files
         if: ${{ false }}
         env:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -39,6 +39,7 @@ jobs:
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
           CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
           GITHUB_SHA: ${{ github.sha }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         shell: bash
         run: |
           set -euo pipefail
@@ -46,6 +47,7 @@ jobs:
           remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
           remote_run_dir="${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           pioneer_dir="${remote_run_dir}/pioneer"
+          pioneer_repo="https://github.com/${GITHUB_REPOSITORY}"
 
           echo "CLUSTER_RUN_DIR=${remote_run_dir}" >> "$GITHUB_ENV"
           echo "CLUSTER_PIONEER_DIR=${pioneer_dir}" >> "$GITHUB_ENV"
@@ -57,7 +59,7 @@ jobs:
             -o ConnectTimeout=30
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' TARGET_SHA='${GITHUB_SHA}' sh -s" <<'EOF'
+          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${GITHUB_SHA}' sh -s" <<'EOF'
             set -eu
             mkdir -p "$RUN_DIR"
             cd "$RUN_DIR"
@@ -72,7 +74,7 @@ jobs:
             if [ -d "$PIONEER_DIR/.git" ]; then
               git -C "$PIONEER_DIR" fetch --all --tags
             else
-              git clone https://github.com/GoldfarbLab/Pioneer.jl "$PIONEER_DIR"
+              git clone "$PIONEER_REPO" "$PIONEER_DIR"
             fi
 
             git -C "$PIONEER_DIR" checkout --force "$TARGET_SHA"

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -134,20 +134,16 @@ jobs:
               exit 1
             fi
 
-            found=0
-            for param_file in "$PARAMS_DIR"/*.json; do
-              if [ ! -f "$param_file" ]; then
-                continue
-              fi
+            param_list=$(find "$PARAMS_DIR" -type f -name 'search*.json' -print)
 
-              found=1
-              PIONEER_DIR="$PIONEER_DIR" PARAM_FILE="$param_file" bsub -w "ended($setup_job_id)" < "$JOB_SCRIPT"
-            done
-
-            if [ "$found" -eq 0 ]; then
+            if [ -z "$param_list" ]; then
               echo "No parameter JSON files found in $PARAMS_DIR" >&2
               exit 1
             fi
+
+            printf '%s\n' "$param_list" | while IFS= read -r param_file; do
+              PIONEER_DIR="$PIONEER_DIR" PARAM_FILE="$param_file" bsub -w "ended($setup_job_id)" < "$JOB_SCRIPT"
+            done
           EOF
 
       - name: Cleanup regression configs on cluster

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -35,7 +35,7 @@ jobs:
           # Restrict permissions on the private key (inheritance removed, user read-only)
           $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
           icacls $privateKeyPath /inheritance:r | Out-Null
-          icacls $privateKeyPath /grant:r "$currentUser:(R)" | Out-Null
+          icacls $privateKeyPath /grant:r "${currentUser}:(R)" | Out-Null
 
           # Preload host key to avoid interactive prompt
           ssh-keyscan -H $env:CLUSTER_HOST | Out-File -FilePath (Join-Path $sshDir 'known_hosts') -Append

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -50,18 +50,18 @@ jobs:
 
           $remoteRunRoot = if ($env:CLUSTER_RUN_ROOT) { $env:CLUSTER_RUN_ROOT } else { '$HOME/pioneer-regressions' }
           $remoteCommand = @"
-set -eu
-RUN_ROOT="$remoteRunRoot"
-mkdir -p "$RUN_ROOT"
-cd "$RUN_ROOT"
+            set -eu
+            RUN_ROOT="$remoteRunRoot"
+            mkdir -p "$RUN_ROOT"
+            cd "$RUN_ROOT"
 
-if [ -d regression-configs/.git ]; then
-  git -C regression-configs fetch --all
-  git -C regression-configs reset --hard origin/main
-else
-  git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs
-fi
-"@
+            if [ -d regression-configs/.git ]; then
+              git -C regression-configs fetch --all
+              git -C regression-configs reset --hard origin/main
+            else
+              git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs
+            fi
+            "@
 
           $sshArgs = @(
             '-o', 'BatchMode=yes',

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -170,10 +170,13 @@ jobs:
             mkdir -p "$ADJUSTED_PARAMS_DIR"
             job_id_dir="$RUN_DIR/job-ids"
             mkdir -p "$job_id_dir"
+            manifest_file="$job_id_dir/expected_results.txt"
+            : > "$manifest_file"
 
             printf '%s\n' "$param_list" | while IFS= read -r param_file; do
               rel_path="${param_file#${PARAMS_DIR}/}"
               dataset_name="${rel_path%%/*}"
+              search_name="$(basename "${rel_path%.*}")"
               adjusted_path="$ADJUSTED_PARAMS_DIR/$rel_path"
               mkdir -p "$(dirname "$adjusted_path")"
 
@@ -189,6 +192,8 @@ jobs:
               escaped_results=$(printf '%s\n' "$adjusted_results" | sed 's/[&/]/\\&/g')
 
               sed "s|\"results\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"results\": \"${escaped_results}\"|" "$param_file" > "$adjusted_path"
+
+              echo "${dataset_name}/${search_name}" >> "$manifest_file"
 
               search_submit=$(PIONEER_DIR="$PIONEER_DIR" PARAM_FILE="$adjusted_path" bsub -w "ended($setup_job_id)" < "$JOB_SCRIPT")
               search_job_id=$(printf '%s\n' "$search_submit" | sed -n 's/Job <\([0-9]\+\)>.*$/\1/p' | head -n 1)
@@ -267,3 +272,110 @@ jobs:
               fi
             done
           EOF
+
+      - name: Wait for regression outputs on shared storage
+        env:
+          CLUSTER_RUN_DIR: ${{ env.CLUSTER_RUN_DIR }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          run_dir="${CLUSTER_RUN_DIR:?CLUSTER_RUN_DIR not set}"
+          manifest_path="$run_dir/job-ids/expected_results.txt"
+          results_root="$run_dir/results"
+
+          if [ ! -f "$manifest_path" ]; then
+            echo "Expected manifest not found at $manifest_path" >&2
+            exit 1
+          fi
+
+          mapfile -t manifest_entries < "$manifest_path"
+
+          if [ "${#manifest_entries[@]}" -eq 0 ]; then
+            echo "Manifest is empty; cannot determine expected results" >&2
+            exit 1
+          fi
+
+          declare -A seen
+          unique_entries=()
+          for entry in "${manifest_entries[@]}"; do
+            clean_entry="${entry%$'\r'}"
+            [ -n "$clean_entry" ] || continue
+            if [[ -z "${seen[$clean_entry]+x}" ]]; then
+              seen[$clean_entry]=1
+              unique_entries+=("$clean_entry")
+            fi
+          done
+
+          total_expected=${#unique_entries[@]}
+          poll_interval=60
+          max_attempts=720
+          attempt=1
+          progress_log=()
+
+          while :; do
+            found=0
+            missing=()
+
+            for entry in "${unique_entries[@]}"; do
+              dataset="${entry%%/*}"
+              search="${entry#*/}"
+              dataset_dir="$results_root/$dataset"
+              metrics_path="$dataset_dir/metrics_${dataset}_${search}.json"
+
+              log_present=""
+              if compgen -G "$dataset_dir/*${search}*.log" > /dev/null; then
+                log_present=1
+              elif compgen -G "$dataset_dir/*${search}*.log.gz" > /dev/null; then
+                log_present=1
+              fi
+
+              if [ -f "$metrics_path" ] || [ -n "$log_present" ]; then
+                found=$((found + 1))
+              else
+                missing+=("$entry")
+              fi
+            done
+
+            progress_log+=("Attempt ${attempt}: ${found}/${total_expected} ready")
+
+            if [ "${#missing[@]}" -eq 0 ]; then
+              echo "All expected regression outputs detected."
+              break
+            fi
+
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "Timeout waiting for regression outputs after $((poll_interval * max_attempts / 60)) minutes" >&2
+              printf 'Still missing:\n' >&2
+              printf '  %s\n' "${missing[@]}" >&2
+              {
+                echo "## Cluster results polling"
+                echo "- Run directory: $run_dir"
+                echo "- Expected outputs: $total_expected"
+                echo "- Status: timed out"
+                echo "- Missing entries:"
+                for entry in "${missing[@]}"; do
+                  echo "  - $entry"
+                done
+                echo "- Progress log:"
+                for line in "${progress_log[@]}"; do
+                  echo "  - $line"
+                done
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+            fi
+
+            attempt=$((attempt + 1))
+            sleep "$poll_interval"
+          done
+
+          {
+            echo "## Cluster results polling"
+            echo "- Run directory: $run_dir"
+            echo "- Expected outputs: $total_expected"
+            echo "- Status: completed"
+            echo "- Progress log:"
+            for line in "${progress_log[@]}"; do
+              echo "  - $line"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -96,7 +96,6 @@ jobs:
           remote_run_dir="${CLUSTER_RUN_DIR:-${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}"
           pioneer_dir="${CLUSTER_PIONEER_DIR:-${remote_run_dir}/pioneer}"
           params_dir="${remote_run_dir}/regression-configs/params"
-          logs_dir="${remote_run_dir}/logs"
           job_script_path="${remote_run_dir}/${REGRESSION_JOB_SCRIPT:-regression-configs/job_scripts/search_dia.bsub}"
 
           ssh_options=(
@@ -107,15 +106,13 @@ jobs:
           )
 
           timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-            "RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' PARAMS_DIR='${params_dir}' LOGS_DIR='${logs_dir}' JOB_SCRIPT='${job_script_path}' sh -s" <<'EOF'
+            "RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' PARAMS_DIR='${params_dir}' JOB_SCRIPT='${job_script_path}' sh -s" <<'EOF'
             set -eu
 
             if [ ! -f "$JOB_SCRIPT" ]; then
               echo "Missing job script: $JOB_SCRIPT" >&2
               exit 1
             fi
-
-            mkdir -p "$LOGS_DIR"
 
             found=0
             for param_file in "$PARAMS_DIR"/*.json; do
@@ -124,9 +121,7 @@ jobs:
               fi
 
               found=1
-              base_name="$(basename "$param_file" .json)"
-
-              PIONEER_DIR="$PIONEER_DIR" PARAM_FILE="$param_file" LOGS_DIR="$LOGS_DIR" JOB_NAME="pioneer-search-${base_name}" bsub < "$JOB_SCRIPT"
+              PIONEER_DIR="$PIONEER_DIR" PARAM_FILE="$param_file" bsub < "$JOB_SCRIPT"
             done
 
             if [ "$found" -eq 0 ]; then

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -249,7 +249,13 @@ jobs:
                 continue
               fi
 
-              metrics_submit=$(PIONEER_DIR="$PIONEER_DIR" PIONEER_ENTRAPMENT_DIR="$ENTRAPMENT_DIR" PARAMS_DIR="$param_dataset_dir" METRICS_FILE="$metrics_file" EXPERIMENTAL_DESIGN_FILE="$exp_design_file" RUN_ID_SUFFIX="$RUN_ID_SUFFIX" bsub -w "$dep_expr" < "$METRICS_SCRIPT")
+              metrics_submit=$(\
+                PIONEER_DIR="$PIONEER_DIR" \
+                ENTRAPMENT_ANALYSES_PATH="$ENTRAPMENT_DIR" \
+                PIONEER_PARAMS_DIR="$param_dataset_dir" \
+                PIONEER_METRICS_FILE="$metrics_file" \
+                PIONEER_EXPERIMENTAL_DESIGN="$exp_design_file" \
+                bsub -w "$dep_expr" < "$METRICS_SCRIPT")
 
               metrics_job_id=$(printf '%s\n' "$metrics_submit" | sed -n 's/Job <\([0-9]\+\)>.*$/\1/p' | head -n 1)
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -51,19 +51,20 @@ jobs:
           $ProgressPreference = 'SilentlyContinue'
 
           $remoteRunRoot = if ($env:CLUSTER_RUN_ROOT) { $env:CLUSTER_RUN_ROOT } else { '$HOME/pioneer-regressions' }
-          $remoteCommand = @"
-set -eu
-RUN_ROOT="$remoteRunRoot"
-mkdir -p "$RUN_ROOT"
-cd "$RUN_ROOT"
-
-if [ -d regression-configs/.git ]; then
-  git -C regression-configs fetch --all
-  git -C regression-configs reset --hard origin/main
-else
-  git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs
-fi
-"@
+          $remoteLines = @(
+            'set -eu',
+            "RUN_ROOT=\"$remoteRunRoot\"",
+            'mkdir -p "$RUN_ROOT"',
+            'cd "$RUN_ROOT"',
+            '',
+            'if [ -d regression-configs/.git ]; then',
+            '  git -C regression-configs fetch --all',
+            '  git -C regression-configs reset --hard origin/main',
+            'else',
+            '  git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs',
+            'fi'
+          )
+          $remoteCommand = $remoteLines -join "`n"
 
           $sshArgs = @(
             '-o', 'BatchMode=yes',

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -31,9 +31,11 @@ jobs:
 
           $privateKeyPath = Join-Path $sshDir 'id_rsa'
           Set-Content -Path $privateKeyPath -Value $env:CLUSTER_SSH_KEY -NoNewline
+
           # Restrict permissions on the private key (inheritance removed, user read-only)
+          $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
           icacls $privateKeyPath /inheritance:r | Out-Null
-          icacls $privateKeyPath /grant:r "$($env:USERNAME):(R)" | Out-Null
+          icacls $privateKeyPath /grant:r "$currentUser:(R)" | Out-Null
 
           # Preload host key to avoid interactive prompt
           ssh-keyscan -H $env:CLUSTER_HOST | Out-File -FilePath (Join-Path $sshDir 'known_hosts') -Append
@@ -50,18 +52,18 @@ jobs:
 
           $remoteRunRoot = if ($env:CLUSTER_RUN_ROOT) { $env:CLUSTER_RUN_ROOT } else { '$HOME/pioneer-regressions' }
           $remoteCommand = @"
-            set -eu
-            RUN_ROOT="$remoteRunRoot"
-            mkdir -p "$RUN_ROOT"
-            cd "$RUN_ROOT"
+set -eu
+RUN_ROOT="$remoteRunRoot"
+mkdir -p "$RUN_ROOT"
+cd "$RUN_ROOT"
 
-            if [ -d regression-configs/.git ]; then
-              git -C regression-configs fetch --all
-              git -C regression-configs reset --hard origin/main
-            else
-              git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs
-            fi
-            "@
+if [ -d regression-configs/.git ]; then
+  git -C regression-configs fetch --all
+  git -C regression-configs reset --hard origin/main
+else
+  git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs
+fi
+"@
 
           $sshArgs = @(
             '-o', 'BatchMode=yes',

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -87,6 +87,7 @@ jobs:
           CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
           CLUSTER_RUN_DIR: ${{ env.CLUSTER_RUN_DIR }}
           CLUSTER_PIONEER_DIR: ${{ env.CLUSTER_PIONEER_DIR }}
+          REGRESSION_JOB_SCRIPT: ${{ vars.REGRESSION_JOB_SCRIPT }}
         shell: bash
         run: |
           set -euo pipefail
@@ -96,7 +97,7 @@ jobs:
           pioneer_dir="${CLUSTER_PIONEER_DIR:-${remote_run_dir}/pioneer}"
           params_dir="${remote_run_dir}/regression-configs/params"
           logs_dir="${remote_run_dir}/logs"
-          scripts_dir="${remote_run_dir}/scripts"
+          job_script_path="${remote_run_dir}/${REGRESSION_JOB_SCRIPT:-regression-configs/job_scripts/search_dia.bsub}"
 
           ssh_options=(
             -o BatchMode=yes
@@ -106,10 +107,15 @@ jobs:
           )
 
           timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-            "RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' PARAMS_DIR='${params_dir}' LOGS_DIR='${logs_dir}' SCRIPTS_DIR='${scripts_dir}' sh -s" <<'EOF'
+            "RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' PARAMS_DIR='${params_dir}' LOGS_DIR='${logs_dir}' JOB_SCRIPT='${job_script_path}' sh -s" <<'EOF'
             set -eu
 
-            mkdir -p "$LOGS_DIR" "$SCRIPTS_DIR"
+            if [ ! -f "$JOB_SCRIPT" ]; then
+              echo "Missing job script: $JOB_SCRIPT" >&2
+              exit 1
+            fi
+
+            mkdir -p "$LOGS_DIR"
 
             found=0
             for param_file in "$PARAMS_DIR"/*.json; do
@@ -119,36 +125,52 @@ jobs:
 
               found=1
               base_name="$(basename "$param_file" .json)"
-              job_script="$SCRIPTS_DIR/search-${base_name}.sh"
 
-              cat > "$job_script" <<EOS
-#!/bin/bash
-#BSUB -g /d.goldfarb/compute
-#BSUB -G compute-d.goldfarb
-#BSUB -a 'docker(julia:1.11-bullseye)'
-#BSUB -J pioneer-search-${base_name}
-#BSUB -q general
-#BSUB -R "rusage[mem=32GB] span[hosts=1]"
-#BSUB -n 16
-#BSUB -W 3000
-#BSUB -M 32GB
-#BSUB -o ${LOGS_DIR}/search-${base_name}.%J.out.txt
-#BSUB -e ${LOGS_DIR}/search-${base_name}.%J.err.txt
-
-source "$LSF_SCRIPT_PATH/config.sh"
-
-cd "${PIONEER_DIR}"
-julia --project=. --threads auto -e "using Pioneer; SearchDIA(\"${param_file}\")"
-EOS
-
-              chmod +x "$job_script"
-              bsub < "$job_script"
+              PIONEER_DIR="$PIONEER_DIR" PARAM_FILE="$param_file" LOGS_DIR="$LOGS_DIR" JOB_NAME="pioneer-search-${base_name}" bsub < "$JOB_SCRIPT"
             done
 
             if [ "$found" -eq 0 ]; then
               echo "No parameter JSON files found in $PARAMS_DIR" >&2
               exit 1
             fi
+          EOF
+
+      - name: Show regression job script content
+        env:
+          CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
+          CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
+          CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
+          CLUSTER_RUN_DIR: ${{ env.CLUSTER_RUN_DIR }}
+          REGRESSION_JOB_SCRIPT: ${{ vars.REGRESSION_JOB_SCRIPT }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
+          remote_run_dir="${CLUSTER_RUN_DIR:-${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}"
+          job_script_path="${remote_run_dir}/${REGRESSION_JOB_SCRIPT:-regression-configs/job_scripts/search_dia.bsub}"
+
+          ssh_options=(
+            -o BatchMode=yes
+            -o ServerAliveInterval=60
+            -o ServerAliveCountMax=3
+            -o ConnectTimeout=30
+          )
+
+          timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+            "JOB_SCRIPT='${job_script_path}' sh -s" <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+            set -eu
+
+            if [ ! -f "$JOB_SCRIPT" ]; then
+              echo "Job script not found: $JOB_SCRIPT" >&2
+              exit 1
+            fi
+
+            echo "### Submitted job script"
+            echo "Path: $JOB_SCRIPT"
+            echo '```bash'
+            cat "$JOB_SCRIPT"
+            echo '```'
           EOF
 
       - name: Cleanup regression configs on cluster

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -355,7 +355,7 @@ jobs:
             echo "$progress_entry" | tee -a "$GITHUB_STEP_SUMMARY"
 
             if [ "${#missing[@]}" -gt 0 ]; then
-              echo "Missing entries (sample):"
+              echo "Missing entries:"
               printf '  %s\n' "${missing[@]}"
             fi
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -430,6 +430,8 @@ jobs:
           fi
 
           shopt -s dotglob nullglob
+          entries=()
+
           for entry in "$run_dir"/* "$run_dir"/.*; do
             base="$(basename "$entry")"
             if [ "$base" = "." ] || [ "$base" = ".." ]; then
@@ -440,7 +442,37 @@ jobs:
               continue
             fi
 
-            rm -rf -- "$entry"
+            entries+=("$entry")
           done
+
+          failed=()
+
+          for entry in "${entries[@]}"; do
+            removed=0
+            for attempt in $(seq 1 5); do
+              if rm -rf -- "$entry"; then
+                echo "Removed $entry (attempt $attempt)"
+                removed=1
+                break
+              fi
+
+              echo "Removal failed for $entry (attempt $attempt); retrying in 5s" >&2
+              sleep 5
+            done
+
+            if [ "$removed" -ne 1 ]; then
+              if [ -e "$entry" ]; then
+                failed+=("$entry")
+              else
+                echo "$entry no longer exists after retries; continuing"
+              fi
+            fi
+          done
+
+          if [ "${#failed[@]}" -gt 0 ]; then
+            echo "Failed to remove the following entries:" >&2
+            printf '  %s\n' "${failed[@]}" >&2
+            exit 1
+          fi
 
           echo "Cleanup complete; preserved results at $results_dir" | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -21,41 +21,69 @@ jobs:
         env:
           CLUSTER_SSH_KEY: ${{ secrets.CLUSTER_SSH_KEY }}
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
-        shell: bash
+        shell: pwsh
         run: |
-          set -euo pipefail
-          install -m 700 -d ~/.ssh
-          echo "$CLUSTER_SSH_KEY" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
+          $ErrorActionPreference = 'Stop'
+          $ProgressPreference = 'SilentlyContinue'
+
+          $sshDir = Join-Path $HOME '.ssh'
+          New-Item -ItemType Directory -Path $sshDir -Force | Out-Null
+
+          $privateKeyPath = Join-Path $sshDir 'id_rsa'
+          Set-Content -Path $privateKeyPath -Value $env:CLUSTER_SSH_KEY -NoNewline
+          # Restrict permissions on the private key (inheritance removed, user read-only)
+          icacls $privateKeyPath /inheritance:r | Out-Null
+          icacls $privateKeyPath /grant:r "$($env:USERNAME):(R)" | Out-Null
+
           # Preload host key to avoid interactive prompt
-          ssh-keyscan -H "$CLUSTER_HOST" >> ~/.ssh/known_hosts
+          ssh-keyscan -H $env:CLUSTER_HOST | Out-File -FilePath (Join-Path $sshDir 'known_hosts') -Append
 
       - name: Checkout regression configs on cluster
         env:
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
           CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
-        shell: bash
+        shell: pwsh
         run: |
-          set -euo pipefail
-          # Guard the SSH session to avoid hanging forever if the cluster is unreachable
-          timeout 5m ssh \
-            -o BatchMode=yes \
-            -o ServerAliveInterval=60 \
-            -o ServerAliveCountMax=3 \
-            "${CLUSTER_USERNAME}@${CLUSTER_HOST}" <<'EOF'
-          set -euo pipefail
-          RUN_ROOT="${CLUSTER_RUN_ROOT:-$HOME/pioneer-regressions}"
-          mkdir -p "$RUN_ROOT"
-          cd "$RUN_ROOT"
+          $ErrorActionPreference = 'Stop'
+          $ProgressPreference = 'SilentlyContinue'
 
-          if [ -d regression-configs/.git ]; then
-            git -C regression-configs fetch --all
-            git -C regression-configs reset --hard origin/main
-          else
-            git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs
-          fi
-          EOF
+          $remoteRunRoot = if ($env:CLUSTER_RUN_ROOT) { $env:CLUSTER_RUN_ROOT } else { '$HOME/pioneer-regressions' }
+          $remoteCommand = @"
+set -euo pipefail
+RUN_ROOT="$remoteRunRoot"
+mkdir -p "$RUN_ROOT"
+cd "$RUN_ROOT"
+
+if [ -d regression-configs/.git ]; then
+  git -C regression-configs fetch --all
+  git -C regression-configs reset --hard origin/main
+else
+  git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs
+fi
+"@
+
+          $sshArgs = @(
+            '-o', 'BatchMode=yes',
+            '-o', 'ServerAliveInterval=60',
+            '-o', 'ServerAliveCountMax=3',
+            '-o', 'ConnectTimeout=30',
+            "$($env:CLUSTER_USERNAME)@$($env:CLUSTER_HOST)",
+            "bash -lc `"$remoteCommand`""
+          )
+
+          $sshProcess = Start-Process -FilePath 'ssh' -ArgumentList $sshArgs -NoNewWindow -PassThru -RedirectStandardOutput 'ssh_regression_checkout_stdout.log' -RedirectStandardError 'ssh_regression_checkout_stderr.log'
+
+          if (-not $sshProcess.WaitForExit(300000)) {
+            $sshProcess.Kill()
+            throw 'SSH command timed out after 300 seconds'
+          }
+
+          Get-Content 'ssh_regression_checkout_stdout.log'
+          if ($sshProcess.ExitCode -ne 0) {
+            Get-Content 'ssh_regression_checkout_stderr.log' | Write-Error
+            throw "SSH command failed with exit code $($sshProcess.ExitCode)"
+          }
 
       - name: Checkout regression parameter configs
         uses: actions/checkout@v5

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -63,6 +63,7 @@ jobs:
 
           echo "CLUSTER_RUN_DIR=${remote_run_dir}" >> "$GITHUB_ENV"
           echo "CLUSTER_RUN_DIR_MOUNT=${mount_run_dir}" >> "$GITHUB_ENV"
+          echo "CLUSTER_RUN_SUFFIX=${run_suffix}" >> "$GITHUB_ENV"
           echo "CLUSTER_PIONEER_DIR=${pioneer_dir}" >> "$GITHUB_ENV"
           echo "CLUSTER_ENTRAPMENT_DIR=${entrapment_dir}" >> "$GITHUB_ENV"
           echo "CLUSTER_DEPOT_DIR=${depot_dir}" >> "$GITHUB_ENV"
@@ -406,23 +407,23 @@ jobs:
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
           CLUSTER_RUN_DIR: ${{ env.CLUSTER_RUN_DIR }}
-          CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
+          CLUSTER_RUN_SUFFIX: ${{ env.CLUSTER_RUN_SUFFIX }}
           CLEANUP_JOB_SCRIPT: ${{ vars.CLEANUP_JOB_SCRIPT }}
         shell: bash
         run: |
           set -euo pipefail
 
-          remote_run_root="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
-          remote_run_dir="${CLUSTER_RUN_DIR:-${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}"
-          cleanup_script_path="${remote_run_dir}/${CLEANUP_JOB_SCRIPT:-regression-configs/job_scripts/cleanup.bsub}"
+          remote_run_dir="${CLUSTER_RUN_DIR:?CLUSTER_RUN_DIR not set}"
 
-          case "$remote_run_dir" in
-            /storage1/fs1/d.goldfarb/Active/Automation/Pioneer/run-*) ;;
-            *)
-              echo "Refusing to submit cleanup for unexpected run directory: $remote_run_dir" >&2
-              exit 1
-              ;;
-          esac
+          cleanup_script_path="${CLEANUP_JOB_SCRIPT:-regression-configs/job_scripts/cleanup.bsub}"
+          if [[ "$cleanup_script_path" != /* ]]; then
+            cleanup_script_path="${remote_run_dir}/${cleanup_script_path}"
+          fi
+
+          if [[ -n "${CLUSTER_RUN_SUFFIX:-}" ]] && [[ "${remote_run_dir##*/}" != "${CLUSTER_RUN_SUFFIX}" ]]; then
+            echo "Run directory mismatch: expected suffix ${CLUSTER_RUN_SUFFIX}, got ${remote_run_dir##*/}" >&2
+            exit 1
+          fi
 
           ssh_options=(
             -o BatchMode=yes

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   regression:
     name: Julia ${{ matrix.version }} regression sweep
-    runs-on: [self-hosted, pioneer-regression]
+    runs-on: [self-hosted, Linux]
     timeout-minutes: 7200
     strategy:
       matrix:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -21,7 +21,7 @@ jobs:
         env:
           CLUSTER_SSH_KEY: ${{ secrets.CLUSTER_SSH_KEY }}
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = 'Stop'
           $ProgressPreference = 'SilentlyContinue'
@@ -43,7 +43,7 @@ jobs:
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
           CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = 'Stop'
           $ProgressPreference = 'SilentlyContinue'

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -80,6 +80,77 @@ jobs:
             git -C "$PIONEER_DIR" checkout --force "$TARGET_SHA"
           EOF
 
+      - name: Submit regression search jobs on cluster
+        env:
+          CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
+          CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
+          CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
+          CLUSTER_RUN_DIR: ${{ env.CLUSTER_RUN_DIR }}
+          CLUSTER_PIONEER_DIR: ${{ env.CLUSTER_PIONEER_DIR }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
+          remote_run_dir="${CLUSTER_RUN_DIR:-${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}"
+          pioneer_dir="${CLUSTER_PIONEER_DIR:-${remote_run_dir}/pioneer}"
+          params_dir="${remote_run_dir}/regression-configs/params"
+          logs_dir="${remote_run_dir}/logs"
+          scripts_dir="${remote_run_dir}/scripts"
+
+          ssh_options=(
+            -o BatchMode=yes
+            -o ServerAliveInterval=60
+            -o ServerAliveCountMax=3
+            -o ConnectTimeout=30
+          )
+
+          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+            "RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' PARAMS_DIR='${params_dir}' LOGS_DIR='${logs_dir}' SCRIPTS_DIR='${scripts_dir}' sh -s" <<'EOF'
+            set -eu
+
+            mkdir -p "$LOGS_DIR" "$SCRIPTS_DIR"
+
+            found=0
+            for param_file in "$PARAMS_DIR"/*.json; do
+              if [ ! -f "$param_file" ]; then
+                continue
+              fi
+
+              found=1
+              base_name="$(basename "$param_file" .json)"
+              job_script="$SCRIPTS_DIR/search-${base_name}.sh"
+
+              cat > "$job_script" <<EOS
+#!/bin/bash
+#BSUB -g /d.goldfarb/compute
+#BSUB -G compute-d.goldfarb
+#BSUB -a 'docker(julia:1.11-bullseye)'
+#BSUB -J pioneer-search-${base_name}
+#BSUB -q general
+#BSUB -R "rusage[mem=32GB] span[hosts=1]"
+#BSUB -n 16
+#BSUB -W 3000
+#BSUB -M 32GB
+#BSUB -o ${LOGS_DIR}/search-${base_name}.%J.out.txt
+#BSUB -e ${LOGS_DIR}/search-${base_name}.%J.err.txt
+
+source "$LSF_SCRIPT_PATH/config.sh"
+
+cd "${PIONEER_DIR}"
+julia --project=. --threads auto -e "using Pioneer; SearchDIA(\"${param_file}\")"
+EOS
+
+              chmod +x "$job_script"
+              bsub < "$job_script"
+            done
+
+            if [ "$found" -eq 0 ]; then
+              echo "No parameter JSON files found in $PARAMS_DIR" >&2
+              exit 1
+            fi
+          EOF
+
       - name: Cleanup regression configs on cluster
         if: ${{ always() }}
         env:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -21,72 +21,50 @@ jobs:
         env:
           CLUSTER_SSH_KEY: ${{ secrets.CLUSTER_SSH_KEY }}
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
-        shell: powershell
+        shell: bash
         run: |
-          $ErrorActionPreference = 'Stop'
-          $ProgressPreference = 'SilentlyContinue'
+          set -euo pipefail
 
-          $sshDir = Join-Path $HOME '.ssh'
-          New-Item -ItemType Directory -Path $sshDir -Force | Out-Null
-
-          $privateKeyPath = Join-Path $sshDir 'id_rsa'
-          Set-Content -Path $privateKeyPath -Value $env:CLUSTER_SSH_KEY -NoNewline
-
-          # Restrict permissions on the private key (inheritance removed, user read-only)
-          $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
-          icacls $privateKeyPath /inheritance:r | Out-Null
-          icacls $privateKeyPath /grant:r "${currentUser}:(R)" | Out-Null
+          mkdir -p ~/.ssh
+          install -m 600 /dev/null ~/.ssh/id_rsa
+          printf '%s' "$CLUSTER_SSH_KEY" > ~/.ssh/id_rsa
 
           # Preload host key to avoid interactive prompt
-          ssh-keyscan -H $env:CLUSTER_HOST | Out-File -FilePath (Join-Path $sshDir 'known_hosts') -Append
+          ssh-keyscan -H "$CLUSTER_HOST" >> ~/.ssh/known_hosts
 
       - name: Checkout regression configs on cluster
         env:
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
           CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
-        shell: powershell
+        shell: bash
         run: |
-          $ErrorActionPreference = 'Stop'
-          $ProgressPreference = 'SilentlyContinue'
+          set -euo pipefail
 
-          $remoteRunRoot = if ($env:CLUSTER_RUN_ROOT) { $env:CLUSTER_RUN_ROOT } else { '$HOME/pioneer-regressions' }
-          $remoteLines = @(
-            'set -eu',
-            "RUN_ROOT=\"$remoteRunRoot\"",
-            'mkdir -p "$RUN_ROOT"',
-            'cd "$RUN_ROOT"',
-            '',
-            'if [ -d regression-configs/.git ]; then',
-            '  git -C regression-configs fetch --all',
-            '  git -C regression-configs reset --hard origin/main',
-            'else',
-            '  git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs',
-            'fi'
-          )
-          $remoteCommand = $remoteLines -join "`n"
+          remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
 
-          $sshArgs = @(
-            '-o', 'BatchMode=yes',
-            '-o', 'ServerAliveInterval=60',
-            '-o', 'ServerAliveCountMax=3',
-            '-o', 'ConnectTimeout=30',
-            "$($env:CLUSTER_USERNAME)@$($env:CLUSTER_HOST)",
-            "sh -c `"$remoteCommand`""
+          remote_script=$(cat <<'EOF'
+set -eu
+mkdir -p "$RUN_ROOT"
+cd "$RUN_ROOT"
+
+if [ -d regression-configs/.git ]; then
+  git -C regression-configs fetch --all
+  git -C regression-configs reset --hard origin/main
+else
+  git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs
+fi
+EOF
+)
+
+          ssh_options=(
+            -o BatchMode=yes
+            -o ServerAliveInterval=60
+            -o ServerAliveCountMax=3
+            -o ConnectTimeout=30
           )
 
-          $sshProcess = Start-Process -FilePath 'ssh' -ArgumentList $sshArgs -NoNewWindow -PassThru -RedirectStandardOutput 'ssh_regression_checkout_stdout.log' -RedirectStandardError 'ssh_regression_checkout_stderr.log'
-
-          if (-not $sshProcess.WaitForExit(300000)) {
-            $sshProcess.Kill()
-            throw 'SSH command timed out after 300 seconds'
-          }
-
-          Get-Content 'ssh_regression_checkout_stdout.log'
-          if ($sshProcess.ExitCode -ne 0) {
-            Get-Content 'ssh_regression_checkout_stderr.log' | Write-Error
-            throw "SSH command failed with exit code $($sshProcess.ExitCode)"
-          }
+          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT=\"${remote_run_root}\" sh -c \"${remote_script}\""
 
       - name: Checkout regression parameter configs
         uses: actions/checkout@v5
@@ -120,5 +98,5 @@ jobs:
       - name: Summarize regression results
         env:
           ENTRAPMENT_ANALYSES_PATH: ${{ github.workspace }}/PioneerEntrapment.jl
-          PIONEER_RESULTS_DIR: C:/pioneer-runner/results/current
+          PIONEER_RESULTS_DIR: /pioneer-runner/results/current
         run: julia --threads auto --project=. test/regression/regression_metrics.jl

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -81,7 +81,7 @@ jobs:
           EOF
 
       - name: Cleanup regression configs on cluster
-        if: ${{ false }}
+        if: ${{ always() }}
         env:
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -199,7 +199,7 @@ jobs:
 
               sed "s|\"results\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"results\": \"${escaped_results}\"|" "$param_file" > "$adjusted_path"
 
-              echo "${dataset_name}/${search_name}" >> "$manifest_file"
+              echo "${dataset_name}" >> "$manifest_file"
 
               search_submit=$(PIONEER_DIR="$PIONEER_DIR" PARAM_FILE="$adjusted_path" bsub -w "ended($setup_job_id)" < "$JOB_SCRIPT")
               search_job_id=$(printf '%s\n' "$search_submit" | sed -n 's/Job <\([0-9]\+\)>.*$/\1/p' | head -n 1)
@@ -326,23 +326,26 @@ jobs:
             found=0
             missing=()
 
-            for entry in "${unique_entries[@]}"; do
-              dataset="${entry%%/*}"
-              search="${entry#*/}"
+            for dataset in "${unique_entries[@]}"; do
               dataset_dir="$results_root/$dataset"
-              metrics_path="$dataset_dir/metrics_${dataset}_${search}.json"
+
+              metrics_glob="$dataset_dir/metrics_${dataset}_*.json"
+              metrics_present=0
+              if compgen -G "$metrics_glob" > /dev/null; then
+                metrics_present=1
+              fi
 
               log_present=""
-              if compgen -G "$dataset_dir/*${search}*.log" > /dev/null; then
+              if compgen -G "$dataset_dir/*.log" > /dev/null; then
                 log_present=1
-              elif compgen -G "$dataset_dir/*${search}*.log.gz" > /dev/null; then
+              elif compgen -G "$dataset_dir/*.log.gz" > /dev/null; then
                 log_present=1
               fi
 
-              if [ -f "$metrics_path" ] || [ -n "$log_present" ]; then
+              if [ "$metrics_present" -eq 1 ] || [ -n "$log_present" ]; then
                 found=$((found + 1))
               else
-                missing+=("$entry")
+                missing+=("$dataset")
               fi
             done
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -352,7 +352,14 @@ jobs:
               fi
             done
 
-            progress_log+=("Attempt ${attempt}: ${found}/${total_expected} ready")
+            progress_entry="Attempt ${attempt}: ${found}/${total_expected} ready"
+            progress_log+=("$progress_entry")
+            echo "$progress_entry"
+
+            if [ "${#missing[@]}" -gt 0 ]; then
+              echo "Missing entries (sample):"
+              printf '  %s\n' "${missing[@]}"
+            fi
 
             if [ "${#missing[@]}" -eq 0 ]; then
               echo "All expected regression outputs detected."

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -433,7 +433,7 @@ jobs:
           )
 
           cleanup_submit="$(timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-            "RUN_DIR='${remote_run_dir}' CLEANUP_SCRIPT='${cleanup_script_path}' bash -s" <<'EOF'
+            "RUN_DIR='${remote_run_dir}' RUN_SUFFIX='${CLUSTER_RUN_SUFFIX:-}' CLEANUP_SCRIPT='${cleanup_script_path}' bash -s" <<'EOF'
               set -eu
 
               if [ ! -f "$CLEANUP_SCRIPT" ]; then
@@ -441,7 +441,7 @@ jobs:
                 exit 1
               fi
 
-              submit_out=$(RUN_DIR="$RUN_DIR" bsub < "$CLEANUP_SCRIPT")
+              submit_out=$(RUN_DIR="$RUN_DIR" RUN_SUFFIX="$RUN_SUFFIX" bsub < "$CLEANUP_SCRIPT")
               printf '%s' "$submit_out"
           EOF
           )"

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -43,6 +43,8 @@ jobs:
           set -euo pipefail
 
           remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
+          remote_run_dir="${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "CLUSTER_RUN_DIR=${remote_run_dir}" >> "$GITHUB_ENV"
 
           ssh_options=(
             -o BatchMode=yes
@@ -51,10 +53,10 @@ jobs:
             -o ConnectTimeout=30
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' sh -s" <<'EOF'
+          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' sh -s" <<'EOF'
             set -eu
-            mkdir -p "$RUN_ROOT"
-            cd "$RUN_ROOT"
+            mkdir -p "$RUN_DIR"
+            cd "$RUN_DIR"
 
             if [ -d regression-configs/.git ]; then
               git -C regression-configs fetch --all
@@ -62,6 +64,32 @@ jobs:
             else
               git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs
             fi
+          EOF
+
+      - name: Cleanup regression configs on cluster
+        if: ${{ always() }}
+        env:
+          CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
+          CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
+          CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
+          CLUSTER_RUN_DIR: ${{ env.CLUSTER_RUN_DIR }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
+          remote_run_dir="${CLUSTER_RUN_DIR:-${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}"
+
+          ssh_options=(
+            -o BatchMode=yes
+            -o ServerAliveInterval=60
+            -o ServerAliveCountMax=3
+            -o ConnectTimeout=30
+          )
+
+          timeout 180 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_DIR='${remote_run_dir}' sh -s" <<'EOF'
+            set -eu
+            rm -rf "$RUN_DIR"
           EOF
 
       - name: Checkout regression parameter configs

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -314,8 +314,8 @@ jobs:
           done
 
           total_expected=${#unique_entries[@]}
-          poll_interval=60
-          max_attempts=720
+          poll_interval=300
+          max_attempts=144
           attempt=1
           progress_log=()
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -255,6 +255,7 @@ jobs:
                 PIONEER_PARAMS_DIR="$param_dataset_dir" \
                 PIONEER_METRICS_FILE="$metrics_file" \
                 PIONEER_EXPERIMENTAL_DESIGN="$exp_design_file" \
+                PIONEER_ARCHIVE_ROOT="$RUN_DIR" \
                 bsub -w "$dep_expr" < "$METRICS_SCRIPT")
 
               metrics_job_id=$(printf '%s\n' "$metrics_submit" | sed -n 's/Job <\([0-9]\+\)>.*$/\1/p' | head -n 1)

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -66,8 +66,45 @@ jobs:
             fi
           EOF
 
+      - name: Checkout Pioneer code on cluster
+        env:
+          CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
+          CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
+          CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
+          CLUSTER_RUN_DIR: ${{ env.CLUSTER_RUN_DIR }}
+          GITHUB_SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
+          remote_run_dir="${CLUSTER_RUN_DIR:-${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}"
+          pioneer_dir="${remote_run_dir}/pioneer"
+          echo "CLUSTER_PIONEER_DIR=${pioneer_dir}" >> "$GITHUB_ENV"
+
+          ssh_options=(
+            -o BatchMode=yes
+            -o ServerAliveInterval=60
+            -o ServerAliveCountMax=3
+            -o ConnectTimeout=30
+          )
+
+          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' TARGET_SHA='${GITHUB_SHA}' sh -s" <<'EOF'
+            set -eu
+            mkdir -p "$RUN_DIR"
+            cd "$RUN_DIR"
+
+            if [ -d "$PIONEER_DIR/.git" ]; then
+              git -C "$PIONEER_DIR" fetch --all --tags
+            else
+              git clone https://github.com/GoldfarbLab/Pioneer.jl "$PIONEER_DIR"
+            fi
+
+            git -C "$PIONEER_DIR" checkout --force "$TARGET_SHA"
+          EOF
+
       - name: Cleanup regression configs on cluster
-        if: ${{ always() }}
+        if: ${{ false }}
         env:
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -289,6 +289,16 @@ jobs:
           manifest_path="$run_dir/job-ids/expected_results.txt"
           results_root="$run_dir/results"
 
+          echo "Run directory contents (top level):"
+          ls -la "$run_dir"
+
+          if [ -d "$run_dir/job-ids" ]; then
+            echo "Job-ids directory contents:"
+            ls -la "$run_dir/job-ids"
+          else
+            echo "Job-ids directory missing at $run_dir/job-ids"
+          fi
+
           if [ ! -f "$manifest_path" ]; then
             echo "Expected manifest not found at $manifest_path" >&2
             exit 1

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -65,35 +65,42 @@ jobs:
           EOF
 
       - name: Checkout regression parameter configs
+        if: ${{ false }}
         uses: actions/checkout@v5
         with:
           repository: GoldfarbLab/pioneer-regression-configs
           path: pioneer-regression-configs
 
       - name: Checkout Entrapment analyses utilities
+        if: ${{ false }}
         uses: actions/checkout@v5
         with:
           repository: nwamsley1/PioneerEntrapment.jl
           path: PioneerEntrapment.jl
 
       - name: Setup Julia
+        if: ${{ false }}
         uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: x64
 
       - name: Instantiate PioneerEntrapment project
+        if: ${{ false }}
         run: julia --threads auto --project=PioneerEntrapment.jl -e 'using Pkg; Pkg.instantiate()'
 
       - name: Instantiate project
+        if: ${{ false }}
         run: julia --threads auto --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.build()'
 
       - name: Run SearchDIA for all parameter files
+        if: ${{ false }}
         env:
           PIONEER_PARAMS_DIR: ${{ github.workspace }}/pioneer-regression-configs/params
         run: julia --threads auto --project=. test/run_regressions.jl
 
       - name: Summarize regression results
+        if: ${{ false }}
         env:
           ENTRAPMENT_ANALYSES_PATH: ${{ github.workspace }}/PioneerEntrapment.jl
           PIONEER_RESULTS_DIR: /pioneer-runner/results/current

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -27,7 +27,8 @@ jobs:
 
           mkdir -p ~/.ssh
           install -m 600 /dev/null ~/.ssh/id_rsa
-          printf '%s' "$CLUSTER_SSH_KEY" > ~/.ssh/id_rsa
+          # Normalize line endings and ensure a trailing newline
+          printf '%s\n' "$CLUSTER_SSH_KEY" | tr -d '\r' > ~/.ssh/id_rsa
 
           # Preload host key to avoid interactive prompt
           ssh-keyscan -H "$CLUSTER_HOST" >> ~/.ssh/known_hosts
@@ -43,20 +44,6 @@ jobs:
 
           remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
 
-          remote_script=$(cat <<'EOF'
-          set -eu
-          mkdir -p "$RUN_ROOT"
-          cd "$RUN_ROOT"
-
-          if [ -d regression-configs/.git ]; then
-            git -C regression-configs fetch --all
-            git -C regression-configs reset --hard origin/main
-          else
-            git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs
-          fi
-          EOF
-          )
-
           ssh_options=(
             -o BatchMode=yes
             -o ServerAliveInterval=60
@@ -64,7 +51,18 @@ jobs:
             -o ConnectTimeout=30
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT=\"${remote_run_root}\" sh -c \"${remote_script}\""
+          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' sh -s" <<'EOF'
+            set -eu
+            mkdir -p "$RUN_ROOT"
+            cd "$RUN_ROOT"
+
+            if [ -d regression-configs/.git ]; then
+              git -C regression-configs fetch --all
+              git -C regression-configs reset --hard origin/main
+            else
+              git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs
+            fi
+          EOF
 
       - name: Checkout regression parameter configs
         uses: actions/checkout@v5

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -33,7 +33,7 @@ jobs:
           # Preload host key to avoid interactive prompt
           ssh-keyscan -H "$CLUSTER_HOST" >> ~/.ssh/known_hosts
 
-      - name: Prepare cluster workspace (configs and Pioneer)
+      - name: Prepare cluster workspace (configs, Pioneer, and depot)
         env:
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
@@ -47,10 +47,12 @@ jobs:
           remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
           remote_run_dir="${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           pioneer_dir="${remote_run_dir}/pioneer"
+          depot_dir="${remote_run_dir}/julia-depot"
           pioneer_repo="https://github.com/${GITHUB_REPOSITORY}"
 
           echo "CLUSTER_RUN_DIR=${remote_run_dir}" >> "$GITHUB_ENV"
           echo "CLUSTER_PIONEER_DIR=${pioneer_dir}" >> "$GITHUB_ENV"
+          echo "CLUSTER_DEPOT_DIR=${depot_dir}" >> "$GITHUB_ENV"
 
           ssh_options=(
             -o BatchMode=yes
@@ -59,7 +61,7 @@ jobs:
             -o ConnectTimeout=30
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${GITHUB_SHA}' sh -s" <<'EOF'
+          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' DEPOT_DIR='${depot_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${GITHUB_SHA}' sh -s" <<'EOF'
             set -eu
             mkdir -p "$RUN_DIR"
             cd "$RUN_DIR"
@@ -78,6 +80,9 @@ jobs:
             fi
 
             git -C "$PIONEER_DIR" checkout --force "$TARGET_SHA"
+
+            mkdir -p "$DEPOT_DIR"
+            JULIA_DEPOT_PATH="$DEPOT_DIR" julia --project="$PIONEER_DIR" -e 'using Pkg; Pkg.instantiate()'
           EOF
 
       - name: Submit regression search jobs on cluster
@@ -87,6 +92,7 @@ jobs:
           CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
           CLUSTER_RUN_DIR: ${{ env.CLUSTER_RUN_DIR }}
           CLUSTER_PIONEER_DIR: ${{ env.CLUSTER_PIONEER_DIR }}
+          CLUSTER_DEPOT_DIR: ${{ env.CLUSTER_DEPOT_DIR }}
           REGRESSION_JOB_SCRIPT: ${{ vars.REGRESSION_JOB_SCRIPT }}
         shell: bash
         run: |
@@ -95,6 +101,7 @@ jobs:
           remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
           remote_run_dir="${CLUSTER_RUN_DIR:-${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}"
           pioneer_dir="${CLUSTER_PIONEER_DIR:-${remote_run_dir}/pioneer}"
+          depot_dir="${CLUSTER_DEPOT_DIR:-${remote_run_dir}/julia-depot}"
           params_dir="${remote_run_dir}/regression-configs/params"
           job_script_path="${remote_run_dir}/${REGRESSION_JOB_SCRIPT:-regression-configs/job_scripts/search_dia.bsub}"
 
@@ -121,7 +128,7 @@ jobs:
               fi
 
               found=1
-              PIONEER_DIR="$PIONEER_DIR" PARAM_FILE="$param_file" bsub < "$JOB_SCRIPT"
+              JULIA_DEPOT_PATH="$DEPOT_DIR" PIONEER_DIR="$PIONEER_DIR" PARAM_FILE="$param_file" bsub < "$JOB_SCRIPT"
             done
 
             if [ "$found" -eq 0 ]; then

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -91,8 +91,8 @@ jobs:
           CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
           CLUSTER_RUN_DIR: ${{ env.CLUSTER_RUN_DIR }}
           CLUSTER_PIONEER_DIR: ${{ env.CLUSTER_PIONEER_DIR }}
-          CLUSTER_DEPOT_DIR: ${{ env.CLUSTER_DEPOT_DIR }}
           REGRESSION_JOB_SCRIPT: ${{ vars.REGRESSION_JOB_SCRIPT }}
+          SETUP_JOB_SCRIPT: ${{ vars.SETUP_JOB_SCRIPT }}
         shell: bash
         run: |
           set -euo pipefail
@@ -100,9 +100,9 @@ jobs:
           remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
           remote_run_dir="${CLUSTER_RUN_DIR:-${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}"
           pioneer_dir="${CLUSTER_PIONEER_DIR:-${remote_run_dir}/pioneer}"
-          depot_dir="${CLUSTER_DEPOT_DIR:-${remote_run_dir}/julia-depot}"
           params_dir="${remote_run_dir}/regression-configs/params"
           job_script_path="${remote_run_dir}/${REGRESSION_JOB_SCRIPT:-regression-configs/job_scripts/search_dia.bsub}"
+          setup_script_path="${remote_run_dir}/${SETUP_JOB_SCRIPT:-regression-configs/job_scripts/setup_pioneer_env.lsf}"
 
           ssh_options=(
             -o BatchMode=yes
@@ -112,11 +112,25 @@ jobs:
           )
 
           timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-            "RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' PARAMS_DIR='${params_dir}' DEPOT_DIR='${depot_dir}' JOB_SCRIPT='${job_script_path}' sh -s" <<'EOF'
+            "RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' PARAMS_DIR='${params_dir}' JOB_SCRIPT='${job_script_path}' SETUP_SCRIPT='${setup_script_path}' sh -s" <<'EOF'
             set -eu
+
+            if [ ! -f "$SETUP_SCRIPT" ]; then
+              echo "Missing setup job script: $SETUP_SCRIPT" >&2
+              exit 1
+            fi
 
             if [ ! -f "$JOB_SCRIPT" ]; then
               echo "Missing job script: $JOB_SCRIPT" >&2
+              exit 1
+            fi
+
+            setup_submit=$(PIONEER_DIR="$PIONEER_DIR" bsub < "$SETUP_SCRIPT")
+            setup_job_id=$(printf '%s\n' "$setup_submit" | sed -n 's/Job <\([0-9]\+\)>.*$/\1/p' | head -n 1)
+
+            if [ -z "$setup_job_id" ]; then
+              echo "Failed to parse setup job ID from submission output:" >&2
+              printf '%s\n' "$setup_submit" >&2
               exit 1
             fi
 
@@ -127,7 +141,7 @@ jobs:
               fi
 
               found=1
-              JULIA_DEPOT_PATH="$DEPOT_DIR" PIONEER_DIR="$PIONEER_DIR" PARAM_FILE="$param_file" bsub < "$JOB_SCRIPT"
+              PIONEER_DIR="$PIONEER_DIR" PARAM_FILE="$param_file" bsub -w "ended($setup_job_id)" < "$JOB_SCRIPT"
             done
 
             if [ "$found" -eq 0 ]; then

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -50,7 +50,7 @@ jobs:
 
           $remoteRunRoot = if ($env:CLUSTER_RUN_ROOT) { $env:CLUSTER_RUN_ROOT } else { '$HOME/pioneer-regressions' }
           $remoteCommand = @"
-set -euo pipefail
+set -eu
 RUN_ROOT="$remoteRunRoot"
 mkdir -p "$RUN_ROOT"
 cd "$RUN_ROOT"
@@ -69,7 +69,7 @@ fi
             '-o', 'ServerAliveCountMax=3',
             '-o', 'ConnectTimeout=30',
             "$($env:CLUSTER_USERNAME)@$($env:CLUSTER_HOST)",
-            "bash -lc `"$remoteCommand`""
+            "sh -c `"$remoteCommand`""
           )
 
           $sshProcess = Start-Process -FilePath 'ssh' -ArgumentList $sshArgs -NoNewWindow -PassThru -RedirectStandardOutput 'ssh_regression_checkout_stdout.log' -RedirectStandardError 'ssh_regression_checkout_stderr.log'

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -131,7 +131,7 @@ jobs:
           EOF
 
       - name: Cleanup regression configs on cluster
-        if: ${{ always() }}
+        if: ${{ false }}
         env:
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -399,3 +399,48 @@ jobs:
               echo "  - $line"
             done
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Clean run workspace on shared storage
+        if: always()
+        env:
+          CLUSTER_RUN_DIR_MOUNT: ${{ env.CLUSTER_RUN_DIR_MOUNT }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          run_dir="${CLUSTER_RUN_DIR_MOUNT:?CLUSTER_RUN_DIR_MOUNT not set}"
+          results_dir="$run_dir/results"
+
+          case "$run_dir" in
+            /mnt/ris/Active/Automation/Pioneer/run-*) ;;
+            *)
+              echo "Refusing to clean unexpected run directory: $run_dir" >&2
+              exit 1
+              ;;
+          esac
+
+          if [ ! -d "$run_dir" ]; then
+            echo "Run directory $run_dir does not exist; skipping cleanup"
+            exit 0
+          fi
+
+          if [ ! -d "$results_dir" ]; then
+            echo "Results directory not found at $results_dir; skipping cleanup"
+            exit 0
+          fi
+
+          shopt -s dotglob nullglob
+          for entry in "$run_dir"/* "$run_dir"/.*; do
+            base="$(basename "$entry")"
+            if [ "$base" = "." ] || [ "$base" = ".." ]; then
+              continue
+            fi
+
+            if [ "$entry" = "$results_dir" ]; then
+              continue
+            fi
+
+            rm -rf -- "$entry"
+          done
+
+          echo "Cleanup complete; preserved results at $results_dir" | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -161,7 +161,7 @@ jobs:
               adjusted_results="${base_results}/${RUN_ID_SUFFIX}"
               escaped_results=$(printf '%s\n' "$adjusted_results" | sed 's/[&/]/\\&/g')
 
-              sed -E "s|(\"results\"[[:space:]]*:[[:space:]]*\")([^"]+)(\")|\\1${escaped_results}\\3|" "$param_file" > "$adjusted_path"
+              sed "s|\"results\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"results\": \"${escaped_results}\"|" "$param_file" > "$adjusted_path"
 
               PIONEER_DIR="$PIONEER_DIR" PARAM_FILE="$adjusted_path" bsub -w "ended($setup_job_id)" < "$JOB_SCRIPT"
             done

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -328,6 +328,9 @@ jobs:
           attempt=1
           progress_log=()
 
+          echo "Polling for ${total_expected} result paths:" | tee -a "$GITHUB_STEP_SUMMARY"
+          printf '  %s\n' "${unique_entries[@]}" | tee -a "$GITHUB_STEP_SUMMARY"
+
           while :; do
             found=0
             missing=()
@@ -352,9 +355,10 @@ jobs:
               fi
             done
 
-            progress_entry="Attempt ${attempt}: ${found}/${total_expected} ready"
+            timestamp=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+            progress_entry="[${timestamp}] Attempt ${attempt}: ${found}/${total_expected} ready"
             progress_log+=("$progress_entry")
-            echo "$progress_entry"
+            echo "$progress_entry" | tee -a "$GITHUB_STEP_SUMMARY"
 
             if [ "${#missing[@]}" -gt 0 ]; then
               echo "Missing entries (sample):"

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -290,16 +290,6 @@ jobs:
           manifest_path="$run_dir/job-ids/expected_results.txt"
           results_root="$run_dir/results"
 
-          echo "Run directory contents (top level):"
-          ls -la "$run_dir"
-
-          if [ -d "$run_dir/job-ids" ]; then
-            echo "Job-ids directory contents:"
-            ls -la "$run_dir/job-ids"
-          else
-            echo "Job-ids directory missing at $run_dir/job-ids"
-          fi
-
           if [ ! -f "$manifest_path" ]; then
             echo "Expected manifest not found at $manifest_path" >&2
             exit 1

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   regression:
     name: Julia ${{ matrix.version }} regression sweep
-    runs-on: [self-hosted, Linux]
+    runs-on: [self-hosted, Linux, pioneer-regression]
     timeout-minutes: 7200
     strategy:
       matrix:
@@ -17,7 +17,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Regression execution temporarily disabled
+        run: echo "Cluster submissions are temporarily disabled while metrics-change workflows are under development."
+
       - name: Configure SSH for cluster access
+        if: ${{ false }}
         env:
           CLUSTER_SSH_KEY: ${{ secrets.CLUSTER_SSH_KEY }}
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
@@ -34,6 +38,7 @@ jobs:
           ssh-keyscan -H "$CLUSTER_HOST" >> ~/.ssh/known_hosts
 
       - name: Prepare cluster workspace (configs, Pioneer, and depot)
+        if: ${{ false }}
         env:
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
@@ -107,6 +112,7 @@ jobs:
           EOF
 
       - name: Submit regression search jobs on cluster
+        if: ${{ false }}
         env:
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
@@ -283,6 +289,7 @@ jobs:
           EOF
 
       - name: Wait for regression outputs on shared storage
+        if: ${{ false }}
         env:
           CLUSTER_RUN_DIR_MOUNT: ${{ env.CLUSTER_RUN_DIR_MOUNT }}
         shell: bash
@@ -404,7 +411,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Submit cluster cleanup job
-        if: always()
+        if: ${{ false }}
         env:
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 7200
     env:
       METRICS_ONLY: ${{ github.event.inputs.metrics_only || 'true' }}
-      RUN_SUFFIX_INPUT: ${{ github.event.inputs.run_suffix || vars.REGRESSION_RUN_SUFFIX || '' }}
+      RUN_SUFFIX_INPUT: ${{ github.event.inputs.run_suffix || vars.REGRESSION_RUN_SUFFIX || 'run-20450267487-4' }}
     strategy:
       matrix:
         version: ['1.11']

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -86,7 +86,6 @@ jobs:
           ssh-keyscan -H "$CLUSTER_HOST" >> ~/.ssh/known_hosts
 
       - name: Prepare cluster workspace (configs, Pioneer, and depot)
-        if: ${{ env.METRICS_ONLY != 'true' }}
         env:
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 7200
     env:
       METRICS_ONLY: ${{ github.event.inputs.metrics_only || 'true' }}
-      RUN_SUFFIX_INPUT: ${{ github.event.inputs.run_suffix || '' }}
+      RUN_SUFFIX_INPUT: ${{ github.event.inputs.run_suffix || vars.REGRESSION_RUN_SUFFIX || '' }}
     strategy:
       matrix:
         version: ['1.11']

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -325,7 +325,7 @@ jobs:
 
           total_expected=${#unique_entries[@]}
           poll_interval=300
-          max_attempts=144
+          max_attempts=576
           attempt=1
           progress_log=()
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -8,6 +8,7 @@ on:
         description: "Existing run suffix to reuse (e.g., run-20450267487-4)."
         required: false
         type: string
+        default: "run-20450267487-4"
       metrics_only:
         description: "Only submit metrics/cleanup for an existing run (skip searches)."
         required: false

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -194,26 +194,25 @@ jobs:
               exit 1
             fi
 
-            setup_job_id=""
-            if [ "${METRICS_ONLY:-false}" != "true" ]; then
-              if [ ! -f "$SETUP_SCRIPT" ]; then
-                echo "Missing setup job script: $SETUP_SCRIPT" >&2
-                exit 1
-              fi
+            if [ ! -f "$SETUP_SCRIPT" ]; then
+              echo "Missing setup job script: $SETUP_SCRIPT" >&2
+              exit 1
+            fi
 
+            if [ "${METRICS_ONLY:-false}" != "true" ]; then
               if [ ! -f "$JOB_SCRIPT" ]; then
                 echo "Missing job script: $JOB_SCRIPT" >&2
                 exit 1
               fi
+            fi
 
-              setup_submit=$(PIONEER_DIR="$PIONEER_DIR" PIONEER_ENTRAPMENT_DIR="$ENTRAPMENT_DIR" bsub < "$SETUP_SCRIPT")
-              setup_job_id=$(printf '%s\n' "$setup_submit" | sed -n 's/Job <\([0-9]\+\)>.*$/\1/p' | head -n 1)
+            setup_submit=$(PIONEER_DIR="$PIONEER_DIR" PIONEER_ENTRAPMENT_DIR="$ENTRAPMENT_DIR" bsub < "$SETUP_SCRIPT")
+            setup_job_id=$(printf '%s\n' "$setup_submit" | sed -n 's/Job <\([0-9]\+\)>.*$/\1/p' | head -n 1)
 
-              if [ -z "$setup_job_id" ]; then
-                echo "Failed to parse setup job ID from submission output:" >&2
-                printf '%s\n' "$setup_submit" >&2
-                exit 1
-              fi
+            if [ -z "$setup_job_id" ]; then
+              echo "Failed to parse setup job ID from submission output:" >&2
+              printf '%s\n' "$setup_submit" >&2
+              exit 1
             fi
 
             param_list=$(find "$PARAMS_DIR" -type f -name 'search*.json' -print)
@@ -291,7 +290,7 @@ jobs:
                 continue
               fi
 
-              dep_expr=""
+              dep_expr="ended(${setup_job_id})"
               if [ "${METRICS_ONLY:-false}" != "true" ]; then
                 job_list_file="$job_id_dir/${dataset_name}.search"
                 if [ ! -s "$job_list_file" ]; then
@@ -301,16 +300,8 @@ jobs:
 
                 while IFS= read -r job_id; do
                   [ -n "$job_id" ] || continue
-                  if [ -n "$dep_expr" ]; then
-                    dep_expr="$dep_expr && "
-                  fi
-                  dep_expr="${dep_expr}ended(${job_id})"
+                  dep_expr="${dep_expr} && ended(${job_id})"
                 done < "$job_list_file"
-
-                if [ -z "$dep_expr" ]; then
-                  echo "Skipping dataset $dataset_name: unable to build dependency expression" >&2
-                  continue
-                fi
               fi
 
               param_dataset_dir="$ADJUSTED_PARAMS_DIR/$dataset_name"
@@ -319,25 +310,14 @@ jobs:
                 continue
               fi
 
-              if [ -n "$dep_expr" ]; then
-                metrics_submit=$(\
-                  PIONEER_DIR="$PIONEER_DIR" \
-                  ENTRAPMENT_ANALYSES_PATH="$ENTRAPMENT_DIR" \
-                  PIONEER_PARAMS_DIR="$param_dataset_dir" \
-                  PIONEER_METRICS_FILE="$metrics_file" \
-                  PIONEER_EXPERIMENTAL_DESIGN="$exp_design_file" \
-                  PIONEER_ARCHIVE_ROOT="$RUN_DIR" \
-                  bsub -w "$dep_expr" < "$METRICS_SCRIPT")
-              else
-                metrics_submit=$(\
-                  PIONEER_DIR="$PIONEER_DIR" \
-                  ENTRAPMENT_ANALYSES_PATH="$ENTRAPMENT_DIR" \
-                  PIONEER_PARAMS_DIR="$param_dataset_dir" \
-                  PIONEER_METRICS_FILE="$metrics_file" \
-                  PIONEER_EXPERIMENTAL_DESIGN="$exp_design_file" \
-                  PIONEER_ARCHIVE_ROOT="$RUN_DIR" \
-                  bsub < "$METRICS_SCRIPT")
-              fi
+              metrics_submit=$(\
+                PIONEER_DIR="$PIONEER_DIR" \
+                ENTRAPMENT_ANALYSES_PATH="$ENTRAPMENT_DIR" \
+                PIONEER_PARAMS_DIR="$param_dataset_dir" \
+                PIONEER_METRICS_FILE="$metrics_file" \
+                PIONEER_EXPERIMENTAL_DESIGN="$exp_design_file" \
+                PIONEER_ARCHIVE_ROOT="$RUN_DIR" \
+                bsub -w "$dep_expr" < "$METRICS_SCRIPT")
 
               metrics_job_id=$(printf '%s\n' "$metrics_submit" | sed -n 's/Job <\([0-9]\+\)>.*$/\1/p' | head -n 1)
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -329,6 +329,7 @@ jobs:
           EOF
 
       - name: Wait for regression outputs on shared storage
+        if: ${{ env.METRICS_ONLY != 'true' }}
         env:
           CLUSTER_RUN_DIR_MOUNT: ${{ env.CLUSTER_RUN_DIR_MOUNT }}
         shell: bash

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -3,12 +3,28 @@ name: Regression Tests
 on:
   push:
   workflow_dispatch:
+    inputs:
+      run_suffix:
+        description: "Existing run suffix to reuse (e.g., run-20450267487-4)."
+        required: false
+        type: string
+      metrics_only:
+        description: "Only submit metrics/cleanup for an existing run (skip searches)."
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
 
 jobs:
   regression:
     name: Julia ${{ matrix.version }} regression sweep
     runs-on: [self-hosted, Linux, pioneer-regression]
     timeout-minutes: 7200
+    env:
+      METRICS_ONLY: ${{ github.event.inputs.metrics_only || 'true' }}
+      RUN_SUFFIX_INPUT: ${{ github.event.inputs.run_suffix || '' }}
     strategy:
       matrix:
         version: ['1.11']
@@ -17,11 +33,42 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Regression execution temporarily disabled
-        run: echo "Cluster submissions are temporarily disabled while metrics-change workflows are under development."
+      - name: Metrics-only notice
+        if: ${{ env.METRICS_ONLY == 'true' }}
+        run: echo "Metrics-only mode enabled; search submissions are skipped."
+
+      - name: Set run directory context
+        env:
+          CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          run_suffix="run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          if [ -n "${RUN_SUFFIX_INPUT}" ]; then
+            if [[ "${RUN_SUFFIX_INPUT}" == run-* ]]; then
+              run_suffix="${RUN_SUFFIX_INPUT}"
+            else
+              run_suffix="run-${RUN_SUFFIX_INPUT}"
+            fi
+          fi
+
+          remote_run_root_raw="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
+          remote_run_root="${remote_run_root_raw%/}"
+          mount_run_root_raw="/mnt/ris/Active/Automation/Pioneer"
+          mount_run_root="${mount_run_root_raw%/}"
+
+          remote_run_dir="${remote_run_root}/${run_suffix}"
+          mount_run_dir="${mount_run_root}/${run_suffix}"
+
+          echo "CLUSTER_RUN_DIR=${remote_run_dir}" >> "$GITHUB_ENV"
+          echo "CLUSTER_RUN_DIR_MOUNT=${mount_run_dir}" >> "$GITHUB_ENV"
+          echo "CLUSTER_RUN_SUFFIX=${run_suffix}" >> "$GITHUB_ENV"
+          echo "CLUSTER_PIONEER_DIR=${remote_run_dir}/pioneer" >> "$GITHUB_ENV"
+          echo "CLUSTER_ENTRAPMENT_DIR=${remote_run_dir}/PioneerEntrapment.jl" >> "$GITHUB_ENV"
+          echo "CLUSTER_DEPOT_DIR=${remote_run_dir}/julia-depot" >> "$GITHUB_ENV"
 
       - name: Configure SSH for cluster access
-        if: ${{ false }}
         env:
           CLUSTER_SSH_KEY: ${{ secrets.CLUSTER_SSH_KEY }}
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
@@ -38,7 +85,7 @@ jobs:
           ssh-keyscan -H "$CLUSTER_HOST" >> ~/.ssh/known_hosts
 
       - name: Prepare cluster workspace (configs, Pioneer, and depot)
-        if: ${{ false }}
+        if: ${{ env.METRICS_ONLY != 'true' }}
         env:
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
@@ -52,14 +99,12 @@ jobs:
 
           remote_run_root_raw="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
           remote_run_root="${remote_run_root_raw%/}"
-          run_suffix="run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          remote_run_dir="${remote_run_root}/${run_suffix}"
-          mount_run_root_raw="/mnt/ris/Active/Automation/Pioneer"
-          mount_run_root="${mount_run_root_raw%/}"
-          mount_run_dir="${mount_run_root}/${run_suffix}"
-          pioneer_dir="${remote_run_dir}/pioneer"
-          entrapment_dir="${remote_run_dir}/PioneerEntrapment.jl"
-          depot_dir="${remote_run_dir}/julia-depot"
+          remote_run_dir="${CLUSTER_RUN_DIR:?CLUSTER_RUN_DIR not set}"
+          mount_run_dir="${CLUSTER_RUN_DIR_MOUNT:?CLUSTER_RUN_DIR_MOUNT not set}"
+          run_suffix="${CLUSTER_RUN_SUFFIX:?CLUSTER_RUN_SUFFIX not set}"
+          pioneer_dir="${CLUSTER_PIONEER_DIR:?CLUSTER_PIONEER_DIR not set}"
+          entrapment_dir="${CLUSTER_ENTRAPMENT_DIR:?CLUSTER_ENTRAPMENT_DIR not set}"
+          depot_dir="${CLUSTER_DEPOT_DIR:?CLUSTER_DEPOT_DIR not set}"
           pioneer_repo="https://github.com/${GITHUB_REPOSITORY}"
           entrapment_repo="${CLUSTER_ENTRAPMENT_REPO:-nwamsley1/PioneerEntrapment.jl}"
           entrapment_repo_url="$entrapment_repo"
@@ -67,13 +112,6 @@ jobs:
           if [[ "$entrapment_repo" != http* ]]; then
             entrapment_repo_url="https://github.com/${entrapment_repo}"
           fi
-
-          echo "CLUSTER_RUN_DIR=${remote_run_dir}" >> "$GITHUB_ENV"
-          echo "CLUSTER_RUN_DIR_MOUNT=${mount_run_dir}" >> "$GITHUB_ENV"
-          echo "CLUSTER_RUN_SUFFIX=${run_suffix}" >> "$GITHUB_ENV"
-          echo "CLUSTER_PIONEER_DIR=${pioneer_dir}" >> "$GITHUB_ENV"
-          echo "CLUSTER_ENTRAPMENT_DIR=${entrapment_dir}" >> "$GITHUB_ENV"
-          echo "CLUSTER_DEPOT_DIR=${depot_dir}" >> "$GITHUB_ENV"
 
           ssh_options=(
             -o BatchMode=yes
@@ -112,7 +150,6 @@ jobs:
           EOF
 
       - name: Submit regression search jobs on cluster
-        if: ${{ false }}
         env:
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
@@ -123,6 +160,7 @@ jobs:
           REGRESSION_JOB_SCRIPT: ${{ vars.REGRESSION_JOB_SCRIPT }}
           SETUP_JOB_SCRIPT: ${{ vars.SETUP_JOB_SCRIPT }}
           METRICS_JOB_SCRIPT: ${{ vars.METRICS_JOB_SCRIPT }}
+          METRICS_ONLY: ${{ env.METRICS_ONLY }}
         shell: bash
         run: |
           set -euo pipefail
@@ -137,7 +175,7 @@ jobs:
           setup_script_path="${remote_run_dir}/${SETUP_JOB_SCRIPT:-regression-configs/job_scripts/setup.bsub}"
           metrics_script_path="${remote_run_dir}/${METRICS_JOB_SCRIPT:-regression-configs/job_scripts/metrics.bsub}"
           adjusted_params_dir="${remote_run_dir}/adjusted-params"
-          run_suffix="run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          run_suffix="${CLUSTER_RUN_SUFFIX:-run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}"
 
           ssh_options=(
             -o BatchMode=yes
@@ -147,31 +185,34 @@ jobs:
           )
 
           timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-            "RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' ENTRAPMENT_DIR='${entrapment_dir}' PARAMS_DIR='${params_dir}' JOB_SCRIPT='${job_script_path}' SETUP_SCRIPT='${setup_script_path}' METRICS_SCRIPT='${metrics_script_path}' ADJUSTED_PARAMS_DIR='${adjusted_params_dir}' RUN_ID_SUFFIX='${run_suffix}' bash -s" <<'EOF'
+            "RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' ENTRAPMENT_DIR='${entrapment_dir}' PARAMS_DIR='${params_dir}' JOB_SCRIPT='${job_script_path}' SETUP_SCRIPT='${setup_script_path}' METRICS_SCRIPT='${metrics_script_path}' ADJUSTED_PARAMS_DIR='${adjusted_params_dir}' RUN_ID_SUFFIX='${run_suffix}' METRICS_ONLY='${METRICS_ONLY}' bash -s" <<'EOF'
             set -eu
-
-            if [ ! -f "$SETUP_SCRIPT" ]; then
-              echo "Missing setup job script: $SETUP_SCRIPT" >&2
-              exit 1
-            fi
-
-            if [ ! -f "$JOB_SCRIPT" ]; then
-              echo "Missing job script: $JOB_SCRIPT" >&2
-              exit 1
-            fi
 
             if [ ! -f "$METRICS_SCRIPT" ]; then
               echo "Missing metrics job script: $METRICS_SCRIPT" >&2
               exit 1
             fi
 
-            setup_submit=$(PIONEER_DIR="$PIONEER_DIR" PIONEER_ENTRAPMENT_DIR="$ENTRAPMENT_DIR" bsub < "$SETUP_SCRIPT")
-            setup_job_id=$(printf '%s\n' "$setup_submit" | sed -n 's/Job <\([0-9]\+\)>.*$/\1/p' | head -n 1)
+            setup_job_id=""
+            if [ "${METRICS_ONLY:-false}" != "true" ]; then
+              if [ ! -f "$SETUP_SCRIPT" ]; then
+                echo "Missing setup job script: $SETUP_SCRIPT" >&2
+                exit 1
+              fi
 
-            if [ -z "$setup_job_id" ]; then
-              echo "Failed to parse setup job ID from submission output:" >&2
-              printf '%s\n' "$setup_submit" >&2
-              exit 1
+              if [ ! -f "$JOB_SCRIPT" ]; then
+                echo "Missing job script: $JOB_SCRIPT" >&2
+                exit 1
+              fi
+
+              setup_submit=$(PIONEER_DIR="$PIONEER_DIR" PIONEER_ENTRAPMENT_DIR="$ENTRAPMENT_DIR" bsub < "$SETUP_SCRIPT")
+              setup_job_id=$(printf '%s\n' "$setup_submit" | sed -n 's/Job <\([0-9]\+\)>.*$/\1/p' | head -n 1)
+
+              if [ -z "$setup_job_id" ]; then
+                echo "Failed to parse setup job ID from submission output:" >&2
+                printf '%s\n' "$setup_submit" >&2
+                exit 1
+              fi
             fi
 
             param_list=$(find "$PARAMS_DIR" -type f -name 'search*.json' -print)
@@ -202,7 +243,11 @@ jobs:
               fi
 
               base_results=${results_path%/}
-              adjusted_results="${base_results}/${RUN_ID_SUFFIX}"
+              if [ "${base_results##*/}" = "$RUN_ID_SUFFIX" ]; then
+                adjusted_results="$base_results"
+              else
+                adjusted_results="${base_results}/${RUN_ID_SUFFIX}"
+              fi
               dataset_name="$(basename "$(dirname "$adjusted_results")")"
               escaped_results=$(printf '%s\n' "$adjusted_results" | sed 's/[&/]/\\&/g')
 
@@ -210,16 +255,18 @@ jobs:
 
               echo "${dataset_name}" >> "$manifest_file"
 
-              search_submit=$(PIONEER_DIR="$PIONEER_DIR" PARAM_FILE="$adjusted_path" bsub -w "ended($setup_job_id)" < "$JOB_SCRIPT")
-              search_job_id=$(printf '%s\n' "$search_submit" | sed -n 's/Job <\([0-9]\+\)>.*$/\1/p' | head -n 1)
+              if [ "${METRICS_ONLY:-false}" != "true" ]; then
+                search_submit=$(PIONEER_DIR="$PIONEER_DIR" PARAM_FILE="$adjusted_path" bsub -w "ended($setup_job_id)" < "$JOB_SCRIPT")
+                search_job_id=$(printf '%s\n' "$search_submit" | sed -n 's/Job <\([0-9]\+\)>.*$/\1/p' | head -n 1)
 
-              if [ -z "$search_job_id" ]; then
-                echo "Failed to parse search job ID from submission output:" >&2
-                printf '%s\n' "$search_submit" >&2
-                exit 1
+                if [ -z "$search_job_id" ]; then
+                  echo "Failed to parse search job ID from submission output:" >&2
+                  printf '%s\n' "$search_submit" >&2
+                  exit 1
+                fi
+
+                echo "$search_job_id" >> "$job_id_dir/${dataset_dir_name}.search"
               fi
-
-              echo "$search_job_id" >> "$job_id_dir/${dataset_dir_name}.search"
             done
 
             dataset_dirs=$(find "$PARAMS_DIR" -mindepth 1 -maxdepth 1 -type d -print)
@@ -231,7 +278,6 @@ jobs:
 
             printf '%s\n' "$dataset_dirs" | while IFS= read -r dataset_dir; do
               dataset_name="$(basename "$dataset_dir")"
-              job_list_file="$job_id_dir/${dataset_name}.search"
               metrics_file="$dataset_dir/metrics.json"
               exp_design_file="$dataset_dir/experimental_design.json"
 
@@ -244,23 +290,26 @@ jobs:
                 continue
               fi
 
-              if [ ! -s "$job_list_file" ]; then
-                echo "Skipping dataset $dataset_name: no search job IDs recorded" >&2
-                continue
-              fi
-
               dep_expr=""
-              while IFS= read -r job_id; do
-                [ -n "$job_id" ] || continue
-                if [ -n "$dep_expr" ]; then
-                  dep_expr="$dep_expr && "
+              if [ "${METRICS_ONLY:-false}" != "true" ]; then
+                job_list_file="$job_id_dir/${dataset_name}.search"
+                if [ ! -s "$job_list_file" ]; then
+                  echo "Skipping dataset $dataset_name: no search job IDs recorded" >&2
+                  continue
                 fi
-                dep_expr="${dep_expr}ended(${job_id})"
-              done < "$job_list_file"
 
-              if [ -z "$dep_expr" ]; then
-                echo "Skipping dataset $dataset_name: unable to build dependency expression" >&2
-                continue
+                while IFS= read -r job_id; do
+                  [ -n "$job_id" ] || continue
+                  if [ -n "$dep_expr" ]; then
+                    dep_expr="$dep_expr && "
+                  fi
+                  dep_expr="${dep_expr}ended(${job_id})"
+                done < "$job_list_file"
+
+                if [ -z "$dep_expr" ]; then
+                  echo "Skipping dataset $dataset_name: unable to build dependency expression" >&2
+                  continue
+                fi
               fi
 
               param_dataset_dir="$ADJUSTED_PARAMS_DIR/$dataset_name"
@@ -269,14 +318,25 @@ jobs:
                 continue
               fi
 
-              metrics_submit=$(\
-                PIONEER_DIR="$PIONEER_DIR" \
-                ENTRAPMENT_ANALYSES_PATH="$ENTRAPMENT_DIR" \
-                PIONEER_PARAMS_DIR="$param_dataset_dir" \
-                PIONEER_METRICS_FILE="$metrics_file" \
-                PIONEER_EXPERIMENTAL_DESIGN="$exp_design_file" \
-                PIONEER_ARCHIVE_ROOT="$RUN_DIR" \
-                bsub -w "$dep_expr" < "$METRICS_SCRIPT")
+              if [ -n "$dep_expr" ]; then
+                metrics_submit=$(\
+                  PIONEER_DIR="$PIONEER_DIR" \
+                  ENTRAPMENT_ANALYSES_PATH="$ENTRAPMENT_DIR" \
+                  PIONEER_PARAMS_DIR="$param_dataset_dir" \
+                  PIONEER_METRICS_FILE="$metrics_file" \
+                  PIONEER_EXPERIMENTAL_DESIGN="$exp_design_file" \
+                  PIONEER_ARCHIVE_ROOT="$RUN_DIR" \
+                  bsub -w "$dep_expr" < "$METRICS_SCRIPT")
+              else
+                metrics_submit=$(\
+                  PIONEER_DIR="$PIONEER_DIR" \
+                  ENTRAPMENT_ANALYSES_PATH="$ENTRAPMENT_DIR" \
+                  PIONEER_PARAMS_DIR="$param_dataset_dir" \
+                  PIONEER_METRICS_FILE="$metrics_file" \
+                  PIONEER_EXPERIMENTAL_DESIGN="$exp_design_file" \
+                  PIONEER_ARCHIVE_ROOT="$RUN_DIR" \
+                  bsub < "$METRICS_SCRIPT")
+              fi
 
               metrics_job_id=$(printf '%s\n' "$metrics_submit" | sed -n 's/Job <\([0-9]\+\)>.*$/\1/p' | head -n 1)
 
@@ -289,7 +349,6 @@ jobs:
           EOF
 
       - name: Wait for regression outputs on shared storage
-        if: ${{ false }}
         env:
           CLUSTER_RUN_DIR_MOUNT: ${{ env.CLUSTER_RUN_DIR_MOUNT }}
         shell: bash
@@ -411,7 +470,6 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Submit cluster cleanup job
-        if: ${{ false }}
         env:
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}

--- a/test/regression/regression_metrics.jl
+++ b/test/regression/regression_metrics.jl
@@ -306,7 +306,7 @@ function archive_results(
         return
     end
 
-    target_dir = joinpath(archive_root, "results", dataset_name, search_name)
+    target_dir = joinpath(archive_root, "results", dataset_name)
     mkpath(target_dir)
 
     if isfile(metrics_path)

--- a/test/regression/regression_metrics.jl
+++ b/test/regression/regression_metrics.jl
@@ -398,13 +398,34 @@ function compute_metrics_for_params_dir(
             dataset_paths = dataset_paths,
         )
 
-        metrics === nothing && continue
-        if metrics isa AbstractDict && isempty(metrics)
-            @warn "No metrics produced for search; skipping metrics file" search=entry.search_name dataset=entry.dataset_name results_dir=entry.results_dir
+        output_path = output_metrics_path(entry.results_dir, entry.dataset_name, entry.search_name)
+
+        metrics === nothing && begin
+            @warn "No metrics produced for search; archiving logs only" search=entry.search_name dataset=entry.dataset_name results_dir=entry.results_dir
+            cleanup_results_dir(entry.results_dir, output_path)
+            archive_results(
+                entry.results_dir,
+                output_path;
+                archive_root = archive_root,
+                dataset_name = entry.dataset_name,
+                search_name = entry.search_name,
+            )
             continue
         end
 
-        output_path = output_metrics_path(entry.results_dir, entry.dataset_name, entry.search_name)
+        if metrics isa AbstractDict && isempty(metrics)
+            @warn "No metrics produced for search; archiving logs only" search=entry.search_name dataset=entry.dataset_name results_dir=entry.results_dir
+            cleanup_results_dir(entry.results_dir, output_path)
+            archive_results(
+                entry.results_dir,
+                output_path;
+                archive_root = archive_root,
+                dataset_name = entry.dataset_name,
+                search_name = entry.search_name,
+            )
+            continue
+        end
+
         open(output_path, "w") do io
             JSON.print(io, metrics)
         end


### PR DESCRIPTION
## Summary
- configure SSH setup for accessing the compute cluster during regression runs
- add remote checkout step for the regression configs with a timeout guard to avoid hanging

## Testing
- not run (workflow update only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69469e91c23c832598911508133a4db1)