### PR TITLE
chore: bump Julia version to 1.12

### DIFF
--- a/.github/workflows/build_app_linux.yml
+++ b/.github/workflows/build_app_linux.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Julia
         uses: julia-actions/setup-julia@v2
         with:
-          version: '1.11'
+          version: '1.12'
 
       - name: Cache Julia packages
         uses: actions/cache@v4

--- a/.github/workflows/build_app_macos.yml
+++ b/.github/workflows/build_app_macos.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Julia
         uses: julia-actions/setup-julia@v2
         with:
-          version: '1.11'
+          version: '1.12'
           arch: ${{ matrix.arch }}
 
       - name: Cache Julia packages

--- a/.github/workflows/build_app_windows.yml
+++ b/.github/workflows/build_app_windows.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Julia
         uses: julia-actions/setup-julia@v2
         with:
-          version: '1.11'
+          version: '1.12'
           arch: ${{ matrix.arch }}
 
       - name: Cache Julia packages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: julia-actions/setup-julia@v2
         with:
-          version: '1.11'
+          version: '1.12'
 
       - name: Cache docs packages
         uses: actions/cache@v4

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 7200
     strategy:
       matrix:
-        version: ['1.11']
+        version: ['1.12']
         dataset_set: ${{ github.event_name == 'release' && fromJSON('["all"]') || (github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.dataset_set)) || fromJSON('["fastest","fast","all"]')) }}
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.11']
+        version: ['1.12']
         os:      [ubuntu-latest]
         arch:    [x64]
 

--- a/Project.toml
+++ b/Project.toml
@@ -97,7 +97,7 @@ StatsBase = "0.34"
 StatsModels = "0.7"
 StatsPlots = "0.15"
 Tables = "1.12"
-julia = "1.11"
+julia = "1.12"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
### Motivation
- Raise the package Julia compatibility to `1.12` to align with newer language features and CI environments.
- Ensure GitHub Actions run workflows using Julia `1.12` so CI and packaging use the updated runtime.

### Description
- Updated the Julia compat entry in `Project.toml` from `1.11` to `1.12`.
- Updated GitHub Actions workflow files to use Julia `1.12` in `tests.yml`, `regression.yml`, `docs.yml`, and the platform-specific `build_app_*.yml` workflows.
- A total of 7 files were modified to reflect the new Julia version.

### Testing
- No automated tests were executed as part of this change.
- CI workflows have been updated and will run under Julia `1.12` when this branch is pushed or a PR is opened.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c1e4cbd0c8325bed10fd77afed108)