### PR TITLE
chore: force headless GR/Plots in CI build workflows

### DIFF
--- a/.github/workflows/build_app_linux.yml
+++ b/.github/workflows/build_app_linux.yml
@@ -29,6 +29,7 @@ jobs:
     env:
       GKSwstype: "100"
       GKS_ENCODING: "utf-8"
+      JULIA_NUM_PRECOMPILE_TASKS: "1"
       JULIA_NUM_THREADS: auto
     outputs:
       version: ${{ steps.get_version.outputs.version }}

--- a/.github/workflows/build_app_linux.yml
+++ b/.github/workflows/build_app_linux.yml
@@ -27,6 +27,8 @@ jobs:
       cancel-in-progress: true
     runs-on: [self-hosted, Linux, pioneer-compile]
     env:
+      GKSwstype: "100"
+      GKS_ENCODING: "utf-8"
       JULIA_NUM_THREADS: auto
     outputs:
       version: ${{ steps.get_version.outputs.version }}

--- a/.github/workflows/build_app_macos.yml
+++ b/.github/workflows/build_app_macos.yml
@@ -29,6 +29,7 @@ jobs:
     env:
       GKSwstype: "100"
       GKS_ENCODING: "utf-8"
+      JULIA_NUM_PRECOMPILE_TASKS: "1"
       JULIA_NUM_THREADS: auto
       MACOS_CERT_P12: ${{ secrets.MACOS_CERT_P12 }}
     outputs:

--- a/.github/workflows/build_app_macos.yml
+++ b/.github/workflows/build_app_macos.yml
@@ -27,6 +27,8 @@ jobs:
       cancel-in-progress: true
     runs-on: ${{ matrix.runner }}
     env:
+      GKSwstype: "100"
+      GKS_ENCODING: "utf-8"
       JULIA_NUM_THREADS: auto
       MACOS_CERT_P12: ${{ secrets.MACOS_CERT_P12 }}
     outputs:

--- a/.github/workflows/build_app_windows.yml
+++ b/.github/workflows/build_app_windows.yml
@@ -27,6 +27,8 @@ jobs:
       cancel-in-progress: true
     runs-on: windows-latest
     env:
+      GKSwstype: "100"
+      GKS_ENCODING: "utf-8"
       JULIA_NUM_THREADS: auto
     outputs:
       version: ${{ steps.get_version.outputs.version }}

--- a/.github/workflows/build_app_windows.yml
+++ b/.github/workflows/build_app_windows.yml
@@ -29,6 +29,7 @@ jobs:
     env:
       GKSwstype: "100"
       GKS_ENCODING: "utf-8"
+      JULIA_NUM_PRECOMPILE_TASKS: "1"
       JULIA_NUM_THREADS: auto
     outputs:
       version: ${{ steps.get_version.outputs.version }}


### PR DESCRIPTION
### Motivation
- Prevent GUI/backend issues during `PackageCompiler` steps by forcing the GR plotting backend into headless mode across all build runners.
- Ensure consistent, non-interactive plotting behavior on Linux, macOS, and Windows CI jobs.

### Description
- Add `GKSwstype: "100"` and `GKS_ENCODING: "utf-8"` to the job-level `env` in `.github/workflows/build_app_linux.yml`, `.github/workflows/build_app_macos.yml`, and `.github/workflows/build_app_windows.yml`.
- These environment variables force the GR backend to run headless so plotting calls during precompile/package steps do not attempt to open a GUI.

### Testing
- No automated tests or CI workflows were executed for this change since it only updates GitHub Actions workflow files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c35cb1860832596cb6fefc00cf6ac)