### PR TITLE
chore: publish Docker images on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,3 +44,38 @@ jobs:
           version: ${{ needs.linux.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker:
+    name: Publish Docker Images
+    needs:
+      - linux
+      - macos
+      - windows
+      - publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push release image
+        run: |
+          docker build -t dennisgoldfarb/pioneer:${{ needs.linux.outputs.version }} .
+          docker push dennisgoldfarb/pioneer:${{ needs.linux.outputs.version }}
+
+      - name: Build and push latest image
+        run: |
+          docker build -t dennisgoldfarb/pioneer:latest .
+          docker push dennisgoldfarb/pioneer:latest


### PR DESCRIPTION
### Motivation
- Automatically publish Docker images as part of the release workflow so release artifacts are published and a `latest` image is kept up-to-date.
- Mirror local Docker commands (`docker build -t dennisgoldfarb/pioneer:latest .` / `docker push dennisgoldfarb/pioneer:latest`) in CI to simplify deployment.
- Tag images with the release version and also push a `latest` tag for convenience when consumers want the most recent build.
- Use repository secrets for Docker Hub credentials to avoid embedding secrets in the workflow.

### Description
- Added a `docker` job to `.github/workflows/release.yml` that runs after the build and publish steps and depends on the release jobs.
- The job sets up Buildx with `docker/setup-buildx-action@v3` and logs into Docker Hub with `docker/login-action@v3` using `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`.
- The job builds and pushes a versioned image `dennisgoldfarb/pioneer:${{ needs.linux.outputs.version }}` and then builds and pushes `dennisgoldfarb/pioneer:latest` using `docker build`/`docker push`.
- The job runs on `ubuntu-latest` and is configured with minimal `contents: read` permissions for the steps it performs.

### Testing
- No automated tests were run because this change only updates CI workflow configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695be5bba90883258dd5fe64ded142da)