### PR TITLE
chore(regression): pin workflow checkout to v0.6.4

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -54,6 +54,7 @@ jobs:
           CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
           GITHUB_SHA: ${{ github.sha }}
           REGRESSION_REF: v0.6.4
+          REGRESSION_REPO: nwamsley1/Pioneer.jl
           GITHUB_REPOSITORY: ${{ github.repository }}
           CLUSTER_ENTRAPMENT_REPO: ${{ secrets.CLUSTER_ENTRAPMENT_REPO }}
         shell: bash
@@ -70,7 +71,10 @@ jobs:
           pioneer_dir="${remote_run_dir}/pioneer"
           entrapment_dir="${remote_run_dir}/PioneerEntrapment.jl"
           depot_dir="${remote_run_dir}/julia-depot"
-          pioneer_repo="https://github.com/${GITHUB_REPOSITORY}"
+          pioneer_repo="${REGRESSION_REPO:-$GITHUB_REPOSITORY}"
+          if [[ "$pioneer_repo" != http* ]]; then
+            pioneer_repo="https://github.com/${pioneer_repo}"
+          fi
           entrapment_repo="${CLUSTER_ENTRAPMENT_REPO:-nwamsley1/PioneerEntrapment.jl}"
           entrapment_repo_url="$entrapment_repo"
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -53,6 +53,7 @@ jobs:
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
           CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
           GITHUB_SHA: ${{ github.sha }}
+          REGRESSION_REF: v0.6.4
           GITHUB_REPOSITORY: ${{ github.repository }}
           CLUSTER_ENTRAPMENT_REPO: ${{ secrets.CLUSTER_ENTRAPMENT_REPO }}
         shell: bash
@@ -84,6 +85,7 @@ jobs:
           echo "CLUSTER_ENTRAPMENT_DIR=${entrapment_dir}" >> "$GITHUB_ENV"
           echo "CLUSTER_DEPOT_DIR=${depot_dir}" >> "$GITHUB_ENV"
 
+          regression_ref="${REGRESSION_REF:-$GITHUB_SHA}"
           ssh_options=(
             -o BatchMode=yes
             -o ServerAliveInterval=60
@@ -91,7 +93,7 @@ jobs:
             -o ConnectTimeout=30
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' DEPOT_DIR='${depot_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${GITHUB_SHA}' ENTRAPMENT_DIR='${entrapment_dir}' ENTRAPMENT_REPO_URL='${entrapment_repo_url}' bash -s" <<'EOF'
+          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' DEPOT_DIR='${depot_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${regression_ref}' ENTRAPMENT_DIR='${entrapment_dir}' ENTRAPMENT_REPO_URL='${entrapment_repo_url}' bash -s" <<'EOF'
             set -eu
             mkdir -p "$RUN_DIR"
             cd "$RUN_DIR"


### PR DESCRIPTION
### Motivation
- Temporarily ensure the regression workflow checks out a known release tag instead of the current commit to reproduce historical runs.
- Make the pinned ref obvious and easy to change by introducing an explicit variable for the ref.

### Description
- Added `REGRESSION_REF: v0.6.4` to the environment for the `Prepare cluster workspace` step in `.github/workflows/regression.yml`.
- Introduced a shell variable `regression_ref` that defaults to `GITHUB_SHA` but is overridden by `REGRESSION_REF` via `regression_ref="${REGRESSION_REF:-$GITHUB_SHA}"`.
- Updated the remote checkout invocation to pass `TARGET_SHA='${regression_ref}'` so the cluster checks out the pinned tag instead of the workflow commit.
- Change is limited to `.github/workflows/regression.yml` and does not modify runtime code.

### Testing
- No automated tests were executed because this is a workflow-only change and does not affect package source or test suite.
- The change was committed locally and staged for PR review without running CI in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954a3fe26ac8325936f4cddadd6a5b8)