### PR TITLE
Replace filesystem polling with bjobs-based cluster job monitoring

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -218,7 +218,9 @@ jobs:
             job_id_dir="$RUN_DIR/job-ids"
             mkdir -p "$job_id_dir"
             manifest_file="$job_id_dir/expected_results.txt"
+            search_job_list="$job_id_dir/search.ids"
             : > "$manifest_file"
+            : > "$search_job_list"
 
             printf '%s\n' "$param_list" | while IFS= read -r param_file; do
               rel_path="${param_file#${PARAMS_DIR}/}"
@@ -267,6 +269,7 @@ jobs:
               fi
 
               echo "$search_job_id" >> "$job_id_dir/${dataset_dir_name}.search"
+              echo "$search_job_id" >> "$search_job_list"
             done
 
             dataset_dirs=$(find "$PARAMS_DIR" -mindepth 1 -maxdepth 1 -type d -print)
@@ -356,15 +359,25 @@ jobs:
           run_dir="${CLUSTER_RUN_DIR_MOUNT:?CLUSTER_RUN_DIR_MOUNT not set}"
           job_id_dir="$run_dir/job-ids"
           metrics_job_list="$job_id_dir/metrics.ids"
+          search_job_list="$job_id_dir/search.ids"
 
           if [ ! -f "$metrics_job_list" ]; then
             echo "Metrics job ID list not found at $metrics_job_list" >&2
+            exit 1
+          fi
+          if [ ! -f "$search_job_list" ]; then
+            echo "Search job ID list not found at $search_job_list" >&2
             exit 1
           fi
 
           mapfile -t metrics_job_ids < "$metrics_job_list"
           if [ "${#metrics_job_ids[@]}" -eq 0 ]; then
             echo "Metrics job ID list is empty; cannot monitor metrics jobs" >&2
+            exit 1
+          fi
+          mapfile -t search_job_ids < "$search_job_list"
+          if [ "${#search_job_ids[@]}" -eq 0 ]; then
+            echo "Search job ID list is empty; cannot monitor search jobs" >&2
             exit 1
           fi
 
@@ -375,64 +388,84 @@ jobs:
             -o ConnectTimeout=30
           )
 
-          total_expected=${#metrics_job_ids[@]}
+          total_metrics=${#metrics_job_ids[@]}
+          total_search=${#search_job_ids[@]}
           poll_interval=300
           max_attempts=600
           attempt=1
           progress_log=()
 
-          echo "Polling for ${total_expected} metrics job(s)." | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "Polling for ${total_search} search job(s) and ${total_metrics} metrics job(s)." | tee -a "$GITHUB_STEP_SUMMARY"
 
           while :; do
-            remaining=()
+            remaining_metrics=()
             for job_id in "${metrics_job_ids[@]}"; do
               clean_id="${job_id%$'\r'}"
               [ -n "$clean_id" ] || continue
-              remaining+=("$clean_id")
+              remaining_metrics+=("$clean_id")
             done
 
-            if [ "${#remaining[@]}" -eq 0 ]; then
+            remaining_search=()
+            for job_id in "${search_job_ids[@]}"; do
+              clean_id="${job_id%$'\r'}"
+              [ -n "$clean_id" ] || continue
+              remaining_search+=("$clean_id")
+            done
+
+            if [ "${#remaining_metrics[@]}" -eq 0 ]; then
               echo "No metrics job IDs remaining to monitor." >&2
+              exit 1
+            fi
+            if [ "${#remaining_search[@]}" -eq 0 ]; then
+              echo "No search job IDs remaining to monitor." >&2
               exit 1
             fi
 
             if ! timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-              "bjobs -a -noheader -o 'jobid' ${remaining[*]} 2>/dev/null | awk '/^[0-9]+$/' >/dev/null" >/dev/null 2>&1; then
+              "bjobs -a -noheader -o 'jobid' ${remaining_metrics[*]} ${remaining_search[*]} 2>/dev/null | awk '/^[0-9]+$/' >/dev/null" >/dev/null 2>&1; then
               echo "Cluster login failed or bjobs unavailable." >&2
               exit 1
             fi
 
             active_jobs=$(timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-              "bjobs -a -noheader -o 'jobid' ${remaining[*]} 2>/dev/null | awk '/^[0-9]+$/'" || true)
-            active_count=0
+              "bjobs -a -noheader -o 'jobid' ${remaining_metrics[*]} 2>/dev/null | awk '/^[0-9]+$/'" || true)
+            active_metrics=0
             if [ -n "$active_jobs" ]; then
-              active_count=$(printf '%s\n' "$active_jobs" | wc -l | tr -d ' ')
+              active_metrics=$(printf '%s\n' "$active_jobs" | wc -l | tr -d ' ')
+            fi
+            active_search_jobs=$(timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+              "bjobs -a -noheader -o 'jobid' ${remaining_search[*]} 2>/dev/null | awk '/^[0-9]+$/'" || true)
+            active_search=0
+            if [ -n "$active_search_jobs" ]; then
+              active_search=$(printf '%s\n' "$active_search_jobs" | wc -l | tr -d ' ')
             fi
 
             timestamp=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-            progress_entry="[${timestamp}] Attempt ${attempt}: ${active_count}/${total_expected} jobs still present"
+            progress_entry="[${timestamp}] Attempt ${attempt}: ${active_search}/${total_search} search jobs still present, ${active_metrics}/${total_metrics} metrics jobs still present"
             progress_log+=("$progress_entry")
             echo "$progress_entry" | tee -a "$GITHUB_STEP_SUMMARY"
 
-            if [ "$active_count" -gt 0 ]; then
-              echo "Waiting on ${active_count} metrics job(s)."
+            if [ "$active_search" -gt 0 ] || [ "$active_metrics" -gt 0 ]; then
+              echo "Waiting on ${active_search} search job(s) and ${active_metrics} metrics job(s)."
             fi
 
-            if [ "$active_count" -eq 0 ]; then
-              echo "All metrics jobs have finished; stopping monitor."
+            if [ "$active_search" -eq 0 ] && [ "$active_metrics" -eq 0 ]; then
+              echo "All search and metrics jobs have finished; stopping monitor."
               break
             fi
 
             if [ "$attempt" -ge "$max_attempts" ]; then
               echo "Timeout waiting for metrics jobs after $((poll_interval * max_attempts / 60)) minutes" >&2
               printf 'Still running:\n' >&2
-              printf '  %s\n' "${active_count}" >&2
+              printf '  search=%s metrics=%s\n' "${active_search}" "${active_metrics}" >&2
               {
                 echo "## Cluster metrics polling"
                 echo "- Run directory: $run_dir"
-                echo "- Expected jobs: $total_expected"
+                echo "- Expected search jobs: $total_search"
+                echo "- Expected metrics jobs: $total_metrics"
                 echo "- Status: timed out"
-                echo "- Remaining jobs: $active_count"
+                echo "- Remaining search jobs: $active_search"
+                echo "- Remaining metrics jobs: $active_metrics"
                 echo "- Progress log:"
                 for line in "${progress_log[@]}"; do
                   echo "  - $line"
@@ -448,7 +481,8 @@ jobs:
           {
             echo "## Cluster metrics polling"
             echo "- Run directory: $run_dir"
-            echo "- Expected jobs: $total_expected"
+            echo "- Expected search jobs: $total_search"
+            echo "- Expected metrics jobs: $total_metrics"
             echo "- Status: completed"
             echo "- Progress log:"
             for line in "${progress_log[@]}"; do

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -422,19 +422,19 @@ jobs:
             fi
 
             if ! timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-              "bjobs -a -noheader -o 'jobid' ${remaining_metrics[*]} ${remaining_search[*]} 2>/dev/null | awk '/^[0-9]+$/' >/dev/null" >/dev/null 2>&1; then
+              "bjobs -noheader -o 'jobid' ${remaining_metrics[*]} ${remaining_search[*]} 2>/dev/null | awk '/^[0-9]+$/' >/dev/null" >/dev/null 2>&1; then
               echo "Cluster login failed or bjobs unavailable." >&2
               exit 1
             fi
 
             active_jobs=$(timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-              "bjobs -a -noheader -o 'jobid' ${remaining_metrics[*]} 2>/dev/null | awk '/^[0-9]+$/'" || true)
+              "bjobs -noheader -o 'jobid' ${remaining_metrics[*]} 2>/dev/null | awk '/^[0-9]+$/'" || true)
             active_metrics=0
             if [ -n "$active_jobs" ]; then
               active_metrics=$(printf '%s\n' "$active_jobs" | wc -l | tr -d ' ')
             fi
             active_search_jobs=$(timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-              "bjobs -a -noheader -o 'jobid' ${remaining_search[*]} 2>/dev/null | awk '/^[0-9]+$/'" || true)
+              "bjobs -noheader -o 'jobid' ${remaining_search[*]} 2>/dev/null | awk '/^[0-9]+$/'" || true)
             active_search=0
             if [ -n "$active_search_jobs" ]; then
               active_search=$(printf '%s\n' "$active_search_jobs" | wc -l | tr -d ' ')
@@ -582,13 +582,13 @@ jobs:
 
           while [ "$attempt" -le "$max_attempts" ]; do
             if ! timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-              "bjobs -a -noheader -o 'jobid' ${report_job_id}" >/dev/null 2>&1; then
+              "bjobs -noheader -o 'jobid' ${report_job_id}" >/dev/null 2>&1; then
               echo "Cluster login failed or bjobs unavailable." >&2
               exit 1
             fi
 
             report_active=$(timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-              "bjobs -a -noheader -o 'jobid' ${report_job_id} 2>/dev/null | tr -d ' '" || true)
+              "bjobs -noheader -o 'jobid' ${report_job_id} 2>/dev/null | tr -d ' '" || true)
 
             if [ -z "$report_active" ]; then
               echo "Report job has finished; stopping monitor."

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -387,9 +387,11 @@ jobs:
 
           ssh_options=(
             -o BatchMode=yes
+            -o LogLevel=ERROR
             -o ServerAliveInterval=60
             -o ServerAliveCountMax=3
             -o ConnectTimeout=30
+            -q
           )
 
           total_metrics=${#metrics_job_ids[@]}
@@ -522,9 +524,11 @@ jobs:
 
           ssh_options=(
             -o BatchMode=yes
+            -o LogLevel=ERROR
             -o ServerAliveInterval=60
             -o ServerAliveCountMax=3
             -o ConnectTimeout=30
+            -q
           )
 
           report_submit="$(timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
@@ -582,9 +586,11 @@ jobs:
 
           ssh_options=(
             -o BatchMode=yes
+            -o LogLevel=ERROR
             -o ServerAliveInterval=60
             -o ServerAliveCountMax=3
             -o ConnectTimeout=30
+            -q
           )
 
           poll_interval=60

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -456,10 +456,6 @@ jobs:
             progress_log+=("$progress_entry")
             echo "$progress_entry" | tee -a "$GITHUB_STEP_SUMMARY"
 
-            if [ "$active_search" -gt 0 ] || [ "$active_metrics" -gt 0 ]; then
-              echo "Waiting on ${active_search} search job(s) and ${active_metrics} metrics job(s)."
-            fi
-
             if [ "$active_search" -eq 0 ] && [ "$active_metrics" -eq 0 ]; then
               echo "All search and metrics jobs have finished; stopping monitor."
               break

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -600,14 +600,15 @@ jobs:
           echo "Monitoring report job ID: ${report_job_id}"
 
           while [ "$attempt" -le "$max_attempts" ]; do
-            if ! timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-              "bjobs -noheader -o 'jobid' ${report_job_id}" >/dev/null 2>&1; then
+            if ! timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "true" >/dev/null 2>&1; then
               echo "Cluster login failed or bjobs unavailable." >&2
               exit 1
             fi
 
-            report_active=$(timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-              "bjobs -noheader -o 'jobid' ${report_job_id} 2>/dev/null | awk '/^[0-9]+$/'" || true)
+            running_jobs=$(timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+              "bjobs -noheader -o 'jobid' 2>/dev/null | awk '/^[0-9]+$/'" || true)
+
+            report_active=$(printf '%s\n' "$running_jobs" | awk -v id="$report_job_id" '$0 == id { found=1 } END { if (found) print id }')
 
             if [ -z "$report_active" ]; then
               echo "Report job has finished; stopping monitor."

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -381,8 +381,7 @@ jobs:
           attempt=1
           progress_log=()
 
-          echo "Polling for ${total_expected} metrics job IDs:" | tee -a "$GITHUB_STEP_SUMMARY"
-          printf '  %s\n' "${metrics_job_ids[@]}" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "Polling for ${total_expected} metrics job(s)." | tee -a "$GITHUB_STEP_SUMMARY"
 
           while :; do
             remaining=()
@@ -397,17 +396,17 @@ jobs:
               exit 1
             fi
 
-            if ! timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "bjobs -a -noheader -o 'jobid' ${remaining[*]}" >/dev/null 2>&1; then
+            if ! timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+              "bjobs -a -noheader -o 'jobid' ${remaining[*]} 2>/dev/null | awk '/^[0-9]+$/' >/dev/null" >/dev/null 2>&1; then
               echo "Cluster login failed or bjobs unavailable." >&2
               exit 1
             fi
 
             active_jobs=$(timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-              "bjobs -a -noheader -o 'jobid' ${remaining[*]} 2>/dev/null | tr -d ' '" || true)
-            mapfile -t active_list <<< "$active_jobs"
+              "bjobs -a -noheader -o 'jobid' ${remaining[*]} 2>/dev/null | awk '/^[0-9]+$/'" || true)
             active_count=0
             if [ -n "$active_jobs" ]; then
-              active_count=${#active_list[@]}
+              active_count=$(printf '%s\n' "$active_jobs" | wc -l | tr -d ' ')
             fi
 
             timestamp=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
@@ -416,8 +415,7 @@ jobs:
             echo "$progress_entry" | tee -a "$GITHUB_STEP_SUMMARY"
 
             if [ "$active_count" -gt 0 ]; then
-              echo "Waiting on metrics job IDs:"
-              printf '  %s\n' "${active_list[@]}"
+              echo "Waiting on ${active_count} metrics job(s)."
             fi
 
             if [ "$active_count" -eq 0 ]; then
@@ -428,16 +426,13 @@ jobs:
             if [ "$attempt" -ge "$max_attempts" ]; then
               echo "Timeout waiting for metrics jobs after $((poll_interval * max_attempts / 60)) minutes" >&2
               printf 'Still running:\n' >&2
-              printf '  %s\n' "${active_list[@]}" >&2
+              printf '  %s\n' "${active_count}" >&2
               {
                 echo "## Cluster metrics polling"
                 echo "- Run directory: $run_dir"
                 echo "- Expected jobs: $total_expected"
                 echo "- Status: timed out"
-                echo "- Remaining job IDs:"
-                for entry in "${active_list[@]}"; do
-                  echo "  - $entry"
-                done
+                echo "- Remaining jobs: $active_count"
                 echo "- Progress log:"
                 for line in "${progress_log[@]}"; do
                   echo "  - $line"
@@ -562,24 +557,23 @@ jobs:
               "bjobs -a -noheader -o 'jobid' ${report_job_id} 2>/dev/null | tr -d ' '" || true)
 
             if [ -z "$report_active" ]; then
-              echo "Report job ${report_job_id} has finished; stopping monitor."
+              echo "Report job has finished; stopping monitor."
               echo "REPORT_PAGES_SUBDIR=${report_subdir}" >> "$GITHUB_ENV"
               echo "REPORT_PAGES_STAGING_DIR=${staging_dir}" >> "$GITHUB_ENV"
               echo "REPORT_PAGES_DIR=${staging_dir}" >> "$GITHUB_ENV"
               {
                 echo "## Regression report"
-                echo "- Report job ID: $report_job_id"
                 echo "- Pages report path: ${report_subdir}/index.html"
               } >> "$GITHUB_STEP_SUMMARY"
               exit 0
             fi
 
-            echo "Waiting for report job ${report_job_id} (attempt ${attempt}/${max_attempts})..."
+            echo "Waiting for report job (attempt ${attempt}/${max_attempts})..."
             attempt=$((attempt + 1))
             sleep "$poll_interval"
           done
 
-          echo "Timeout waiting for report job ${report_job_id}" >&2
+          echo "Timeout waiting for report job" >&2
           exit 1
 
       - name: Update gh-pages site on cluster

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -597,6 +597,8 @@ jobs:
           max_attempts=180
           attempt=1
 
+          echo "Monitoring report job ID: ${report_job_id}"
+
           while [ "$attempt" -le "$max_attempts" ]; do
             if ! timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
               "bjobs -noheader -o 'jobid' ${report_job_id}" >/dev/null 2>&1; then
@@ -605,7 +607,7 @@ jobs:
             fi
 
             report_active=$(timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-              "bjobs -noheader -o 'jobid' ${report_job_id} 2>/dev/null | tr -d ' '" || true)
+              "bjobs -noheader -o 'jobid' ${report_job_id} 2>/dev/null | awk '/^[0-9]+$/'" || true)
 
             if [ -z "$report_active" ]; then
               echo "Report job has finished; stopping monitor."

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -422,23 +422,34 @@ jobs:
             fi
 
             if ! timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-              "bjobs -noheader -o 'jobid' ${remaining_metrics[*]} ${remaining_search[*]} 2>/dev/null | awk '/^[0-9]+$/' >/dev/null" >/dev/null 2>&1; then
+              "bjobs -noheader -o 'jobid' 2>/dev/null | awk '/^[0-9]+$/' >/dev/null" >/dev/null 2>&1; then
               echo "Cluster login failed or bjobs unavailable." >&2
               exit 1
             fi
 
-            active_jobs=$(timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-              "bjobs -noheader -o 'jobid' ${remaining_metrics[*]} 2>/dev/null | awk '/^[0-9]+$/'" || true)
+            running_jobs=$(timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+              "bjobs -noheader -o 'jobid' 2>/dev/null | awk '/^[0-9]+$/'" || true)
+            declare -A running_map=()
+            if [ -n "$running_jobs" ]; then
+              while IFS= read -r job_id; do
+                [ -n "$job_id" ] || continue
+                running_map["$job_id"]=1
+              done <<< "$running_jobs"
+            fi
+
             active_metrics=0
-            if [ -n "$active_jobs" ]; then
-              active_metrics=$(printf '%s\n' "$active_jobs" | wc -l | tr -d ' ')
-            fi
-            active_search_jobs=$(timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-              "bjobs -noheader -o 'jobid' ${remaining_search[*]} 2>/dev/null | awk '/^[0-9]+$/'" || true)
+            for job_id in "${remaining_metrics[@]}"; do
+              if [[ -n "${running_map[$job_id]+x}" ]]; then
+                active_metrics=$((active_metrics + 1))
+              fi
+            done
+
             active_search=0
-            if [ -n "$active_search_jobs" ]; then
-              active_search=$(printf '%s\n' "$active_search_jobs" | wc -l | tr -d ' ')
-            fi
+            for job_id in "${remaining_search[@]}"; do
+              if [[ -n "${running_map[$job_id]+x}" ]]; then
+                active_search=$((active_search + 1))
+              fi
+            done
 
             timestamp=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
             progress_entry="[${timestamp}] Attempt ${attempt}: ${active_search}/${total_search} search jobs still present, ${active_metrics}/${total_metrics} metrics jobs still present"

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -827,8 +827,7 @@ jobs:
             }
             const normalizedBase = pagesUrl.endsWith('/') ? pagesUrl.slice(0, -1) : pagesUrl;
             const reportUrl = `${normalizedBase}/${reportSubdir}/`;
-            const historyUrl = `${normalizedBase}/reports/`;
-            const body = `**Regression metrics report**: <a href="${reportUrl}" target="_blank" rel="noopener noreferrer">Open report</a><br/>**Report history**: <a href="${historyUrl}" target="_blank" rel="noopener noreferrer">View all reports</a>`;
+            const body = `**Regression metrics report**: <a href="${reportUrl}" target="_blank" rel="noopener noreferrer">Open report</a>`;
             const { owner, repo } = context.repo;
             const pulls = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner,

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -84,9 +84,11 @@ jobs:
 
           ssh_options=(
             -o BatchMode=yes
+            -o LogLevel=ERROR
             -o ServerAliveInterval=60
             -o ServerAliveCountMax=3
             -o ConnectTimeout=30
+            -q
           )
 
           timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' DEPOT_DIR='${depot_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${GITHUB_SHA}' ENTRAPMENT_DIR='${entrapment_dir}' ENTRAPMENT_REPO_URL='${entrapment_repo_url}' bash -s" <<'EOF'
@@ -146,9 +148,11 @@ jobs:
 
           ssh_options=(
             -o BatchMode=yes
+            -o LogLevel=ERROR
             -o ServerAliveInterval=60
             -o ServerAliveCountMax=3
             -o ConnectTimeout=30
+            -q
           )
 
           timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -294,6 +294,8 @@ jobs:
               dataset_name="$(basename "$dataset_dir")"
               job_list_file="$job_id_dir/${dataset_name}.search"
               metrics_file="$dataset_dir/metrics.json"
+              metrics_job_list="$job_id_dir/metrics.ids"
+              touch "$metrics_job_list"
 
               if [ ! -f "$metrics_file" ]; then
                 echo "Skipping dataset $dataset_name: missing metrics.json" >&2
@@ -337,105 +339,103 @@ jobs:
                 printf '%s\n' "$metrics_submit" >&2
                 exit 1
               fi
+
+              echo "$metrics_job_id" >> "$metrics_job_list"
             done
           EOF
 
       - name: Wait for regression outputs on shared storage
         env:
           CLUSTER_RUN_DIR_MOUNT: ${{ env.CLUSTER_RUN_DIR_MOUNT }}
+          CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
+          CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
         shell: bash
         run: |
           set -euo pipefail
 
           run_dir="${CLUSTER_RUN_DIR_MOUNT:?CLUSTER_RUN_DIR_MOUNT not set}"
-          manifest_path="$run_dir/job-ids/expected_results.txt"
-          results_root="$run_dir/results"
+          job_id_dir="$run_dir/job-ids"
+          metrics_job_list="$job_id_dir/metrics.ids"
 
-          if [ ! -f "$manifest_path" ]; then
-            echo "Expected manifest not found at $manifest_path" >&2
+          if [ ! -f "$metrics_job_list" ]; then
+            echo "Metrics job ID list not found at $metrics_job_list" >&2
             exit 1
           fi
 
-          mapfile -t manifest_entries < "$manifest_path"
-
-          if [ "${#manifest_entries[@]}" -eq 0 ]; then
-            echo "Manifest is empty; cannot determine expected results" >&2
+          mapfile -t metrics_job_ids < "$metrics_job_list"
+          if [ "${#metrics_job_ids[@]}" -eq 0 ]; then
+            echo "Metrics job ID list is empty; cannot monitor metrics jobs" >&2
             exit 1
           fi
 
-          declare -A seen
-          unique_entries=()
-          for entry in "${manifest_entries[@]}"; do
-            clean_entry="${entry%$'\r'}"
-            [ -n "$clean_entry" ] || continue
-            if [[ -z "${seen[$clean_entry]+x}" ]]; then
-              seen[$clean_entry]=1
-              unique_entries+=("$clean_entry")
-            fi
-          done
+          ssh_options=(
+            -o BatchMode=yes
+            -o ServerAliveInterval=60
+            -o ServerAliveCountMax=3
+            -o ConnectTimeout=30
+          )
 
-          total_expected=${#unique_entries[@]}
+          total_expected=${#metrics_job_ids[@]}
           poll_interval=300
           max_attempts=600
           attempt=1
           progress_log=()
 
-          echo "Polling for ${total_expected} result paths:" | tee -a "$GITHUB_STEP_SUMMARY"
-          printf '  %s\n' "${unique_entries[@]}" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "Polling for ${total_expected} metrics job IDs:" | tee -a "$GITHUB_STEP_SUMMARY"
+          printf '  %s\n' "${metrics_job_ids[@]}" | tee -a "$GITHUB_STEP_SUMMARY"
 
           while :; do
-            found=0
-            missing=()
-
-            for dataset in "${unique_entries[@]}"; do
-              dataset_dir="$results_root/$dataset"
-
-              metrics_glob="$dataset_dir/metrics_${dataset}_*.json"
-              metrics_present=0
-              if compgen -G "$metrics_glob" > /dev/null; then
-                metrics_present=1
-              fi
-
-              log_present=""
-              if compgen -G "$dataset_dir/*.log" > /dev/null; then
-                log_present=1
-              elif compgen -G "$dataset_dir/*.log.gz" > /dev/null; then
-                log_present=1
-              fi
-
-              if [ "$metrics_present" -eq 1 ] || [ -n "$log_present" ]; then
-                found=$((found + 1))
-              else
-                missing+=("$dataset")
-              fi
+            remaining=()
+            for job_id in "${metrics_job_ids[@]}"; do
+              clean_id="${job_id%$'\r'}"
+              [ -n "$clean_id" ] || continue
+              remaining+=("$clean_id")
             done
 
+            if [ "${#remaining[@]}" -eq 0 ]; then
+              echo "No metrics job IDs remaining to monitor." >&2
+              exit 1
+            fi
+
+            if ! timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "bjobs -a -noheader -o 'jobid' ${remaining[*]}" >/dev/null 2>&1; then
+              echo "Cluster login failed or bjobs unavailable." >&2
+              exit 1
+            fi
+
+            active_jobs=$(timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+              "bjobs -a -noheader -o 'jobid' ${remaining[*]} 2>/dev/null | tr -d ' '" || true)
+            mapfile -t active_list <<< "$active_jobs"
+            active_count=0
+            if [ -n "$active_jobs" ]; then
+              active_count=${#active_list[@]}
+            fi
+
             timestamp=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-            progress_entry="[${timestamp}] Attempt ${attempt}: ${found}/${total_expected} ready"
+            progress_entry="[${timestamp}] Attempt ${attempt}: ${active_count}/${total_expected} jobs still present"
             progress_log+=("$progress_entry")
             echo "$progress_entry" | tee -a "$GITHUB_STEP_SUMMARY"
 
-            if [ "${#missing[@]}" -gt 0 ]; then
-              echo "Missing entries:"
-              printf '  %s\n' "${missing[@]}"
+            if [ "$active_count" -gt 0 ]; then
+              echo "Waiting on metrics job IDs:"
+              printf '  %s\n' "${active_list[@]}"
             fi
 
-            if [ "${#missing[@]}" -eq 0 ]; then
-              echo "All expected regression outputs detected."
+            if [ "$active_count" -eq 0 ]; then
+              echo "All metrics jobs have finished; stopping monitor."
               break
             fi
 
             if [ "$attempt" -ge "$max_attempts" ]; then
-              echo "Timeout waiting for regression outputs after $((poll_interval * max_attempts / 60)) minutes" >&2
-              printf 'Still missing:\n' >&2
-              printf '  %s\n' "${missing[@]}" >&2
+              echo "Timeout waiting for metrics jobs after $((poll_interval * max_attempts / 60)) minutes" >&2
+              printf 'Still running:\n' >&2
+              printf '  %s\n' "${active_list[@]}" >&2
               {
-                echo "## Cluster results polling"
+                echo "## Cluster metrics polling"
                 echo "- Run directory: $run_dir"
-                echo "- Expected outputs: $total_expected"
+                echo "- Expected jobs: $total_expected"
                 echo "- Status: timed out"
-                echo "- Missing entries:"
-                for entry in "${missing[@]}"; do
+                echo "- Remaining job IDs:"
+                for entry in "${active_list[@]}"; do
                   echo "  - $entry"
                 done
                 echo "- Progress log:"
@@ -451,9 +451,9 @@ jobs:
           done
 
           {
-            echo "## Cluster results polling"
+            echo "## Cluster metrics polling"
             echo "- Run directory: $run_dir"
-            echo "- Expected outputs: $total_expected"
+            echo "- Expected jobs: $total_expected"
             echo "- Status: completed"
             echo "- Progress log:"
             for line in "${progress_log[@]}"; do
@@ -524,6 +524,9 @@ jobs:
           CLUSTER_RUN_DIR: ${{ env.CLUSTER_RUN_DIR }}
           CLUSTER_RUN_DIR_MOUNT: ${{ env.CLUSTER_RUN_DIR_MOUNT }}
           REPORT_HTML_PATH: ${{ env.REPORT_HTML_PATH }}
+          REPORT_JOB_ID: ${{ env.REPORT_JOB_ID }}
+          CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
+          CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
         shell: bash
         run: |
           set -euo pipefail
@@ -535,31 +538,48 @@ jobs:
           ref_name="${GITHUB_REF_NAME:-unknown}"
           ref_sanitized=$(printf '%s' "$ref_name" | tr '/ ' '__')
           report_subdir="reports/${ref_sanitized}/${GITHUB_SHA:-unknown}/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          report_job_id="${REPORT_JOB_ID:?REPORT_JOB_ID not set}"
+
+          ssh_options=(
+            -o BatchMode=yes
+            -o ServerAliveInterval=60
+            -o ServerAliveCountMax=3
+            -o ConnectTimeout=30
+          )
 
           poll_interval=60
           max_attempts=180
           attempt=1
 
           while [ "$attempt" -le "$max_attempts" ]; do
-            if [ -f "$html_report_path" ]; then
-              echo "Report found at $html_report_path"
+            if ! timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+              "bjobs -a -noheader -o 'jobid' ${report_job_id}" >/dev/null 2>&1; then
+              echo "Cluster login failed or bjobs unavailable." >&2
+              exit 1
+            fi
+
+            report_active=$(timeout 120 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+              "bjobs -a -noheader -o 'jobid' ${report_job_id} 2>/dev/null | tr -d ' '" || true)
+
+            if [ -z "$report_active" ]; then
+              echo "Report job ${report_job_id} has finished; stopping monitor."
               echo "REPORT_PAGES_SUBDIR=${report_subdir}" >> "$GITHUB_ENV"
               echo "REPORT_PAGES_STAGING_DIR=${staging_dir}" >> "$GITHUB_ENV"
               echo "REPORT_PAGES_DIR=${staging_dir}" >> "$GITHUB_ENV"
               {
                 echo "## Regression report"
-                echo "- HTML report path: $html_report_path"
+                echo "- Report job ID: $report_job_id"
                 echo "- Pages report path: ${report_subdir}/index.html"
               } >> "$GITHUB_STEP_SUMMARY"
               exit 0
             fi
 
-            echo "Waiting for report output (attempt ${attempt}/${max_attempts})..."
+            echo "Waiting for report job ${report_job_id} (attempt ${attempt}/${max_attempts})..."
             attempt=$((attempt + 1))
             sleep "$poll_interval"
           done
 
-          echo "Timeout waiting for regression report at $html_report_path" >&2
+          echo "Timeout waiting for report job ${report_job_id}" >&2
           exit 1
 
       - name: Update gh-pages site on cluster


### PR DESCRIPTION
### Motivation
- Replace fragile filesystem polling of `results` with direct cluster job queue checks via `bjobs` to more reliably detect completion.
- Ensure metrics job IDs are recorded at submission so they can be monitored remotely rather than inferred from files.
- Use SSH login checks and suppressed output so the workflow only needs to know login success and which jobs remain.
- Apply the same queue-based monitoring to the report job to avoid waiting on shared storage artifacts.

### Description
- Record metrics job IDs to `job-ids/metrics.ids` during metrics submission (`bsub`) for later monitoring.
- Replace polling of result files with periodic `ssh` calls that run `bjobs` against the recorded job IDs, using `ssh` options and `timeout` to avoid hanging.
- Add `REPORT_JOB_ID` handling and switch the report wait step to check `bjobs` for the report job ID and export pages env vars once the job finishes.
- Update `GITHUB_STEP_SUMMARY` messages to show active job IDs, progress log entries, timeout information, and fail fast on SSH/bjobs errors.

### Testing
- No automated tests were run for this change because it only modifies the CI workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959c2c6a9408325ae4679655f1d32ba)