### PR TITLE
fix: bkill leftover regression jobs in cleanup

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1038,6 +1038,18 @@ jobs:
               fi
 
               submit_out=$(RUN_DIR="$RUN_DIR" RUN_SUFFIX="$RUN_SUFFIX" bsub $cleanup_wait < "$CLEANUP_SCRIPT")
+              job_id_dir="$RUN_DIR/job-ids"
+              for job_list in "$job_id_dir/search.ids" "$job_id_dir/metrics.ids"; do
+                if [ -f "$job_list" ]; then
+                  while IFS= read -r job_id; do
+                    [ -n "$job_id" ] || continue
+                    bkill "$job_id" >/dev/null 2>&1 || true
+                  done < "$job_list"
+                fi
+              done
+              if [ -n "$REPORT_JOB_ID" ]; then
+                bkill "$REPORT_JOB_ID" >/dev/null 2>&1 || true
+              fi
               printf '%s' "$submit_out"
           EOF
           )"

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -236,8 +236,11 @@ jobs:
             mkdir -p "$job_id_dir"
             manifest_file="$job_id_dir/expected_results.txt"
             search_job_list="$job_id_dir/search.ids"
+            setup_job_list="$job_id_dir/setup.ids"
             : > "$manifest_file"
             : > "$search_job_list"
+            : > "$setup_job_list"
+            echo "$setup_job_id" >> "$setup_job_list"
 
             printf '%s\n' "$param_list" | while IFS= read -r param_file; do
               rel_path="${param_file#${PARAMS_DIR}/}"
@@ -1039,7 +1042,7 @@ jobs:
 
               submit_out=$(RUN_DIR="$RUN_DIR" RUN_SUFFIX="$RUN_SUFFIX" bsub $cleanup_wait < "$CLEANUP_SCRIPT")
               job_id_dir="$RUN_DIR/job-ids"
-              for job_list in "$job_id_dir/search.ids" "$job_id_dir/metrics.ids"; do
+              for job_list in "$job_id_dir/setup.ids" "$job_id_dir/search.ids" "$job_id_dir/metrics.ids"; do
                 if [ -f "$job_list" ]; then
                   while IFS= read -r job_id; do
                     [ -n "$job_id" ] || continue


### PR DESCRIPTION
### Motivation
- Ensure the regression workflow cleanup step terminates any remaining cluster jobs to avoid resource leakage.
- The previous cleanup only submitted a cleanup job but did not proactively kill outstanding `search`, `metrics`, or report jobs.

### Description
- Update `.github/workflows/regression.yml` to define `job_id_dir` and iterate over `job-ids/search.ids` and `job-ids/metrics.ids` to `bkill` each recorded job ID.
- Also call `bkill` on the `REPORT_JOB_ID` if present, while preserving the existing `bsub` cleanup job submission logic.
- Errors from `bkill` are ignored (`|| true`) so the cleanup step remains best-effort and non-fatal.

### Testing
- No automated tests were run because this is a workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695be1ce0f88832586a15ea4c242bf69)