### PR TITLE
chore: pin Docker image build to release version via build-arg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,3 +44,39 @@ jobs:
           version: ${{ needs.linux.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker:
+    name: Publish Docker Images
+    needs:
+      - linux
+      - macos
+      - windows
+      - publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push release image
+        run: |
+          docker build --build-arg PIONEER_VERSION=${{ needs.linux.outputs.version }} \
+            -t dennisgoldfarb/pioneer:${{ needs.linux.outputs.version }} .
+          docker push dennisgoldfarb/pioneer:${{ needs.linux.outputs.version }}
+
+      - name: Build and push latest image
+        run: |
+          docker build -t dennisgoldfarb/pioneer:latest .
+          docker push dennisgoldfarb/pioneer:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,18 @@ RUN apt-get update \
     && apt-get install -y curl ca-certificates jq libicu-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Get latest release info from GitHub API and download the correct .deb asset
-RUN LATEST_VERSION=$(curl -s https://api.github.com/repos/nwamsley1/Pioneer.jl/releases/latest | jq -r .tag_name) && \
-    FILE_NAME=$(curl -s https://api.github.com/repos/nwamsley1/Pioneer.jl/releases/latest \
+ARG PIONEER_VERSION=latest
+
+# Get release info from GitHub API and download the correct .deb asset
+RUN if [ "$PIONEER_VERSION" = "latest" ]; then \
+        RELEASE_URL="https://api.github.com/repos/nwamsley1/Pioneer.jl/releases/latest"; \
+    else \
+        RELEASE_URL="https://api.github.com/repos/nwamsley1/Pioneer.jl/releases/tags/${PIONEER_VERSION}"; \
+    fi && \
+    TAG_NAME=$(curl -s "$RELEASE_URL" | jq -r .tag_name) && \
+    FILE_NAME=$(curl -s "$RELEASE_URL" \
         | jq -r '.assets[] | select(.name | endswith(".deb")) | .name') && \
-    curl -L "https://github.com/nwamsley1/Pioneer.jl/releases/download/${LATEST_VERSION}/${FILE_NAME}" -o /tmp/${FILE_NAME} && \
+    curl -L "https://github.com/nwamsley1/Pioneer.jl/releases/download/${TAG_NAME}/${FILE_NAME}" -o /tmp/${FILE_NAME} && \
     apt-get install -y /tmp/${FILE_NAME} && \
     rm /tmp/${FILE_NAME}
 


### PR DESCRIPTION
### Motivation
- Ensure the versioned Docker image tag actually contains the matching Pioneer release instead of always baking whatever is `latest` at build time.
- Address the race condition where `releases/latest` could change while the release job runs so the tagged image is reliable.
- Make the release workflow produce repeatable, auditable images for the published release version.

### Description
- Add `ARG PIONEER_VERSION=latest` to the `Dockerfile` and use it to choose the GitHub release URL so builds can target a specific tag or `latest`.
- Replace the unconditional `releases/latest` lookup with logic that fetches `/releases/tags/${PIONEER_VERSION}` when a version is provided and falls back to `/releases/latest` otherwise.
- Pass the release version into the Docker build in `.github/workflows/release.yml` via `--build-arg PIONEER_VERSION=${{ needs.linux.outputs.version }}` when building the versioned image tag.
- Continue building and pushing the `latest` tag unchanged for convenience.

### Testing
- No automated tests were executed because this change only updates the Dockerfile and CI workflow configuration.
- CI workflows were not run as part of this change, so behavior will be validated on the next release run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695be5bba90883258dd5fe64ded142da)