### PR TITLE
feat: add regression metrics report generation and PR posting

### DIFF
--- a/test/regression/regression_metrics.jl
+++ b/test/regression/regression_metrics.jl
@@ -450,20 +450,14 @@ function build_metrics_report(metrics_by_version::Dict{String, Dict{String, Dict
     String(take!(report))
 end
 
-function current_commit_label()
-    sha = get(ENV, "GITHUB_SHA", "")
-    if isempty(sha)
-        try
-            sha = readchomp(`git rev-parse --short HEAD`)
-        catch err
-            @warn "Unable to resolve git commit SHA for report label" error=err
-            sha = "current"
-        end
-    else
-        sha = first(sha, min(length(sha), 7))
+function current_version_label_from_path(path::AbstractString)
+    parts = collect(splitpath(path))
+    metrics_idx = findfirst(isequal("metrics"), parts)
+    if metrics_idx !== nothing && metrics_idx < length(parts)
+        return parts[metrics_idx + 1]
     end
 
-    "commit $(sha)"
+    basename(path)
 end
 
 function write_report(report_text::AbstractString, results_root::AbstractString)
@@ -519,23 +513,26 @@ function post_report_to_pr(report_text::AbstractString)
     response.status in 200:299
 end
 
-function generate_regression_report(results_root::AbstractString; current_metrics::Dict{String, Dict{String, Dict{String, Any}}} = Dict{String, Dict{String, Dict{String, Any}}}())
+function generate_regression_report(
+    results_root::AbstractString;
+    current_metrics::Dict{String, Dict{String, Dict{String, Any}}} = Dict{String, Dict{String, Dict{String, Any}}}(),
+    current_version_label::AbstractString = current_version_label_from_path(results_root),
+)
     release_metrics = collect_metrics_from_versioned_root(RELEASE_METRICS_ROOT)
     develop_metrics = collect_metrics_from_search_root(DEVELOP_METRICS_ROOT; version_label = "develop")
 
-    commit_label = current_commit_label()
     version_order = ordered_release_versions(release_metrics)
     push!(version_order, "develop")
-    push!(version_order, commit_label)
+    push!(version_order, current_version_label)
 
     metrics_by_version = Dict{String, Dict{String, Dict{String, Any}}}()
     merge!(metrics_by_version, release_metrics)
     metrics_by_version["develop"] = get(develop_metrics, "develop", Dict{String, Dict{String, Any}}())
 
     if isempty(current_metrics)
-        current_metrics = collect_metrics_from_results_root(results_root; version_label = commit_label)
+        current_metrics = collect_metrics_from_results_root(results_root; version_label = current_version_label)
     end
-    metrics_by_version[commit_label] = get(current_metrics, commit_label, Dict{String, Dict{String, Any}}())
+    metrics_by_version[current_version_label] = get(current_metrics, current_version_label, Dict{String, Dict{String, Any}}())
 
     report_text = build_metrics_report(metrics_by_version, version_order)
     report_path = write_report(report_text, results_root)
@@ -822,14 +819,20 @@ function compute_metrics_for_params_dir(
         dirname(dataset_dir)
     end
 
+    current_version_label = !isempty(archive_root) ? basename(archive_root) : current_version_label_from_path(report_root)
+
     current_metrics = if !isempty(archive_root)
-        collect_metrics_from_results_root(report_root; version_label = current_commit_label())
+        collect_metrics_from_results_root(report_root; version_label = current_version_label)
     else
         unique_results_dirs = unique([entry.results_dir for entry in dataset_entries])
-        collect_metrics_from_results_dirs(unique_results_dirs; version_label = current_commit_label())
+        collect_metrics_from_results_dirs(unique_results_dirs; version_label = current_version_label)
     end
 
-    generate_regression_report(report_root; current_metrics = current_metrics)
+    generate_regression_report(
+        report_root;
+        current_metrics = current_metrics,
+        current_version_label = current_version_label,
+    )
 end
 
 function main()
@@ -925,7 +928,8 @@ function main()
         end
     end
 
-    generate_regression_report(results_dir)
+    current_version_label = current_version_label_from_path(results_dir)
+    generate_regression_report(results_dir; current_version_label = current_version_label)
 end
 
 main()

--- a/test/regression/regression_metrics.jl
+++ b/test/regression/regression_metrics.jl
@@ -400,8 +400,8 @@ function build_metrics_report(metrics_by_version::Dict{String, Dict{String, Dict
     report = IOBuffer()
     println(report, "# Regression Metrics Report")
     println(report, "")
-    println(report, "- Generated: $(Dates.format(now(), dateformat\"yyyy-mm-dd HH:MM:SS\"))")
-    println(report, "- Versions: $(join(version_order, ", "))")
+    println(report, "- Generated: ", Dates.format(now(), dateformat"yyyy-mm-dd HH:MM:SS"))
+    println(report, "- Versions: ", join(version_order, ", "))
     println(report, "")
 
     for dataset in sort(collect(datasets))

--- a/test/regression/regression_metrics.jl
+++ b/test/regression/regression_metrics.jl
@@ -401,7 +401,7 @@ function build_metrics_report(metrics_by_version::Dict{String, Dict{String, Dict
     println(report, "# Regression Metrics Report")
     println(report, "")
     println(report, "- Generated: $(Dates.format(now(), dateformat\"yyyy-mm-dd HH:MM:SS\"))")
-    println(report, "- Versions: $(join(version_order, \", \"))")
+    println(report, "- Versions: $(join(version_order, ", "))")
     println(report, "")
 
     for dataset in sort(collect(datasets))

--- a/test/regression/regression_metrics.jl
+++ b/test/regression/regression_metrics.jl
@@ -2,8 +2,11 @@
 
 using Arrow
 using DataFrames
+using Dates
 using JSON
+using Printf
 using Statistics
+using Downloads
 
 include("metrics_helpers.jl")
 include("entrapment_metrics.jl")
@@ -15,6 +18,10 @@ using .EntrapmentMetrics: compute_entrapment_metrics
 using .ThreeProteomeMetrics: experimental_design_entry, experimental_design_for_dataset, fold_change_metrics_for_table, gene_counts_metrics_by_run, load_experimental_design, load_three_proteome_designs, normalize_metric_label, run_groups_for_dataset, three_proteome_design_entry
 
 const DEFAULT_METRIC_GROUPS = ["identification", "CV", "eFDR", "runtime"]
+const RELEASE_METRICS_ROOT = "/storage1/fs1/d.goldfarb/Active/Automation/Pioneer/metrics/release"
+const DEVELOP_METRICS_ROOT = "/storage1/fs1/d.goldfarb/Active/Automation/Pioneer/metrics/develop"
+
+const REPORT_FILENAME = "metrics_report.md"
 
 function read_required_table(path::AbstractString)
     isfile(path) || error("Required file not found: $path")
@@ -168,6 +175,373 @@ function metric_groups_for_search(config::Dict, search_name::AbstractString)
     end
 end
 
+function flatten_metrics(data; prefix::AbstractString = "")
+    flattened = Dict{String, Any}()
+
+    if data isa AbstractDict
+        for (key, value) in data
+            key_str = String(key)
+            path = isempty(prefix) ? key_str : string(prefix, "/", key_str)
+            if value isa AbstractDict
+                merge!(flattened, flatten_metrics(value; prefix = path))
+            else
+                flattened[path] = value
+            end
+        end
+    else
+        flattened[prefix] = data
+    end
+
+    flattened
+end
+
+function parse_metrics_filename(filename::AbstractString; dataset_hint::AbstractString = "", search_hint::AbstractString = "")
+    if startswith(filename, "metrics_") && endswith(filename, ".json")
+        base = replace(filename, r"^metrics_" => "")
+        base = replace(base, r"\.json$" => "")
+        if !isempty(search_hint) && endswith(base, string("_", search_hint))
+            dataset = replace(base, string("_", search_hint) => "")
+            return dataset, search_hint
+        end
+        if !isempty(dataset_hint) && startswith(base, string(dataset_hint, "_"))
+            search = replace(base, string(dataset_hint, "_") => "")
+            return dataset_hint, search
+        end
+    end
+
+    return nothing, nothing
+end
+
+function metrics_value_is_numeric(value)
+    value isa Number && isfinite(float(value))
+end
+
+function format_metric_value(value)
+    if value === nothing
+        return "NA"
+    elseif value isa Missing
+        return "NA"
+    elseif value isa Integer
+        return string(value)
+    elseif value isa AbstractFloat
+        return @sprintf("%.4f", value)
+    elseif value isa Number
+        return string(value)
+    else
+        return string(value)
+    end
+end
+
+function format_metric_delta(current, previous)
+    if metrics_value_is_numeric(current) && metrics_value_is_numeric(previous)
+        delta = float(current) - float(previous)
+        return @sprintf("%+.4f", delta)
+    end
+    return "NA"
+end
+
+function collect_metrics_from_versioned_root(root::AbstractString)
+    metrics = Dict{String, Dict{String, Dict{String, Any}}}()
+    !isdir(root) && return metrics
+
+    for version_dir in readdir(root; join = true)
+        isdir(version_dir) || continue
+        version = basename(version_dir)
+        version_metrics = Dict{String, Dict{String, Any}}()
+
+        for search_dir in readdir(version_dir; join = true)
+            isdir(search_dir) || continue
+            search_name = basename(search_dir)
+
+            for file in readdir(search_dir; join = true)
+                isfile(file) || continue
+                filename = basename(file)
+                !startswith(filename, "metrics_") && continue
+                !endswith(filename, ".json") && continue
+
+                dataset, search = parse_metrics_filename(filename; search_hint = search_name)
+                if dataset === nothing || search === nothing
+                    continue
+                end
+
+                raw = JSON.parsefile(file)
+                flattened = flatten_metrics(raw)
+                dataset_metrics = get!(version_metrics, dataset, Dict{String, Any}())
+                dataset_metrics[search] = flattened
+            end
+        end
+
+        metrics[version] = version_metrics
+    end
+
+    metrics
+end
+
+function collect_metrics_from_search_root(root::AbstractString; version_label::AbstractString = "develop")
+    metrics = Dict{String, Dict{String, Dict{String, Any}}}()
+    !isdir(root) && return metrics
+
+    version_metrics = Dict{String, Dict{String, Any}}()
+    for search_dir in readdir(root; join = true)
+        isdir(search_dir) || continue
+        search_name = basename(search_dir)
+
+        for file in readdir(search_dir; join = true)
+            isfile(file) || continue
+            filename = basename(file)
+            !startswith(filename, "metrics_") && continue
+            !endswith(filename, ".json") && continue
+
+            dataset, search = parse_metrics_filename(filename; search_hint = search_name)
+            if dataset === nothing || search === nothing
+                continue
+            end
+
+            raw = JSON.parsefile(file)
+            flattened = flatten_metrics(raw)
+            dataset_metrics = get!(version_metrics, dataset, Dict{String, Any}())
+            dataset_metrics[search] = flattened
+        end
+    end
+
+    metrics[version_label] = version_metrics
+    metrics
+end
+
+function collect_metrics_from_results_root(root::AbstractString; version_label::AbstractString)
+    metrics = Dict{String, Dict{String, Dict{String, Any}}}()
+    !isdir(root) && return metrics
+
+    version_metrics = Dict{String, Dict{String, Any}}()
+    for dataset_dir in readdir(root; join = true)
+        isdir(dataset_dir) || continue
+        dataset_name = basename(dataset_dir)
+
+        for file in readdir(dataset_dir; join = true)
+            isfile(file) || continue
+            filename = basename(file)
+            !startswith(filename, "metrics_") && continue
+            !endswith(filename, ".json") && continue
+
+            dataset, search = parse_metrics_filename(filename; dataset_hint = dataset_name)
+            if dataset === nothing || search === nothing
+                continue
+            end
+
+            raw = JSON.parsefile(file)
+            flattened = flatten_metrics(raw)
+            dataset_metrics = get!(version_metrics, dataset, Dict{String, Any}())
+            dataset_metrics[search] = flattened
+        end
+    end
+
+    metrics[version_label] = version_metrics
+    metrics
+end
+
+function collect_metrics_from_results_dirs(results_dirs::AbstractVector{<:AbstractString}; version_label::AbstractString)
+    metrics = Dict{String, Dict{String, Dict{String, Any}}}()
+    version_metrics = Dict{String, Dict{String, Any}}()
+
+    for results_dir in results_dirs
+        isdir(results_dir) || continue
+        dataset_name = dataset_name_from_results(results_dir)
+        for file in readdir(results_dir; join = true)
+            isfile(file) || continue
+            filename = basename(file)
+            !startswith(filename, "metrics_") && continue
+            !endswith(filename, ".json") && continue
+
+            dataset, search = parse_metrics_filename(filename; dataset_hint = dataset_name)
+            if dataset === nothing || search === nothing
+                continue
+            end
+
+            raw = JSON.parsefile(file)
+            flattened = flatten_metrics(raw)
+            dataset_metrics = get!(version_metrics, dataset, Dict{String, Any}())
+            dataset_metrics[search] = flattened
+        end
+    end
+
+    metrics[version_label] = version_metrics
+    metrics
+end
+
+function parse_version_tuple(version::AbstractString)
+    cleaned = replace(version, r"^v" => "")
+    parts = split(cleaned, ".")
+    parsed = map(part -> tryparse(Int, part), parts)
+    if any(x -> x === nothing, parsed)
+        return (typemax(Int),)
+    end
+    return Tuple(parsed)
+end
+
+function ordered_release_versions(metrics::Dict{String, Dict{String, Dict{String, Any}}})
+    versions = collect(keys(metrics))
+    sort(versions; by = parse_version_tuple)
+end
+
+function build_metrics_report(metrics_by_version::Dict{String, Dict{String, Dict{String, Any}}}, version_order::Vector{String})
+    datasets = Set{String}()
+    searches = Dict{String, Set{String}}()
+
+    for (version, dataset_metrics) in metrics_by_version
+        for (dataset, search_metrics) in dataset_metrics
+            push!(datasets, dataset)
+            dataset_searches = get!(searches, dataset, Set{String}())
+            for search in keys(search_metrics)
+                push!(dataset_searches, search)
+            end
+        end
+    end
+
+    report = IOBuffer()
+    println(report, "# Regression Metrics Report")
+    println(report, "")
+    println(report, "- Generated: $(Dates.format(now(), dateformat\"yyyy-mm-dd HH:MM:SS\"))")
+    println(report, "- Versions: $(join(version_order, \", \"))")
+    println(report, "")
+
+    for dataset in sort(collect(datasets))
+        dataset_searches = get(searches, dataset, Set{String}())
+        for search in sort(collect(dataset_searches))
+            println(report, "## Dataset: $(dataset) — Search: $(search)")
+            println(report, "")
+
+            metric_keys = Set{String}()
+            for version in version_order
+                dataset_metrics = get(metrics_by_version, version, Dict{String, Dict{String, Any}}())
+                search_metrics = get(get(dataset_metrics, dataset, Dict{String, Any}()), search, Dict{String, Any}())
+                for key in keys(search_metrics)
+                    push!(metric_keys, key)
+                end
+            end
+
+            header_cells = ["Metric"]
+            for (idx, version) in enumerate(version_order)
+                push!(header_cells, version)
+                idx > 1 && push!(header_cells, "Δ")
+            end
+            println(report, "| ", join(header_cells, " | "), " |")
+            println(report, "|", join(fill("---", length(header_cells)), "|"), "|")
+
+            for metric in sort(collect(metric_keys))
+                row_cells = String[metric]
+                previous_value = nothing
+                for (idx, version) in enumerate(version_order)
+                    dataset_metrics = get(metrics_by_version, version, Dict{String, Dict{String, Any}}())
+                    search_metrics = get(get(dataset_metrics, dataset, Dict{String, Any}()), search, Dict{String, Any}())
+                    value = get(search_metrics, metric, nothing)
+                    push!(row_cells, format_metric_value(value))
+                    if idx > 1
+                        push!(row_cells, format_metric_delta(value, previous_value))
+                    end
+                    previous_value = value
+                end
+                println(report, "| ", join(row_cells, " | "), " |")
+            end
+
+            println(report, "")
+        end
+    end
+
+    String(take!(report))
+end
+
+function current_commit_label()
+    sha = get(ENV, "GITHUB_SHA", "")
+    if isempty(sha)
+        try
+            sha = readchomp(`git rev-parse --short HEAD`)
+        catch err
+            @warn "Unable to resolve git commit SHA for report label" error=err
+            sha = "current"
+        end
+    else
+        sha = first(sha, min(length(sha), 7))
+    end
+
+    "commit $(sha)"
+end
+
+function write_report(report_text::AbstractString, results_root::AbstractString)
+    mkpath(results_root)
+    report_path = joinpath(results_root, REPORT_FILENAME)
+    open(report_path, "w") do io
+        write(io, report_text)
+    end
+    report_path
+end
+
+function post_report_to_pr(report_text::AbstractString)
+    event_path = get(ENV, "GITHUB_EVENT_PATH", "")
+    isempty(event_path) && return false
+    !isfile(event_path) && return false
+
+    token = get(ENV, "GITHUB_TOKEN", "")
+    isempty(token) && return false
+
+    repo = get(ENV, "GITHUB_REPOSITORY", "")
+    isempty(repo) && return false
+
+    event = JSON.parsefile(event_path)
+    pull_request = get(event, "pull_request", nothing)
+    pull_request === nothing && return false
+    pr_number = get(pull_request, "number", nothing)
+    pr_number === nothing && return false
+
+    body = """
+    ## Regression Metrics Report
+
+    <details>
+    <summary>View report</summary>
+
+    $(report_text)
+    </details>
+    """
+
+    url = "https://api.github.com/repos/$(repo)/issues/$(pr_number)/comments"
+    headers = Dict(
+        "Authorization" => "token $(token)",
+        "Accept" => "application/vnd.github+json",
+        "User-Agent" => "PioneerMetricsReporter",
+    )
+
+    response = Downloads.request(
+        url,
+        "POST",
+        headers,
+        JSON.json(Dict("body" => body)),
+    )
+
+    response.status in 200:299
+end
+
+function generate_regression_report(results_root::AbstractString; current_metrics::Dict{String, Dict{String, Dict{String, Any}}} = Dict{String, Dict{String, Dict{String, Any}}}())
+    release_metrics = collect_metrics_from_versioned_root(RELEASE_METRICS_ROOT)
+    develop_metrics = collect_metrics_from_search_root(DEVELOP_METRICS_ROOT; version_label = "develop")
+
+    commit_label = current_commit_label()
+    version_order = ordered_release_versions(release_metrics)
+    push!(version_order, "develop")
+    push!(version_order, commit_label)
+
+    metrics_by_version = Dict{String, Dict{String, Dict{String, Any}}}()
+    merge!(metrics_by_version, release_metrics)
+    metrics_by_version["develop"] = get(develop_metrics, "develop", Dict{String, Dict{String, Any}}())
+
+    if isempty(current_metrics)
+        current_metrics = collect_metrics_from_results_root(results_root; version_label = commit_label)
+    end
+    metrics_by_version[commit_label] = get(current_metrics, commit_label, Dict{String, Dict{String, Any}}())
+
+    report_text = build_metrics_report(metrics_by_version, version_order)
+    report_path = write_report(report_text, results_root)
+    posted = post_report_to_pr(report_text)
+    @info "Generated regression metrics report" report_path=report_path posted_to_pr=posted
+end
 
 function dataset_dirs_from_root(root::AbstractString)
     !isdir(root) && return String[]
@@ -439,6 +813,23 @@ function compute_metrics_for_params_dir(
             search_name = entry.search_name,
         )
     end
+
+    report_root = if !isempty(archive_root)
+        joinpath(archive_root, "results")
+    else
+        first_results_dir = first(dataset_entries).results_dir
+        dataset_dir = dirname(first_results_dir)
+        dirname(dataset_dir)
+    end
+
+    current_metrics = if !isempty(archive_root)
+        collect_metrics_from_results_root(report_root; version_label = current_commit_label())
+    else
+        unique_results_dirs = unique([entry.results_dir for entry in dataset_entries])
+        collect_metrics_from_results_dirs(unique_results_dirs; version_label = current_commit_label())
+    end
+
+    generate_regression_report(report_root; current_metrics = current_metrics)
 end
 
 function main()
@@ -533,6 +924,8 @@ function main()
             JSON.print(io, metrics)
         end
     end
+
+    generate_regression_report(results_dir)
 end
 
 main()


### PR DESCRIPTION
### Motivation
- Produce a human-readable comparison of regression metrics across historical releases, the `develop` branch, and the current commit to track changes over time.
- Aggregate metrics stored under the release and develop roots and compute per-metric deltas so regressions or improvements are visible at a glance.
- Persist a Markdown report in the results area and post it as a comment on a GitHub pull request when running in CI to provide immediate feedback to reviewers.

### Description
- Added constants and imports: `RELEASE_METRICS_ROOT`, `DEVELOP_METRICS_ROOT`, `REPORT_FILENAME`, and new `using` imports for `Dates`, `Printf`, and `Downloads` for formatting and HTTP posting.
- Implemented metric handling helpers including `flatten_metrics`, `parse_metrics_filename`, numeric checks and formatting (`format_metric_value`, `format_metric_delta`), and release-version ordering (`parse_version_tuple`, `ordered_release_versions`).
- Implemented metric collectors for multiple layouts: `collect_metrics_from_versioned_root`, `collect_metrics_from_search_root`, `collect_metrics_from_results_root`, and `collect_metrics_from_results_dirs`, plus `build_metrics_report`, `write_report`, and `post_report_to_pr` that posts the Markdown to the PR via `Downloads.request`.
- Integrated report generation by adding `generate_regression_report` and invoking it from both `compute_metrics_for_params_dir` and `main`, writing `metrics_report.md` into the results root and treating missing metrics as `NA` while computing numeric deltas when possible.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f10aa2a888325aa603cb5acdf273a)